### PR TITLE
fix(arxiv): retry 429/503 with exponential backoff and jitter

### DIFF
--- a/apps/agent-worker/src/agent_worker/tools/arxiv.py
+++ b/apps/agent-worker/src/agent_worker/tools/arxiv.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 import re
+from typing import Any
 
 import httpx
 from defusedxml import ElementTree as ET
@@ -31,6 +33,51 @@ _ATOM_NS = {
 _ARXIV_ID_RE = re.compile(r"arxiv\.org/abs/([^/?#]+)$", re.IGNORECASE)
 
 ARXIV_API_URL = "https://export.arxiv.org/api/query"
+
+_RETRY_STATUS = {429, 503}
+_TRANSIENT_EXC = (httpx.ConnectError, httpx.ReadTimeout, httpx.RemoteProtocolError)
+_MAX_RETRIES = 3
+_BASE_DELAY = 1.0  # seconds; multiplied 2^attempt
+
+
+async def _get_with_retry(
+    client: httpx.AsyncClient, url: str, params: dict[str, Any]
+) -> httpx.Response:
+    """GET with exponential backoff for 429 / 503 / transient network errors.
+
+    Retries up to _MAX_RETRIES times. Delays: 1s, 2s, 4s, each ±30% jitter.
+    Non-transient errors (400, 401, 5xx other than 503) propagate
+    immediately. The caller (_safe_arxiv in searcher.py) already converts
+    final exceptions into an empty result.
+    """
+    delay = _BASE_DELAY
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            r = await client.get(url, params=params)
+            if r.status_code in _RETRY_STATUS and attempt < _MAX_RETRIES:
+                jitter = delay * (0.7 + random.random() * 0.6)
+                _log.info(
+                    "arXiv %d on %r; retrying in %.2fs (attempt %d/%d)",
+                    r.status_code, params.get("search_query"), jitter,
+                    attempt + 1, _MAX_RETRIES,
+                )
+                await asyncio.sleep(jitter)
+                delay *= 2
+                continue
+            r.raise_for_status()
+            return r
+        except _TRANSIENT_EXC as e:
+            if attempt >= _MAX_RETRIES:
+                raise
+            jitter = delay * (0.7 + random.random() * 0.6)
+            _log.info(
+                "arXiv transient %r; retrying in %.2fs (attempt %d/%d)",
+                e, jitter, attempt + 1, _MAX_RETRIES,
+            )
+            await asyncio.sleep(jitter)
+            delay *= 2
+    # Unreachable; the loop either returns or raises.
+    raise RuntimeError("retry loop fell through")
 
 
 async def search_arxiv(
@@ -59,8 +106,7 @@ async def search_arxiv(
         client = httpx.AsyncClient(timeout=timeout)
     try:
         assert client is not None
-        r = await client.get(ARXIV_API_URL, params=params)
-        r.raise_for_status()
+        r = await _get_with_retry(client, ARXIV_API_URL, params)
         return _parse_atom(r.text)
     finally:
         if own_client and client is not None:

--- a/apps/agent-worker/tests/test_arxiv_tool.py
+++ b/apps/agent-worker/tests/test_arxiv_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 from agent_worker.tools.arxiv import (
     ARXIV_API_URL,
@@ -118,3 +119,65 @@ async def test_batch_search_arxiv_empty_queries() -> None:
 )
 def test_parse_atom_parametrized(xml_payload: str, expected_count: int) -> None:
     assert len(_parse_atom(xml_payload)) == expected_count
+
+
+async def test_search_arxiv_retries_on_429(httpx_mock, monkeypatch):  # type: ignore[no-untyped-def]
+    """429 then 200 must succeed within budget."""
+    sleeps: list[float] = []
+
+    async def fake_sleep(s: float) -> None:
+        sleeps.append(s)
+
+    monkeypatch.setattr("agent_worker.tools.arxiv.asyncio.sleep", fake_sleep)
+    httpx_mock.add_response(status_code=429)
+    httpx_mock.add_response(text=_SAMPLE_ATOM)
+    papers = await search_arxiv("queueing", max_results=5)
+    assert len(papers) == 2  # _SAMPLE_ATOM has 2 entries
+    assert len(sleeps) == 1  # one backoff between attempts
+    assert 0.7 <= sleeps[0] <= 1.3  # base 1.0s ±30%
+
+
+async def test_search_arxiv_retries_on_503(httpx_mock, monkeypatch):  # type: ignore[no-untyped-def]
+    async def fake_sleep(s: float) -> None: ...
+
+    monkeypatch.setattr("agent_worker.tools.arxiv.asyncio.sleep", fake_sleep)
+    httpx_mock.add_response(status_code=503)
+    httpx_mock.add_response(text=_SAMPLE_ATOM)
+    papers = await search_arxiv("anything", max_results=5)
+    assert len(papers) == 2
+
+
+async def test_search_arxiv_retries_on_transient_network_error(httpx_mock, monkeypatch):  # type: ignore[no-untyped-def]
+    async def fake_sleep(s: float) -> None: ...
+
+    monkeypatch.setattr("agent_worker.tools.arxiv.asyncio.sleep", fake_sleep)
+    httpx_mock.add_exception(httpx.ConnectError("boom"))
+    httpx_mock.add_response(text=_SAMPLE_ATOM)
+    papers = await search_arxiv("anything")
+    assert len(papers) == 2
+
+
+async def test_search_arxiv_gives_up_after_max_retries(httpx_mock, monkeypatch):  # type: ignore[no-untyped-def]
+    """Four consecutive 429s exhaust retries; last raises."""
+
+    async def fake_sleep(s: float) -> None: ...
+
+    monkeypatch.setattr("agent_worker.tools.arxiv.asyncio.sleep", fake_sleep)
+    for _ in range(4):
+        httpx_mock.add_response(status_code=429)
+    with pytest.raises(httpx.HTTPStatusError):
+        await search_arxiv("anything")
+
+
+async def test_search_arxiv_does_not_retry_on_400(httpx_mock, monkeypatch):  # type: ignore[no-untyped-def]
+    """Non-transient client error propagates immediately."""
+    sleeps: list[float] = []
+
+    async def fake_sleep(s: float) -> None:
+        sleeps.append(s)
+
+    monkeypatch.setattr("agent_worker.tools.arxiv.asyncio.sleep", fake_sleep)
+    httpx_mock.add_response(status_code=400)
+    with pytest.raises(httpx.HTTPStatusError):
+        await search_arxiv("anything")
+    assert sleeps == []  # no backoff


### PR DESCRIPTION
## Why
arXiv asks for ≤1 request per 3s; under Searcher's 5-query batch the worker hit \`429 Too Many Requests\` on production runs (observed in the v0.5.0 verification), silently zeroing the arXiv retrieval leg. No retries on the wire today.

## What
- New \`_get_with_retry\` wraps the GET with up to 3 retries on 429 / 503 / transient network errors (\`ConnectError\`, \`ReadTimeout\`, \`RemoteProtocolError\`).
- Backoff schedule: 1s, 2s, 4s — each ±30% jitter via \`random.random()\`.
- Non-transient errors (400, 401, other 5xx) propagate immediately. No retry budget wasted on caller-side mistakes.
- \`batch_search_arxiv\`'s per-query try/except still wraps the final exception into an empty result, preserving graceful degradation when arXiv is fully down.

## Tests
- 5 new tests in \`test_arxiv_tool.py\`: 429→200, 503→200, transient network error→200, exhausted retries raise, 400 propagates without backoff. Mock \`asyncio.sleep\` so tests don't actually wait.
- 10 → 15 tests pass; ruff clean.