### PR TITLE
feat(critic): per-stage threshold overrides; relax Searcher to 0.75/0.80

### DIFF
--- a/apps/agent-worker/src/agent_worker/pipeline.py
+++ b/apps/agent-worker/src/agent_worker/pipeline.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 from uuid import UUID
 
@@ -68,6 +70,12 @@ class CriticPolicy:
     estimated_review_cost_rmb: float = 0.02
     estimated_revision_cost_rmb: float = 0.05
     estimated_coder_revision_cost_rmb: float = 0.12
+    min_score_overrides: Mapping[str, float] = field(
+        default_factory=lambda: MappingProxyType({"searcher": 0.75})
+    )
+    min_checklist_pass_rate_overrides: Mapping[str, float] = field(
+        default_factory=lambda: MappingProxyType({"searcher": 0.80})
+    )
 
 
 DEFAULT_CRITIC_POLICY = CriticPolicy()
@@ -96,9 +104,15 @@ def _critique_requires_revision(
         return True
     if report.major_finding_count >= 2:
         return True
-    if report.score < policy.min_score:
+    min_score = policy.min_score_overrides.get(
+        report.target_agent, policy.min_score
+    )
+    if report.score < min_score:
         return True
-    if report.checklist_pass_rate < policy.min_checklist_pass_rate:
+    min_pass_rate = policy.min_checklist_pass_rate_overrides.get(
+        report.target_agent, policy.min_checklist_pass_rate
+    )
+    if report.checklist_pass_rate < min_pass_rate:
         return True
     if report.passed:
         return False

--- a/apps/agent-worker/tests/test_pipeline_critic_gate.py
+++ b/apps/agent-worker/tests/test_pipeline_critic_gate.py
@@ -15,6 +15,8 @@ def _report(
     score: float = 0.9,
     checklist_passes: list[bool] | None = None,
     budget_exhausted: bool = False,
+    target_agent: str = "analyzer",
+    target_schema: str = "AnalyzerOutput",
 ) -> CritiqueReport:
     findings = []
     if severity is not None:
@@ -37,8 +39,8 @@ def _report(
         for idx, item_passed in enumerate(checklist_passes or [], start=1)
     ]
     return CritiqueReport(
-        target_agent="analyzer",
-        target_schema="AnalyzerOutput",
+        target_agent=target_agent,  # type: ignore[arg-type]
+        target_schema=target_schema,
         passed=passed,
         score=score,
         summary="summary",
@@ -123,3 +125,51 @@ def test_default_policy_has_active_revision_cost_estimates() -> None:
     assert policy.estimated_review_cost_rmb > 0
     assert policy.estimated_revision_cost_rmb > 0
     assert policy.estimated_coder_revision_cost_rmb > policy.estimated_revision_cost_rmb
+
+
+# checklist_pass_rate = 21/25 = 0.84 (between the 0.80 searcher override and
+# the 0.85 uniform default), score 0.78 (between the 0.75 override and the
+# 0.80 default). Both signals cross the override threshold but not the default.
+# Capped at 25 items because CritiqueReport.checklist has max_length=30.
+_SEARCHER_OVERRIDE_PASSES = [True] * 21 + [False] * 4
+
+
+def test_searcher_below_uniform_threshold_passes_with_override() -> None:
+    report = _report(
+        passed=True,
+        score=0.78,
+        checklist_passes=_SEARCHER_OVERRIDE_PASSES,
+        target_agent="searcher",
+        target_schema="SearchFindings",
+    )
+
+    assert _critique_requires_revision(report, CriticPolicy()) is False
+
+
+def test_modeler_below_uniform_threshold_still_requires_revision() -> None:
+    report = _report(
+        passed=True,
+        score=0.78,
+        checklist_passes=_SEARCHER_OVERRIDE_PASSES,
+        target_agent="modeler",
+        target_schema="ModelSpec",
+    )
+
+    assert _critique_requires_revision(report, CriticPolicy()) is True
+
+
+def test_explicit_override_can_be_disabled_per_call() -> None:
+    report = _report(
+        passed=True,
+        score=0.78,
+        checklist_passes=_SEARCHER_OVERRIDE_PASSES,
+        target_agent="searcher",
+        target_schema="SearchFindings",
+    )
+
+    policy = CriticPolicy(
+        min_score_overrides={},
+        min_checklist_pass_rate_overrides={},
+    )
+
+    assert _critique_requires_revision(report, policy) is True


### PR DESCRIPTION
## Why
v0.5.2 end-to-end run on a Chinese M/M/c bank-queueing problem saw Searcher Critic scores oscillate **0.72 → 0.84 → 0.76** across three rounds, exhausting the self-refine budget despite high-quality content (8 retained on-topic papers, 6 grounded key_findings). Uniform \`min_score=0.80\` / \`min_checklist_pass_rate=0.85\` thresholds are too strict for Searcher specifically — its LLM curation has fundamentally more friction (paraphrasing, paper-finding alignment) than other stages.

## What
- \`CriticPolicy\` gains \`min_score_overrides\` and \`min_checklist_pass_rate_overrides\` (immutable \`MappingProxyType\` since the dataclass is frozen).
- Defaults relax Searcher to \`{"searcher": 0.75}\` / \`{"searcher": 0.80}\`. Other stages unaffected.
- \`_critique_requires_revision\` consults the overrides keyed by \`report.target_agent\` with fallback to the uniform thresholds.

## Tests
- 3 new tests in \`test_pipeline_critic_gate.py\`: Searcher passes below uniform threshold; Modeler with same numbers still requires revision; explicit empty-overrides falls back to uniform behavior.
- 14 → 17 tests pass; ruff clean.

## Backward compatibility
- Frozen \`MappingProxyType\` defaults; callers can pass empty mappings to disable per-stage logic. No schema change.