### PR TITLE
fix(docker): unpin Dockerfile.gateway builder from BUILDPLATFORM

### DIFF
--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -1,7 +1,13 @@
 # syntax=docker/dockerfile:1.7
 
 # ---- builder ----
-FROM --platform=$BUILDPLATFORM rust:1.83-slim-bookworm AS builder
+# NB: do NOT pin to --platform=$BUILDPLATFORM here. We want the builder to
+# match the buildx target so cargo emits a binary the runtime image can
+# actually exec. Pinning to BUILDPLATFORM produced amd64 binaries inside
+# arm64 images (qemu-x86_64 launch failures on Apple Silicon / Graviton),
+# fixed in v0.5.1. Trade-off: arm64 builds run cargo under qemu, ~3x
+# slower, but correctness wins.
+FROM rust:1.83-slim-bookworm AS builder
 ENV CARGO_TERM_COLOR=always DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
       pkg-config libssl-dev ca-certificates \

--- a/tests/test_dockerfile_gateway_target_platform.py
+++ b/tests/test_dockerfile_gateway_target_platform.py
@@ -1,0 +1,43 @@
+"""Regression guard: Dockerfile.gateway must not pin its builder to BUILDPLATFORM.
+
+Pinning the builder stage to ``--platform=$BUILDPLATFORM`` made cargo emit a
+binary in the build host's arch, which then got copied into a runtime image
+of a different arch — the resulting image launched under
+``qemu-<host-arch>`` and crashed on the missing dynamic linker. v0.5.1
+removed that pin; this test fails the CI if anyone reintroduces it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_dockerfile_gateway_builder_does_not_pin_buildplatform() -> None:
+    contents = (ROOT / "Dockerfile.gateway").read_text(encoding="utf-8")
+
+    # Strip comment lines so the check only inspects actual Dockerfile
+    # instructions — the rationale comment in the file legitimately mentions
+    # the forbidden directive.
+    code_lines = [
+        line
+        for line in contents.splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+
+    # The *runtime* stage may legitimately omit a platform pin (it inherits
+    # the buildx target). What we forbid is the builder being pinned to the
+    # build host — that decoupled the cargo target from the runtime image.
+    for line in code_lines:
+        assert "--platform=$BUILDPLATFORM" not in line, (
+            "Dockerfile.gateway must not pin a build stage to BUILDPLATFORM. "
+            "Doing so produces a binary in the build host's arch, mismatching "
+            "the runtime image and crashing under qemu emulation. See v0.5.1 "
+            "release notes."
+        )
+
+    # Sanity: the builder stage and a runtime stage both still exist; we
+    # didn't accidentally collapse them.
+    assert "AS builder" in contents
+    assert "AS runtime" in contents


### PR DESCRIPTION
The builder stage of \`Dockerfile.gateway\` was pinned to \`--platform=\$BUILDPLATFORM\`, so cargo always ran in the build host's arch (amd64 on GHA). When buildx targets \`linux/amd64,linux/arm64\` it copied that amd64 binary into both runtime images — including the arm64 one. Resulting runtime: arm64 image with an amd64 ELF inside.

## Reproduction
\`\`\`
$ docker pull --platform linux/arm64 ghcr.io/ymylive/mathodology-gateway:0.5.0
$ docker run --rm --platform linux/arm64 ghcr.io/ymylive/mathodology-gateway:0.5.0
qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
\`\`\`

Found during the v0.5.0 local Phase-4 verification on Apple Silicon. amd64 deployments unaffected (BUILDPLATFORM == TARGETPLATFORM).

## Fix
Drop the \`--platform=\$BUILDPLATFORM\` pin. Builder now runs in the buildx target arch — native on amd64 hosts, qemu-emulated on arm64 cross-builds. Build wall time goes up ~3x for arm64 (cargo + ring under emulation); acceptable for correctness.

## Regression guard
\`tests/test_dockerfile_gateway_target_platform.py\` reads \`Dockerfile.gateway\`, strips comment lines, and asserts no \`--platform=\$BUILDPLATFORM\` appears in any instruction. Fails CI if someone reintroduces it.

## Test plan
- [x] Repo-root pytest: regression test passes.
- [x] No existing tests touched.
- [ ] CI on this PR validates worker pytest, gateway cargo, web typecheck, contracts drift.
- [ ] Post-merge \`v0.5.1\` release will verify the fix end-to-end on multi-arch GHCR image.