### PR TITLE
Fix WiX util extension loading during MSI compile

### DIFF
--- a/installer/windows/Mathodology.wxs
+++ b/installer/windows/Mathodology.wxs
@@ -6,7 +6,7 @@
       heat dir ..\..\apps\web\dist     -cg WebDistGroup    -gg -srd -dr WEBDIR    -var var.WebDistSrc    -out auto-web.wxs
       heat dir ..\..\apps\agent-worker -cg WorkerGroup     -gg -srd -dr WORKERDIR -var var.WorkerSrc     -out auto-worker.wxs
       heat dir ..\..\packages\py-contracts -cg PyContractsGroup -gg -srd -dr PYCDIR -var var.PyContractsSrc -out auto-pycontracts.wxs
-      candle Mathodology.wxs auto-web.wxs auto-worker.wxs auto-pycontracts.wxs ^
+      candle -ext WixUtilExtension Mathodology.wxs auto-web.wxs auto-worker.wxs auto-pycontracts.wxs ^
              -dWebDistSrc=..\..\apps\web\dist ^
              -dWorkerSrc=..\..\apps\agent-worker ^
              -dPyContractsSrc=..\..\packages\py-contracts

--- a/installer/windows/build-msi.cmd
+++ b/installer/windows/build-msi.cmd
@@ -41,8 +41,10 @@ REM the .cmd in CWD before resolving heat.exe on PATH, so calling `heat`
 REM bare would recurse into our own script (STATUS_STACK_OVERFLOW).
 call "%HERE%harvest.cmd" || exit /b 1
 
-REM 2. compile.
+REM 2. compile. WixUtilExtension is needed here too because candle.exe
+REM validates the util:EnvironmentVariable element before light.exe links.
 candle.exe -nologo -arch x64 ^
+       -ext WixUtilExtension ^
        -dVersion=%WIX_VERSION% ^
        -dWebDistSrc=%ROOT%\apps\web\dist ^
        -dWorkerSrc=%ROOT%\apps\agent-worker ^


### PR DESCRIPTION
Fixes #16.

This keeps the Windows MSI pipeline change scoped to the current v0.4.2 failure: `Mathodology.wxs` uses `<util:EnvironmentVariable>`, so `candle.exe` also needs `-ext WixUtilExtension` during compile; passing the extension only to `light.exe` is too late and produces `CNDL0200`.

Changes:
- add `-ext WixUtilExtension` to the `candle.exe` invocation in `installer/windows/build-msi.cmd`
- update the WXS build comment so the documented command matches CI/script behavior

Local verification in this Linux runner:
- `git diff --check`
- static assertion that both `candle.exe` and `light.exe` include `WixUtilExtension`, while `Mathodology.wxs` still contains `<util:EnvironmentVariable>`

I could not run the actual WiX 3 toolchain here because it requires a Windows host; the PR is intended to let the existing Windows release workflow validate the next MSI failure/success point.