### PR TITLE
feat(worker): bundle open-webSearch MCP for Baidu/CSDN/Juejin support

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -33,6 +33,17 @@ RUN set -eux; \
 # uv — pinned.
 RUN pip install --no-cache-dir "uv==${UV_VERSION}"
 
+# Node 20.x via NodeSource — ~150MB on top of the existing layer.
+# Required so the Searcher can launch the open-webSearch MCP over stdio;
+# without it Bing/Baidu/CSDN/Juejin/DuckDuckGo silently return zero hits.
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/* \
+ && node --version && npm --version
+
+# open-webSearch MCP — keeps Baidu/CSDN/Juejin reachable from the worker.
+RUN npm install -g open-websearch
+
 RUN useradd --system --uid 1000 --create-home --home-dir /app --shell /bin/bash app \
  && mkdir -p /app /data/runs \
  && chown -R app:app /app /data
@@ -47,7 +58,8 @@ USER app
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     PATH=/app/.venv/bin:$PATH \
     RUNS_DIR=/data/runs \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    OPEN_WEBSEARCH_CMD=open-websearch
 
 # Resolve from the workspace root so mm-contracts (workspace dep) is found.
 RUN uv sync --frozen --package agent-worker

--- a/tests/test_dockerfile_worker_open_websearch.py
+++ b/tests/test_dockerfile_worker_open_websearch.py
@@ -1,0 +1,39 @@
+"""Regression guard: Dockerfile.worker must include open-webSearch MCP runtime.
+
+Without Node + the npm package globally installed in the worker image,
+Baidu/CSDN/Juejin/etc go silent (the Python config falls back to
+`npx open-websearch` which fails with command-not-found). Verified during
+v0.5.2 end-to-end testing — log line "primary=open_websearch: 0 papers
+across 5 engines" with reasoning_effort=low on a Chinese problem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_dockerfile_worker_includes_node_and_websearch_mcp() -> None:
+    contents = (ROOT / "Dockerfile.worker").read_text(encoding="utf-8")
+
+    code_lines = [
+        line for line in contents.splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+    code = "\n".join(code_lines)
+
+    # Node runtime (any reasonable installation marker).
+    assert "nodesource" in code.lower() or "nodejs" in code.lower(), (
+        "Dockerfile.worker must install Node.js for the open-webSearch MCP"
+    )
+    # The MCP package install line.
+    assert "open-websearch" in code, (
+        "Dockerfile.worker must `npm install -g open-websearch` so the "
+        "Searcher can launch the MCP via open_websearch_cmd"
+    )
+    # The env var pointing at the launch command.
+    assert "OPEN_WEBSEARCH_CMD" in code, (
+        "Dockerfile.worker must set OPEN_WEBSEARCH_CMD so the worker "
+        "process knows how to spawn the MCP"
+    )


### PR DESCRIPTION
## Why
The worker image shipped Python only — no Node — so the open-webSearch MCP could not launch and Bing / Baidu / CSDN / Juejin / DuckDuckGo all silently returned 0 hits. Verified during v0.5.2 end-to-end on a Chinese M/M/c problem: \`primary=open_websearch: 0 papers across 5 engines\`. This silently halved the Searcher's coverage for Chinese-language problems where Baidu / CSDN / Juejin actually matter.

## What
- Install Node.js 20.x via NodeSource in the runtime stage.
- Globally install the \`open-websearch\` npm package (resolved from \`scripts/install.sh:281\`, \`scripts/preflight.sh:72\`, default cmd in \`config.py:37\`).
- \`ENV OPEN_WEBSEARCH_CMD=open-websearch\` so the worker process picks it up by default.
- Layer order: Node + npm install BEFORE Python source COPY → Python source changes don't bust the Node layer.
- Existing tectonic / pandoc / uv / fonts apt block untouched.

## Tests
- New regression test \`tests/test_dockerfile_worker_open_websearch.py\` (mirrors \`test_dockerfile_gateway_target_platform.py\` style).
- \`docker buildx build --check Dockerfile.worker\`: clean.
- ruff: clean.

## Image impact
~150MB increase. Tradeoff acceptable: restores the entire web-search leg for Chinese problems, where it's strictly necessary.

## Risk
\`open-websearch\` is pure JS/TS — no node-gyp native compile. qemu-arm64 build risk is low.