### PR TITLE
feat(searcher): top-3 paper PDF enrichment with compaction

### DIFF
--- a/apps/agent-worker/pyproject.toml
+++ b/apps/agent-worker/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
   "fastembed>=0.4",
   "defusedxml>=0.7",
   "mcp>=1.27.0",
+  "trafilatura>=1.12",
+  "pdfplumber>=0.11",
 ]
 
 [dependency-groups]

--- a/apps/agent-worker/src/agent_worker/agents/searcher.py
+++ b/apps/agent-worker/src/agent_worker/agents/searcher.py
@@ -50,6 +50,7 @@ from agent_worker.prompts import load_prompt
 from agent_worker.tools.arxiv import batch_search_arxiv
 from agent_worker.tools.crossref import batch_search_crossref
 from agent_worker.tools.openalex import batch_search_openalex
+from agent_worker.tools.pdf import batch_enrich_papers
 from agent_worker.tools.tavily import TavilyResult, batch_search_tavily
 from agent_worker.tools.web_search_mcp import WebResult, batch_search_web
 
@@ -163,6 +164,7 @@ class SearcherAgent:
         run_effort: ReasoningEffort = "medium",
         long_context: bool = False,
         model_override: str | None = None,
+        runs_dir: Path | None = None,
     ) -> None:
         self.gateway = gateway
         self.emitter = emitter
@@ -170,6 +172,7 @@ class SearcherAgent:
         self._run_effort: ReasoningEffort = run_effort
         self._long_context: bool = long_context
         self._model_override: str | None = model_override
+        self._runs_dir: Path | None = runs_dir
 
     async def run_for(
         self, problem: ProblemInput, analysis: AnalyzerOutput
@@ -566,6 +569,32 @@ class SearcherAgent:
             findings = SearchFindings(queries=queries)
         else:
             findings = await self._synthesize(problem, analysis, queries, unique)
+
+        # Phase 3.5/3.6: enrich top papers with full text + compact oversized files.
+        # Skip when runs_dir wasn't injected (test fixtures) or there are no
+        # papers to enrich.
+        if findings.papers and self._runs_dir is not None:
+            runs_papers_dir = (
+                self._runs_dir / str(self.emitter.run_id) / "papers"
+            )
+            paths = await batch_enrich_papers(
+                findings.papers,
+                runs_papers_dir=runs_papers_dir,
+                top_n=3,
+                mailto=settings.polite_mailto or None,
+            )
+            paths = await self._compact_oversized_papers(runs_papers_dir, paths)
+            findings = findings.model_copy(update={"paper_fulltext_paths": paths})
+            await self.emitter.emit(
+                "log",
+                {
+                    "level": "info",
+                    "message": (
+                        f"enriched {len(paths)} of top 3 papers with full text"
+                    ),
+                },
+                agent=self.AGENT_NAME,
+            )
 
         duration_ms = int((time.monotonic() - t0) * 1000)
         await self.emitter.emit(

--- a/apps/agent-worker/src/agent_worker/agents/searcher.py
+++ b/apps/agent-worker/src/agent_worker/agents/searcher.py
@@ -26,6 +26,7 @@ import asyncio
 import json
 import logging
 import time
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -113,6 +114,39 @@ def _normalize_url(url: str) -> str:
     )
 
 _log = logging.getLogger(__name__)
+
+
+# --- PDF enrichment / compaction tuning -------------------------------------
+COMPACT_THRESHOLD_CHARS = 24_000
+COMPACT_TARGET_CHARS = 24_000
+COMPACT_MIN_OUTPUT_CHARS = 1_000
+
+_COMPACT_SYSTEM_PROMPT = """You compress an academic paper into a high-density summary for downstream LLM citation. Preserve verbatim:
+- Mathematical formulas (LaTeX or plain)
+- Parameter definitions and units
+- Methodology steps in order
+- Experimental setup (sample size, data source, conditions)
+- Numerical results with confidence intervals or error bars
+- Key claims that Writer might cite
+
+Drop entirely:
+- Boilerplate (acknowledgments, ethics, conflicts of interest)
+- Related-work prose (the Writer has SearchFindings.papers for that)
+- Narrative filler ("In this paper we propose...")
+- Reference list
+- Repeated information
+
+Preserve the source language. If the input is Chinese, output Chinese.
+If English, output English. Do not translate.
+
+Output: dense markdown, ≤24000 characters. Keep section headings
+(## Methods, ## Results, etc.) so Writer can grep for them.
+Respond with the compacted markdown only."""
+
+# Sentinel for _stream_and_collect's default. Passing response_format=None
+# explicitly disables the JSON-object constraint (used by _compact_one); the
+# default preserves backward compat for _ask_llm / _refine_queries.
+_DEFAULT_JSON_RESPONSE_FORMAT: dict[str, Any] = {"type": "json_object"}
 
 
 class SearcherAgent:
@@ -767,6 +801,89 @@ class SearcherAgent:
             )
             return raw_queries
 
+    async def _compact_oversized_papers(
+        self, runs_papers_dir: Path, paths: list[str]
+    ) -> list[str]:
+        """Compact any persisted paper text exceeding COMPACT_THRESHOLD_CHARS.
+
+        Overwrites in place. Compaction failure leaves the raw file untouched —
+        the Writer side has its own char-budget soft truncation as a safety
+        net. Returns the same paths argument unchanged (compaction never drops
+        a paper; it either improves the file or leaves it alone).
+        """
+        run_dir = runs_papers_dir.parent
+        for rel_path in paths:
+            abs_path = run_dir / rel_path
+            try:
+                raw = abs_path.read_text("utf-8")
+            except OSError as e:
+                await self.emitter.emit(
+                    "log",
+                    {
+                        "level": "warning",
+                        "message": f"compact: could not read {rel_path}: {e}",
+                    },
+                    agent=self.AGENT_NAME,
+                )
+                continue
+            if len(raw) <= COMPACT_THRESHOLD_CHARS:
+                continue
+            compacted = await self._compact_one(raw)
+            if not compacted or len(compacted) < COMPACT_MIN_OUTPUT_CHARS:
+                await self.emitter.emit(
+                    "log",
+                    {
+                        "level": "warning",
+                        "message": (
+                            f"compact: keeping raw for {rel_path} "
+                            f"(compaction unusable)"
+                        ),
+                    },
+                    agent=self.AGENT_NAME,
+                )
+                continue
+            abs_path.write_text(compacted, encoding="utf-8")
+            await self.emitter.emit(
+                "log",
+                {
+                    "level": "info",
+                    "message": (
+                        f"compact: {rel_path} {len(raw)} → {len(compacted)} chars"
+                    ),
+                },
+                agent=self.AGENT_NAME,
+            )
+        return paths
+
+    async def _compact_one(self, raw_text: str) -> str | None:
+        """Run one LLM call to compress raw paper text. None on failure."""
+        model = self._model_override or self.prompt.model_preference[0]
+        user_text = (
+            "Compact this paper text into ≤24000 characters of dense markdown, "
+            "preserving the source language verbatim.\n\nRaw paper text:\n\n"
+            + raw_text
+        )
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": _COMPACT_SYSTEM_PROMPT},
+            {"role": "user", "content": user_text},
+        ]
+        try:
+            text = await self._stream_and_collect(
+                model, messages, response_format=None
+            )
+        except Exception as e:  # noqa: BLE001
+            await self.emitter.emit(
+                "log",
+                {
+                    "level": "warning",
+                    "message": f"compact: LLM call failed: {e}",
+                },
+                agent=self.AGENT_NAME,
+            )
+            return None
+        text = text.strip() if isinstance(text, str) else ""
+        return text or None
+
     async def _synthesize(
         self,
         problem: ProblemInput,
@@ -879,8 +996,19 @@ class SearcherAgent:
         ) from last_err
 
     async def _stream_and_collect(
-        self, model: str, messages: list[dict[str, Any]]
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        *,
+        response_format: dict[str, Any] | None = _DEFAULT_JSON_RESPONSE_FORMAT,
     ) -> str:
+        """Stream completion; concat deltas; return raw text.
+
+        ``response_format`` defaults to ``{"type": "json_object"}`` to preserve
+        the existing JSON-only behavior used by ``_ask_llm`` /
+        ``_refine_queries``. Pass ``response_format=None`` for free-form text
+        responses (e.g. the compaction LLM call, which returns markdown).
+        """
         effort = self.prompt.reasoning_effort or self._run_effort
         parts: list[str] = []
         async for delta in self.gateway.stream_completion(
@@ -891,7 +1019,7 @@ class SearcherAgent:
             temperature=self.prompt.temperature,
             # 20k default, 1M when long-context opt-in is set. See base.py.
             max_tokens=1_000_000 if self._long_context else 20000,
-            response_format={"type": "json_object"},
+            response_format=response_format,
             reasoning_effort=effort,
         ):
             parts.append(delta)

--- a/apps/agent-worker/src/agent_worker/agents/writer.py
+++ b/apps/agent-worker/src/agent_worker/agents/writer.py
@@ -6,6 +6,8 @@ Final stage of the pipeline. Single LLM call, structured JSON output → PaperDr
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from typing import Any
 
 from mm_contracts import (
     AnalyzerOutput,
@@ -13,10 +15,18 @@ from mm_contracts import (
     ModelSpec,
     PaperDraft,
     ProblemInput,
+    ReasoningEffort,
     SearchFindings,
 )
 
 from agent_worker.agents.base import BaseAgent
+from agent_worker.events import EventEmitter
+from agent_worker.gateway_client import GatewayClient
+
+# Per-paper Writer-side budget. Last-resort safety net: Searcher already
+# compacts files > 24k chars in Phase 3.6, but uncompacted survivors get
+# truncated here at a paragraph boundary so the prompt cannot explode.
+WRITER_SOFT_TRUNCATE_CHARS = 32_000
 
 
 class WriterAgent(BaseAgent):
@@ -24,6 +34,29 @@ class WriterAgent(BaseAgent):
 
     AGENT_NAME = "writer"
     OUTPUT_MODEL = PaperDraft
+
+    def __init__(
+        self,
+        gateway: GatewayClient,
+        emitter: EventEmitter,
+        prompt_version: str = "v1",
+        run_effort: ReasoningEffort = "medium",
+        long_context: bool = False,
+        model_override: str | None = None,
+        run_dir: Path | None = None,
+    ) -> None:
+        super().__init__(
+            gateway,
+            emitter,
+            prompt_version=prompt_version,
+            run_effort=run_effort,
+            long_context=long_context,
+            model_override=model_override,
+        )
+        # Run-directory root (e.g. runs/<run_id>) used to resolve relative
+        # paths from `SearchFindings.paper_fulltext_paths`. Optional so
+        # existing callers / tests that don't pass it still work.
+        self._run_dir: Path | None = run_dir
 
     async def run_for(
         self,
@@ -35,11 +68,12 @@ class WriterAgent(BaseAgent):
     ) -> PaperDraft:
         """Render the Writer template from all upstream artifacts and call the LLM."""
         # Fallback so existing callers / tests that don't pass findings still work.
-        findings_payload = (
+        findings_payload: dict[str, Any] = (
             findings.model_dump(mode="json")
             if findings is not None
             else {"queries": [], "papers": [], "key_findings": [], "datasets_mentioned": []}
         )
+        fulltexts_block = self._build_fulltexts_block(findings)
         output = await self.run(
             problem_text=problem.problem_text,
             competition_type=problem.competition_type,
@@ -75,9 +109,46 @@ class WriterAgent(BaseAgent):
             findings_json=json.dumps(
                 findings_payload, ensure_ascii=False, indent=2
             ),
+            paper_fulltexts=fulltexts_block,
         )
         assert isinstance(output, PaperDraft)
         return output
+
+    def _build_fulltexts_block(
+        self, findings: SearchFindings | None
+    ) -> str:
+        """Read paper full-text files referenced by `findings.paper_fulltext_paths`.
+
+        Each path is resolved against `self._run_dir`. Missing files /
+        read errors are skipped silently so the pipeline degrades to
+        abstract-only citation. Files larger than
+        `WRITER_SOFT_TRUNCATE_CHARS` are truncated at the last paragraph
+        boundary before the cap as a last safety net.
+        """
+        if (
+            findings is None
+            or not findings.paper_fulltext_paths
+            or self._run_dir is None
+        ):
+            return ""
+        blocks: list[str] = []
+        for idx, rel_path in enumerate(findings.paper_fulltext_paths, start=1):
+            abs_path = self._run_dir / rel_path
+            if not abs_path.exists():
+                continue
+            try:
+                text = abs_path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            if len(text) > WRITER_SOFT_TRUNCATE_CHARS:
+                text = (
+                    text[:WRITER_SOFT_TRUNCATE_CHARS].rsplit("\n\n", 1)[0]
+                    + "\n\n[...truncated]"
+                )
+            blocks.append(
+                f"### Paper {idx} (cite as findings.papers[{idx - 1}])\n\n{text}"
+            )
+        return "\n\n".join(blocks)
 
 
 __all__ = ["WriterAgent"]

--- a/apps/agent-worker/src/agent_worker/pipeline.py
+++ b/apps/agent-worker/src/agent_worker/pipeline.py
@@ -328,7 +328,7 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
             )
             assert isinstance(analysis, AnalyzerOutput)
 
-            searcher = SearcherAgent(gateway, emitter, **kwargs)
+            searcher = SearcherAgent(gateway, emitter, runs_dir=runs_dir, **kwargs)
             findings = await searcher.run_for(problem, analysis)
             findings = await _review_and_maybe_revise(
                 critic=critic,

--- a/apps/agent-worker/src/agent_worker/pipeline.py
+++ b/apps/agent-worker/src/agent_worker/pipeline.py
@@ -375,7 +375,7 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                 coder_out=coder_out,
             )
 
-            writer = WriterAgent(gateway, emitter, **kwargs)
+            writer = WriterAgent(gateway, emitter, run_dir=run_dir, **kwargs)
             paper = await writer.run_for(
                 problem, analysis, spec, coder_out, findings
             )

--- a/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
@@ -87,6 +87,16 @@ Coder executed cells (JSON array; each has source, stdout[:500], result):
 Searcher findings (JSON; may be empty):
 {{ findings_json }}
 
+## Supplementary full text for citation grounding
+
+The following are the full text (or compacted summaries) of the top
+papers retrieved by the Searcher. Use them to ground specific
+citations — refer to equations, methodology details, and numerical
+results verbatim where appropriate. When this block is empty, fall
+back to title+abstract citation from the Sources list.
+
+{{ paper_fulltexts }}
+
 Respond with a JSON object. Required top-level keys:
   title (string),
   abstract (string; English ≤ 800 words or Chinese ≤ 1000 字; MUST contain ≥ 2 concrete numerical results),

--- a/apps/agent-worker/src/agent_worker/tools/pdf.py
+++ b/apps/agent-worker/src/agent_worker/tools/pdf.py
@@ -1,0 +1,74 @@
+"""PDF / OA paper retrieval and text extraction.
+
+A thin async layer that:
+  - resolves a Paper (with arxiv_id or doi) to a fetchable PDF/HTML URL
+    (arXiv direct + Unpaywall API for DOIs)
+  - downloads + extracts the text via pdfplumber (PDF) or trafilatura (HTML)
+  - persists the top N papers' text under runs/<run_id>/papers/NN.md for
+    the Writer to consume
+
+Best-effort throughout: any failure returns None / [] / "" so the Searcher
+keeps running and SearchFindings.paper_fulltext_paths just stays empty.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from mm_contracts import Paper
+
+_log = logging.getLogger(__name__)
+
+ARXIV_PDF_TEMPLATE = "https://arxiv.org/pdf/{arxiv_id}.pdf"
+UNPAYWALL_API_URL = "https://api.unpaywall.org/v2/{doi}"
+
+
+async def find_pdf_url(
+    paper: Paper,
+    *,
+    mailto: str | None = None,
+    timeout: float = 10.0,  # noqa: ASYNC109 — applied to the httpx client, not an asyncio primitive
+) -> str | None:
+    """Resolve a Paper to a fetchable PDF/HTML URL or None.
+
+    Resolution order:
+      1. arXiv ID present → arxiv.org/pdf/<id>.pdf (always available)
+      2. DOI present → Unpaywall API → best_oa_location.url_for_pdf
+      3. None
+    """
+    if paper.arxiv_id:
+        return ARXIV_PDF_TEMPLATE.format(arxiv_id=paper.arxiv_id)
+    if not paper.doi:
+        return None
+
+    # Unpaywall recommends including a mailto for the polite pool. Without
+    # one we still get a response, just with stricter rate limits.
+    params: dict[str, str] = {}
+    if mailto:
+        params["email"] = mailto
+    url = UNPAYWALL_API_URL.format(doi=paper.doi)
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            r = await client.get(url, params=params)
+            r.raise_for_status()
+            data = r.json()
+    except Exception as e:  # noqa: BLE001 — best-effort
+        _log.info("Unpaywall lookup failed for %s: %s", paper.doi, e)
+        return None
+
+    if not isinstance(data, dict):
+        return None
+    oa = data.get("best_oa_location")
+    if not isinstance(oa, dict):
+        return None
+    pdf_url = oa.get("url_for_pdf")
+    return pdf_url if isinstance(pdf_url, str) and pdf_url.strip() else None
+
+
+__all__ = [
+    "ARXIV_PDF_TEMPLATE",
+    "UNPAYWALL_API_URL",
+    "find_pdf_url",
+]

--- a/apps/agent-worker/src/agent_worker/tools/pdf.py
+++ b/apps/agent-worker/src/agent_worker/tools/pdf.py
@@ -55,7 +55,7 @@ async def find_pdf_url(
             r.raise_for_status()
             data = r.json()
     except Exception as e:  # noqa: BLE001 — best-effort
-        _log.info("Unpaywall lookup failed for %s: %s", paper.doi, e)
+        _log.warning("Unpaywall lookup failed for %s: %s", paper.doi, e)
         return None
 
     if not isinstance(data, dict):

--- a/apps/agent-worker/src/agent_worker/tools/pdf.py
+++ b/apps/agent-worker/src/agent_worker/tools/pdf.py
@@ -13,9 +13,13 @@ keeps running and SearchFindings.paper_fulltext_paths just stays empty.
 
 from __future__ import annotations
 
+import io
 import logging
+from typing import Literal
 
 import httpx
+import pdfplumber
+import trafilatura
 from mm_contracts import Paper
 
 _log = logging.getLogger(__name__)
@@ -67,8 +71,67 @@ async def find_pdf_url(
     return pdf_url if isinstance(pdf_url, str) and pdf_url.strip() else None
 
 
+async def fetch_and_extract(
+    url: str,
+    *,
+    timeout: float = 15.0,  # noqa: ASYNC109 — applied to httpx, not an asyncio primitive
+    max_bytes: int = 20_000_000,
+) -> tuple[str | None, Literal["trafilatura", "pdfplumber", "none"]]:
+    """Fetch URL and return (extracted_text, parser_name).
+
+    text=None signals failure for any reason (network, oversize, parse,
+    or empty extraction). The caller never raises — the Searcher's
+    enrichment phase is best-effort. ``max_bytes`` rejects oversized
+    bodies to bound memory.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            r = await client.get(url, follow_redirects=True)
+            r.raise_for_status()
+    except Exception as e:  # noqa: BLE001 — best-effort
+        _log.warning("fetch_and_extract: HTTP failure for %s: %s", url, e)
+        return None, "none"
+
+    content = r.content
+    if len(content) > max_bytes:
+        _log.warning(
+            "fetch_and_extract: oversized response %d bytes for %s; rejecting",
+            len(content), url,
+        )
+        return None, "none"
+
+    ctype = (r.headers.get("content-type") or "").lower()
+    if "pdf" in ctype or url.lower().endswith(".pdf"):
+        try:
+            with pdfplumber.open(io.BytesIO(content)) as pdf:
+                pages_text = [p.extract_text() or "" for p in pdf.pages]
+            text = "\n\n".join(t for t in pages_text if t.strip())
+        except Exception as e:  # noqa: BLE001
+            _log.warning("fetch_and_extract: pdfplumber failed for %s: %s", url, e)
+            return None, "none"
+        return (text, "pdfplumber") if text.strip() else (None, "none")
+
+    # HTML / other text content → trafilatura
+    try:
+        text = trafilatura.extract(
+            content,
+            include_comments=False,
+            include_tables=True,
+            favor_recall=True,
+            url=url,
+        )
+    except Exception as e:  # noqa: BLE001
+        _log.warning("fetch_and_extract: trafilatura failed for %s: %s", url, e)
+        return None, "none"
+
+    if not text or not text.strip():
+        return None, "none"
+    return text, "trafilatura"
+
+
 __all__ = [
     "ARXIV_PDF_TEMPLATE",
     "UNPAYWALL_API_URL",
+    "fetch_and_extract",
     "find_pdf_url",
 ]

--- a/apps/agent-worker/src/agent_worker/tools/pdf.py
+++ b/apps/agent-worker/src/agent_worker/tools/pdf.py
@@ -13,8 +13,10 @@ keeps running and SearchFindings.paper_fulltext_paths just stays empty.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
+from pathlib import Path
 from typing import Literal
 
 import httpx
@@ -129,9 +131,60 @@ async def fetch_and_extract(
     return text, "trafilatura"
 
 
+async def batch_enrich_papers(
+    papers: list[Paper],
+    runs_papers_dir: Path,
+    top_n: int = 3,
+    *,
+    mailto: str | None = None,
+    concurrency: int = 3,
+) -> list[str]:
+    """Enrich the top N papers concurrently and persist successes.
+
+    For each paper in papers[:top_n], in parallel (bounded by ``concurrency``):
+      1. Resolve a PDF/HTML URL via find_pdf_url.
+      2. Fetch + extract via fetch_and_extract.
+      3. On success, write the text to ``runs_papers_dir / f"{idx:02d}.md"``
+         where ``idx`` is the 1-based original position in papers[:top_n].
+
+    Returns a list of relative paths under runs_papers_dir.parent, in
+    original index order, suitable for SearchFindings.paper_fulltext_paths.
+    Failed papers are not represented in the output.
+    """
+    if not papers:
+        return []
+    # Create directory synchronously (I/O is local).
+    runs_papers_dir.mkdir(parents=True, exist_ok=True)  # noqa: ASYNC240
+    sem = asyncio.Semaphore(concurrency)
+
+    async def enrich_one(idx: int, paper: Paper) -> tuple[int, str | None]:
+        async with sem:
+            pdf_url = await find_pdf_url(paper, mailto=mailto)
+            if not pdf_url:
+                return idx, None
+            text, parser = await fetch_and_extract(pdf_url)
+            if not text:
+                _log.warning(
+                    "enrich: extraction empty for paper #%d (%s)", idx, pdf_url
+                )
+                return idx, None
+            rel_path = f"papers/{idx:02d}.md"
+            (runs_papers_dir / f"{idx:02d}.md").write_text(text, encoding="utf-8")
+            _log.info(
+                "enrich: paper #%d via %s (%d chars)", idx, parser, len(text)
+            )
+            return idx, rel_path
+
+    results = await asyncio.gather(
+        *(enrich_one(i, p) for i, p in enumerate(papers[:top_n], start=1))
+    )
+    return [rel for _, rel in sorted(results) if rel is not None]
+
+
 __all__ = [
     "ARXIV_PDF_TEMPLATE",
     "UNPAYWALL_API_URL",
+    "batch_enrich_papers",
     "fetch_and_extract",
     "find_pdf_url",
 ]

--- a/apps/agent-worker/tests/test_contracts_searchfindings.py
+++ b/apps/agent-worker/tests/test_contracts_searchfindings.py
@@ -1,0 +1,34 @@
+"""Backward-compat check for the SearchFindings.paper_fulltext_paths field."""
+
+from __future__ import annotations
+
+import pytest
+from mm_contracts import SearchFindings
+from pydantic import ValidationError
+
+
+def test_searchfindings_without_paper_fulltext_paths_defaults_to_empty() -> None:
+    sf = SearchFindings(queries=["q"], papers=[], key_findings=[], datasets_mentioned=[])
+    assert sf.paper_fulltext_paths == []
+
+
+def test_searchfindings_accepts_paper_fulltext_paths() -> None:
+    sf = SearchFindings(
+        queries=["q"],
+        papers=[],
+        key_findings=[],
+        datasets_mentioned=[],
+        paper_fulltext_paths=["papers/01.md", "papers/02.md", "papers/03.md"],
+    )
+    assert sf.paper_fulltext_paths == ["papers/01.md", "papers/02.md", "papers/03.md"]
+
+
+def test_searchfindings_caps_paper_fulltext_paths_at_three() -> None:
+    with pytest.raises(ValidationError):
+        SearchFindings(
+            queries=["q"],
+            papers=[],
+            key_findings=[],
+            datasets_mentioned=[],
+            paper_fulltext_paths=[f"papers/0{i}.md" for i in range(1, 5)],
+        )

--- a/apps/agent-worker/tests/test_pdf_tool.py
+++ b/apps/agent-worker/tests/test_pdf_tool.py
@@ -1,0 +1,70 @@
+"""Tests for tools/pdf.py — offline via pytest-httpx."""
+
+from __future__ import annotations
+
+from agent_worker.tools.pdf import find_pdf_url
+from mm_contracts import Paper
+
+
+def _arxiv_paper(arxiv_id: str = "2312.01234") -> Paper:
+    return Paper(
+        title="Arxiv Paper",
+        authors=["A. B."],
+        abstract="abs",
+        url=f"http://arxiv.org/abs/{arxiv_id}",
+        arxiv_id=arxiv_id,
+    )
+
+
+def _doi_paper(doi: str = "10.1234/example.2024.001") -> Paper:
+    return Paper(
+        title="Crossref Paper",
+        authors=["C. D."],
+        abstract="abs",
+        url=f"https://doi.org/{doi}",
+        doi=doi,
+    )
+
+
+async def test_find_pdf_url_returns_arxiv_pdf_for_arxiv_paper() -> None:
+    """arXiv papers are resolved without contacting Unpaywall."""
+    url = await find_pdf_url(_arxiv_paper("2312.01234"))
+    assert url == "https://arxiv.org/pdf/2312.01234.pdf"
+
+
+async def test_find_pdf_url_returns_oa_url_when_unpaywall_has_one(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    httpx_mock.add_response(
+        json={
+            "best_oa_location": {
+                "url_for_pdf": "https://example.org/paper.pdf",
+            }
+        }
+    )
+    url = await find_pdf_url(_doi_paper("10.1/abc"), mailto="bot@example.com")
+    assert url == "https://example.org/paper.pdf"
+    request = httpx_mock.get_request()
+    assert "10.1/abc" in str(request.url)
+    assert "email=bot%40example.com" in str(request.url)
+
+
+async def test_find_pdf_url_returns_none_when_unpaywall_has_no_oa(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    httpx_mock.add_response(json={"best_oa_location": None})
+    url = await find_pdf_url(_doi_paper("10.1/no-oa"), mailto="bot@example.com")
+    assert url is None
+
+
+async def test_find_pdf_url_returns_none_when_paper_has_neither_arxiv_nor_doi() -> None:
+    paper = Paper(
+        title="Web Hit",
+        authors=[],
+        abstract="",
+        url="https://blog.example/post",
+    )
+    url = await find_pdf_url(paper, mailto="bot@example.com")
+    assert url is None
+
+
+async def test_find_pdf_url_returns_none_when_unpaywall_5xx(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    httpx_mock.add_response(status_code=503)
+    url = await find_pdf_url(_doi_paper(), mailto="bot@example.com")
+    assert url is None

--- a/apps/agent-worker/tests/test_pdf_tool.py
+++ b/apps/agent-worker/tests/test_pdf_tool.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from agent_worker.tools.pdf import fetch_and_extract, find_pdf_url
+from pathlib import Path
+
+from agent_worker.tools.pdf import batch_enrich_papers, fetch_and_extract, find_pdf_url
 from mm_contracts import Paper
 
 
@@ -160,3 +162,93 @@ async def test_fetch_and_extract_returns_none_when_extractor_returns_empty(
     text, parser = await fetch_and_extract("http://example.com/empty.pdf")
     assert text is None
     assert parser == "none"
+
+
+async def test_batch_enrich_papers_writes_files_for_arxiv_sources(
+    tmp_path: Path, httpx_mock, monkeypatch
+) -> None:
+    # Three arXiv papers — no Unpaywall calls, direct PDF URLs.
+    papers = [_arxiv_paper(f"2401.{i:05d}") for i in range(1, 4)]
+    # Each pdf fetch returns a parseable PDF byte stream.
+    for _ in papers:
+        httpx_mock.add_response(
+            content=b"%PDF-1.4\n",
+            headers={"content-type": "application/pdf"},
+        )
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.pdfplumber.open",
+        lambda _: _FakePdf([_FakePage("paper body")]),
+    )
+
+    runs_papers_dir = tmp_path / "papers"
+    paths = await batch_enrich_papers(
+        papers, runs_papers_dir=runs_papers_dir, top_n=3
+    )
+    assert paths == ["papers/01.md", "papers/02.md", "papers/03.md"]
+    for rel in paths:
+        assert (tmp_path / rel).read_text("utf-8") == "paper body"
+
+
+async def test_batch_enrich_papers_caps_at_top_n(
+    tmp_path: Path, httpx_mock, monkeypatch
+) -> None:
+    """Given 5 papers and top_n=3, only the first 3 are processed."""
+    papers = [_arxiv_paper(f"2401.{i:05d}") for i in range(1, 6)]
+    for _ in range(3):
+        httpx_mock.add_response(
+            content=b"%PDF-1.4\n",
+            headers={"content-type": "application/pdf"},
+        )
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.pdfplumber.open",
+        lambda _: _FakePdf([_FakePage("body")]),
+    )
+
+    paths = await batch_enrich_papers(
+        papers, runs_papers_dir=tmp_path / "papers", top_n=3
+    )
+    assert len(paths) == 3
+
+
+async def test_batch_enrich_papers_skips_failed_papers(
+    tmp_path: Path, httpx_mock, monkeypatch
+) -> None:
+    """Paper 2 fails; results contain only 01 and 03 with correct numbering."""
+    papers = [_arxiv_paper(f"2401.{i:05d}") for i in range(1, 4)]
+    # Paper 1: success
+    httpx_mock.add_response(
+        content=b"%PDF-1.4\n", headers={"content-type": "application/pdf"}
+    )
+    # Paper 2: HTTP failure
+    httpx_mock.add_response(status_code=503)
+    # Paper 3: success
+    httpx_mock.add_response(
+        content=b"%PDF-1.4\n", headers={"content-type": "application/pdf"}
+    )
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.pdfplumber.open",
+        lambda _: _FakePdf([_FakePage("body")]),
+    )
+
+    paths = await batch_enrich_papers(
+        papers, runs_papers_dir=tmp_path / "papers", top_n=3, concurrency=1
+    )
+    # Numbering matches original index (01, 03) — 02 dropped.
+    assert paths == ["papers/01.md", "papers/03.md"]
+
+
+async def test_batch_enrich_papers_returns_empty_when_all_fail(
+    tmp_path: Path, httpx_mock
+) -> None:
+    papers = [_arxiv_paper(f"2401.{i:05d}") for i in range(1, 4)]
+    for _ in range(3):
+        httpx_mock.add_response(status_code=503)
+    paths = await batch_enrich_papers(
+        papers, runs_papers_dir=tmp_path / "papers", top_n=3
+    )
+    assert paths == []
+
+
+async def test_batch_enrich_papers_empty_list_input() -> None:
+    paths = await batch_enrich_papers([], runs_papers_dir=Path("/nonexistent"))
+    assert paths == []

--- a/apps/agent-worker/tests/test_pdf_tool.py
+++ b/apps/agent-worker/tests/test_pdf_tool.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from agent_worker.tools.pdf import find_pdf_url
+from agent_worker.tools.pdf import fetch_and_extract, find_pdf_url
 from mm_contracts import Paper
 
 
@@ -68,3 +68,95 @@ async def test_find_pdf_url_returns_none_when_unpaywall_5xx(httpx_mock) -> None:
     httpx_mock.add_response(status_code=503)
     url = await find_pdf_url(_doi_paper(), mailto="bot@example.com")
     assert url is None
+
+
+# Minimal valid PDF byte stream that pdfplumber accepts. We do NOT actually
+# parse it — pdfplumber.open is monkey-patched in the test below.
+_FAKE_PDF_BYTES = b"%PDF-1.4\n%fake\n"
+
+
+class _FakePage:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def extract_text(self) -> str:
+        return self._text
+
+
+class _FakePdf:
+    def __init__(self, pages: list[_FakePage]) -> None:
+        self.pages = pages
+
+    def __enter__(self) -> _FakePdf:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+
+async def test_fetch_and_extract_pdf(httpx_mock, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    httpx_mock.add_response(
+        content=_FAKE_PDF_BYTES,
+        headers={"content-type": "application/pdf"},
+    )
+    fake = _FakePdf([_FakePage("Hello, world."), _FakePage("Methods: ...")])
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.pdfplumber.open", lambda _: fake
+    )
+
+    text, parser = await fetch_and_extract("http://example.com/p.pdf")
+    assert "Hello, world." in text
+    assert "Methods" in text
+    assert parser == "pdfplumber"
+
+
+async def test_fetch_and_extract_html_uses_trafilatura(httpx_mock, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    html = b"<html><body><article>Main content here.</article></body></html>"
+    httpx_mock.add_response(
+        content=html, headers={"content-type": "text/html; charset=utf-8"}
+    )
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.trafilatura.extract",
+        lambda body, **_: "Main content here.",
+    )
+
+    text, parser = await fetch_and_extract("http://example.com/article")
+    assert text == "Main content here."
+    assert parser == "trafilatura"
+
+
+async def test_fetch_and_extract_rejects_oversized_response(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    httpx_mock.add_response(
+        content=b"x" * (21 * 1024 * 1024),
+        headers={"content-type": "application/pdf"},
+    )
+    text, parser = await fetch_and_extract(
+        "http://example.com/huge.pdf", max_bytes=20_000_000
+    )
+    assert text is None
+    assert parser == "none"
+
+
+async def test_fetch_and_extract_returns_none_on_timeout(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    import httpx
+    httpx_mock.add_exception(httpx.ReadTimeout("slow"))
+    text, parser = await fetch_and_extract("http://example.com/slow.pdf")
+    assert text is None
+    assert parser == "none"
+
+
+async def test_fetch_and_extract_returns_none_when_extractor_returns_empty(
+    httpx_mock, monkeypatch  # type: ignore[no-untyped-def]
+) -> None:
+    httpx_mock.add_response(
+        content=_FAKE_PDF_BYTES,
+        headers={"content-type": "application/pdf"},
+    )
+    fake = _FakePdf([_FakePage("")])
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.pdfplumber.open", lambda _: fake
+    )
+
+    text, parser = await fetch_and_extract("http://example.com/empty.pdf")
+    assert text is None
+    assert parser == "none"

--- a/apps/agent-worker/tests/test_searcher_agent.py
+++ b/apps/agent-worker/tests/test_searcher_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -359,3 +360,105 @@ async def test_searcher_revise_with_critique_returns_validated_findings(
     )
 
     assert revised.key_findings == ["Sparse search results; use as context only."]
+
+
+async def test_searcher_populates_paper_fulltext_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    problem: ProblemInput,
+    analysis: AnalyzerOutput,
+    tmp_path: Path,
+) -> None:
+    """When runs_dir is provided and enrichment succeeds, paths land on SearchFindings."""
+    papers = _sample_papers()
+
+    async def fake_batch(queries, max_per_query=5, concurrency=2):  # noqa: ANN001
+        return {q: papers for q in queries[:1]} | {q: [] for q in queries[1:]}
+
+    async def fake_empty(queries, **_):  # noqa: ANN001, ANN003
+        return {q: [] for q in queries}
+
+    async def fake_enrich(papers_arg, runs_papers_dir, top_n=3, **_):  # noqa: ANN001, ANN003
+        # Confirm the Searcher chose the right cap.
+        assert top_n == 3
+        runs_papers_dir.mkdir(parents=True, exist_ok=True)
+        (runs_papers_dir / "01.md").write_text("body 1", encoding="utf-8")
+        return ["papers/01.md"]
+
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_arxiv", fake_batch
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_openalex", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_crossref", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_web", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_enrich_papers", fake_enrich
+    )
+
+    gateway = _FakeGateway([_FINDINGS_JSON])
+    emitter = _FakeEmitter()
+
+    agent = SearcherAgent(gateway, emitter, runs_dir=tmp_path)  # type: ignore[arg-type]
+    out = await agent.run_for(problem, analysis)
+
+    assert out.paper_fulltext_paths == ["papers/01.md"]
+    paper_file = tmp_path / str(emitter.run_id) / "papers" / "01.md"
+    assert paper_file.exists()
+
+
+async def test_searcher_skips_enrichment_when_no_papers(
+    monkeypatch: pytest.MonkeyPatch,
+    problem: ProblemInput,
+    analysis: AnalyzerOutput,
+    tmp_path: Path,
+) -> None:
+    """No papers → no enrichment call → empty paper_fulltext_paths."""
+    async def fake_batch_empty(queries, max_per_query=5, concurrency=2):  # noqa: ANN001
+        return {q: [] for q in queries}
+
+    async def fake_empty(queries, **_):  # noqa: ANN001, ANN003
+        return {q: [] for q in queries}
+
+    enrich_called = False
+
+    async def fake_enrich(*_a, **_kw):  # noqa: ANN001, ANN003
+        nonlocal enrich_called
+        enrich_called = True
+        return []
+
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_arxiv", fake_batch_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_openalex", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_crossref", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_web", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_enrich_papers", fake_enrich
+    )
+
+    class _NoopGateway:
+        async def stream_completion(self, **_: object) -> AsyncIterator[str]:
+            raise AssertionError("LLM must not be called")
+            yield ""
+
+        async def close(self) -> None:
+            pass
+
+    emitter = _FakeEmitter()
+    agent = SearcherAgent(_NoopGateway(), emitter, runs_dir=tmp_path)  # type: ignore[arg-type]
+    out = await agent.run_for(problem, analysis)
+
+    assert out.papers == []
+    assert out.paper_fulltext_paths == []
+    assert enrich_called is False

--- a/apps/agent-worker/tests/test_searcher_compaction.py
+++ b/apps/agent-worker/tests/test_searcher_compaction.py
@@ -1,0 +1,87 @@
+"""Tests for SearcherAgent._compact_oversized_papers."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from uuid import uuid4
+
+from agent_worker.agents import SearcherAgent
+from agent_worker.agents.searcher import COMPACT_THRESHOLD_CHARS
+
+
+class _FakeEmitter:
+    def __init__(self) -> None:
+        self.run_id = uuid4()
+        self.events: list[tuple[str, dict, str | None]] = []
+
+    async def emit(self, kind, payload=None, agent=None):  # noqa: ANN001
+        self.events.append((kind, payload or {}, agent))
+
+
+class _ScriptedGateway:
+    def __init__(self, response: str | Exception) -> None:
+        self._response = response
+
+    async def stream_completion(self, **_: object) -> AsyncIterator[str]:
+        if isinstance(self._response, Exception):
+            raise self._response
+        yield self._response
+
+    async def close(self) -> None:
+        pass
+
+
+def _make_agent(response):  # noqa: ANN001
+    return SearcherAgent(_ScriptedGateway(response), _FakeEmitter())  # type: ignore[arg-type]
+
+
+async def test_compact_skips_files_under_threshold(tmp_path: Path) -> None:
+    """Files under the threshold are not touched and the LLM is not called."""
+    agent = _make_agent(RuntimeError("LLM must not be called for short files"))
+    runs_papers_dir = tmp_path / "papers"
+    runs_papers_dir.mkdir()
+    short = "short content" * 100  # well below 24k chars
+    (runs_papers_dir / "01.md").write_text(short, encoding="utf-8")
+
+    paths = await agent._compact_oversized_papers(runs_papers_dir, ["papers/01.md"])
+    assert paths == ["papers/01.md"]
+    assert (runs_papers_dir / "01.md").read_text("utf-8") == short
+
+
+async def test_compact_overwrites_oversized_file_with_llm_output(tmp_path: Path) -> None:
+    # Must exceed COMPACT_MIN_OUTPUT_CHARS (1000) to be accepted as usable.
+    compacted = "## Methods\n\n" + ("dense " * 250)
+    agent = _make_agent(compacted)
+    runs_papers_dir = tmp_path / "papers"
+    runs_papers_dir.mkdir()
+    long_text = "x" * (COMPACT_THRESHOLD_CHARS + 1000)
+    (runs_papers_dir / "01.md").write_text(long_text, encoding="utf-8")
+
+    paths = await agent._compact_oversized_papers(runs_papers_dir, ["papers/01.md"])
+    assert paths == ["papers/01.md"]
+    # _compact_one strips the LLM output before persisting.
+    assert (runs_papers_dir / "01.md").read_text("utf-8") == compacted.strip()
+
+
+async def test_compact_keeps_raw_on_llm_failure(tmp_path: Path) -> None:
+    agent = _make_agent(RuntimeError("provider 502"))
+    runs_papers_dir = tmp_path / "papers"
+    runs_papers_dir.mkdir()
+    long_text = "x" * (COMPACT_THRESHOLD_CHARS + 1000)
+    (runs_papers_dir / "01.md").write_text(long_text, encoding="utf-8")
+
+    paths = await agent._compact_oversized_papers(runs_papers_dir, ["papers/01.md"])
+    assert paths == ["papers/01.md"]
+    assert (runs_papers_dir / "01.md").read_text("utf-8") == long_text
+
+
+async def test_compact_keeps_raw_when_llm_output_too_short(tmp_path: Path) -> None:
+    agent = _make_agent("tiny")  # << COMPACT_MIN_OUTPUT_CHARS
+    runs_papers_dir = tmp_path / "papers"
+    runs_papers_dir.mkdir()
+    long_text = "x" * (COMPACT_THRESHOLD_CHARS + 1000)
+    (runs_papers_dir / "01.md").write_text(long_text, encoding="utf-8")
+
+    await agent._compact_oversized_papers(runs_papers_dir, ["papers/01.md"])
+    assert (runs_papers_dir / "01.md").read_text("utf-8") == long_text

--- a/apps/agent-worker/tests/test_writer_agent.py
+++ b/apps/agent-worker/tests/test_writer_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -17,6 +18,7 @@ from mm_contracts import (
     PaperDraft,
     PaperSection,
     ProblemInput,
+    SearchFindings,
 )
 
 
@@ -121,6 +123,128 @@ async def test_writer_agent_returns_validated_paper(
     assert "stage.start" in kinds
     assert "agent.output" in kinds
     assert "stage.done" in kinds
+
+
+async def test_writer_includes_paper_fulltexts_when_paths_present(
+    tmp_path: Path,
+    problem: ProblemInput,
+    analysis: AnalyzerOutput,
+    spec: ModelSpec,
+    coder_output: CoderOutput,
+) -> None:
+    run_dir = tmp_path / "run"
+    papers_dir = run_dir / "papers"
+    papers_dir.mkdir(parents=True)
+    (papers_dir / "01.md").write_text("paper 1 full text", encoding="utf-8")
+    (papers_dir / "02.md").write_text("paper 2 full text", encoding="utf-8")
+
+    captured_messages: list[dict] = []
+
+    class _CapturingGateway:
+        async def stream_completion(self, **kwargs: object) -> AsyncIterator[str]:
+            msgs = kwargs.get("messages") or []
+            assert isinstance(msgs, list)
+            captured_messages.extend(msgs)  # type: ignore[arg-type]
+            yield (
+                '{"title":"T","abstract":"a",'
+                '"sections":[{"title":"Intro","body_markdown":"x"}],'
+                '"references":[],"figure_refs":[]}'
+            )
+
+        async def close(self) -> None:
+            pass
+
+    emitter = _FakeEmitter()
+    findings = SearchFindings(
+        queries=["q"],
+        papers=[],
+        key_findings=[],
+        datasets_mentioned=[],
+        paper_fulltext_paths=["papers/01.md", "papers/02.md"],
+    )
+
+    agent = WriterAgent(_CapturingGateway(), emitter, run_dir=run_dir)  # type: ignore[arg-type]
+    await agent.run_for(problem, analysis, spec, coder_output, findings)
+
+    body = "\n".join(str(m.get("content", "")) for m in captured_messages)
+    assert "paper 1 full text" in body
+    assert "paper 2 full text" in body
+    # Numbered cite hint surfaces in the user prompt.
+    assert "Paper 1" in body
+    assert "Paper 2" in body
+
+
+async def test_writer_omits_fulltexts_when_no_paths(
+    tmp_path: Path,
+    problem: ProblemInput,
+    analysis: AnalyzerOutput,
+    spec: ModelSpec,
+    coder_output: CoderOutput,
+) -> None:
+    """Empty `paper_fulltext_paths` → no Paper N block + no errors."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    paper_json = (
+        '{"title":"T","abstract":"a",'
+        '"sections":[{"title":"Intro","body_markdown":"x"}],'
+        '"references":[],"figure_refs":[]}'
+    )
+    gateway = _FakeGateway([paper_json])
+    emitter = _FakeEmitter()
+    findings = SearchFindings(queries=[], papers=[], key_findings=[])
+
+    agent = WriterAgent(gateway, emitter, run_dir=run_dir)  # type: ignore[arg-type]
+    paper = await agent.run_for(problem, analysis, spec, coder_output, findings)
+    assert isinstance(paper, PaperDraft)
+
+
+async def test_writer_truncates_oversized_fulltext(
+    tmp_path: Path,
+    problem: ProblemInput,
+    analysis: AnalyzerOutput,
+    spec: ModelSpec,
+    coder_output: CoderOutput,
+) -> None:
+    """Oversized paper file is truncated at paragraph boundary."""
+    from agent_worker.agents.writer import WRITER_SOFT_TRUNCATE_CHARS
+
+    run_dir = tmp_path / "run"
+    papers_dir = run_dir / "papers"
+    papers_dir.mkdir(parents=True)
+    # Build a file well over the soft cap, with regular paragraph
+    # boundaries so the rsplit("\n\n", 1) lands on one.
+    paragraph = ("x" * 100 + "\n\n") * (WRITER_SOFT_TRUNCATE_CHARS // 102 + 50)
+    (papers_dir / "01.md").write_text(paragraph, encoding="utf-8")
+
+    captured_messages: list[dict] = []
+
+    class _CapturingGateway:
+        async def stream_completion(self, **kwargs: object) -> AsyncIterator[str]:
+            msgs = kwargs.get("messages") or []
+            assert isinstance(msgs, list)
+            captured_messages.extend(msgs)  # type: ignore[arg-type]
+            yield (
+                '{"title":"T","abstract":"a",'
+                '"sections":[{"title":"Intro","body_markdown":"x"}],'
+                '"references":[],"figure_refs":[]}'
+            )
+
+        async def close(self) -> None:
+            pass
+
+    emitter = _FakeEmitter()
+    findings = SearchFindings(
+        queries=["q"],
+        papers=[],
+        key_findings=[],
+        paper_fulltext_paths=["papers/01.md"],
+    )
+
+    agent = WriterAgent(_CapturingGateway(), emitter, run_dir=run_dir)  # type: ignore[arg-type]
+    await agent.run_for(problem, analysis, spec, coder_output, findings)
+
+    body = "\n".join(str(m.get("content", "")) for m in captured_messages)
+    assert "[...truncated]" in body
 
 
 def test_render_paper_markdown_has_title_and_abstract() -> None:

--- a/docs/superpowers/plans/2026-05-11-searcher-pdf-enrichment.md
+++ b/docs/superpowers/plans/2026-05-11-searcher-pdf-enrichment.md
@@ -1,0 +1,1461 @@
+# Searcher PDF Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich `SearchFindings` with full-text content for the top 3 papers so the Writer can cite specific equations, methodology details, and numerical results instead of generic "according to [12]".
+
+**Architecture:** Add a new `tools/pdf.py` module that resolves Paper → PDF URL (arXiv direct + Unpaywall for DOIs) and extracts text via trafilatura/pdfplumber. Wire two new phases into `SearcherAgent.run_for`: (3.5) `batch_enrich_papers` persists top-3 papers' text to `runs/<id>/papers/NN.md`; (3.6) `_compact_oversized_papers` invokes an inline LLM call to compact files over 24k chars while preserving source language. Writer reads paths from `SearchFindings.paper_fulltext_paths` and inlines content into its prompt with a 32k-char paragraph-boundary soft-truncation safety net. Failure-tolerant at every step — empty `paper_fulltext_paths` reverts cleanly to v0.5.3 behavior.
+
+**Tech Stack:** Python 3.11, httpx (async HTTP), trafilatura (HTML→text), pdfplumber (PDF→text), Pydantic v2 (contracts), pytest + pytest-httpx (tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-11-searcher-pdf-enrichment-design.md`
+
+---
+
+## Task 1: Add dependencies and extend `SearchFindings` contract
+
+**Files:**
+- Modify: `apps/agent-worker/pyproject.toml` (add deps)
+- Modify: `apps/agent-worker/uv.lock` (auto-regenerated)
+- Modify: `packages/py-contracts/src/mm_contracts/agent_io.py` (`SearchFindings` model)
+- Modify: `packages/ts-contracts/src/index.ts` (TS mirror)
+- Test: `apps/agent-worker/tests/test_contracts_searchfindings.py` (new minimal test for the new field)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/agent-worker/tests/test_contracts_searchfindings.py`:
+
+```python
+"""Backward-compat check for the SearchFindings.paper_fulltext_paths field."""
+
+from __future__ import annotations
+
+import pytest
+from mm_contracts import SearchFindings
+from pydantic import ValidationError
+
+
+def test_searchfindings_without_paper_fulltext_paths_defaults_to_empty() -> None:
+    sf = SearchFindings(queries=["q"], papers=[], key_findings=[], datasets_mentioned=[])
+    assert sf.paper_fulltext_paths == []
+
+
+def test_searchfindings_accepts_paper_fulltext_paths() -> None:
+    sf = SearchFindings(
+        queries=["q"],
+        papers=[],
+        key_findings=[],
+        datasets_mentioned=[],
+        paper_fulltext_paths=["papers/01.md", "papers/02.md", "papers/03.md"],
+    )
+    assert sf.paper_fulltext_paths == ["papers/01.md", "papers/02.md", "papers/03.md"]
+
+
+def test_searchfindings_caps_paper_fulltext_paths_at_three() -> None:
+    with pytest.raises(ValidationError):
+        SearchFindings(
+            queries=["q"],
+            papers=[],
+            key_findings=[],
+            datasets_mentioned=[],
+            paper_fulltext_paths=[f"papers/0{i}.md" for i in range(1, 5)],
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_contracts_searchfindings.py -v`
+Expected: FAIL on `paper_fulltext_paths` — `SearchFindings` does not have that field yet.
+
+- [ ] **Step 3: Add the contract field**
+
+Edit `packages/py-contracts/src/mm_contracts/agent_io.py`, find class `SearchFindings`, append (preserving existing fields):
+
+```python
+class SearchFindings(BaseModel):
+    """Searcher agent output: curated papers + synthesized key findings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    queries: list[str] = Field(default_factory=list, max_length=10)
+    papers: list[Paper] = Field(default_factory=list, max_length=15)
+    key_findings: list[str] = Field(default_factory=list, max_length=10)
+    datasets_mentioned: list[str] = Field(default_factory=list, max_length=10)
+    # NEW: relative paths under runs/<run_id>/ pointing at extracted full-text
+    # markdown for the top 3 cited papers. Empty when enrichment did not run
+    # or every paper's PDF was unreachable / parse failed. The Writer reads
+    # these to ground specific citations; failure to load is non-fatal.
+    paper_fulltext_paths: list[str] = Field(default_factory=list, max_length=3)
+```
+
+- [ ] **Step 4: Mirror in TS contracts**
+
+Edit `packages/ts-contracts/src/index.ts`, find the existing `SearchFindings` interface (or add one if missing), append:
+
+```ts
+export interface SearchFindings {
+  queries?: string[];
+  papers?: Paper[];
+  key_findings?: string[];
+  datasets_mentioned?: string[];
+  paper_fulltext_paths?: string[];
+}
+```
+
+If `SearchFindings` already exists in `index.ts`, only add the `paper_fulltext_paths?: string[];` line. Do NOT alter the existing fields.
+
+- [ ] **Step 5: Add the new Python dependencies**
+
+Run: `cd apps/agent-worker && uv add 'trafilatura>=1.12' 'pdfplumber>=0.11'`
+Expected: writes to `pyproject.toml`, regenerates `uv.lock`. `uv` resolves transitive deps (`pdfminer.six`, `lxml`, `justext`, `charset-normalizer`).
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_contracts_searchfindings.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 7: Run full repo lint and the full agent-worker test suite to confirm no regression**
+
+Run: `cd /Users/cornna/project/math_agent && uvx ruff check .`
+Expected: `All checks passed!`
+
+Run: `cd apps/agent-worker && uv run pytest --tb=short -q`
+Expected: All existing tests still pass (290 baseline + the 3 new ones = 293).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/py-contracts/src/mm_contracts/agent_io.py packages/ts-contracts/src/index.ts apps/agent-worker/pyproject.toml apps/agent-worker/uv.lock apps/agent-worker/tests/test_contracts_searchfindings.py
+git commit -m "feat(contracts): add SearchFindings.paper_fulltext_paths (top-3 cap)
+
+Backward compatible (default empty). TS mirror optional. Adds trafilatura
+and pdfplumber as agent-worker deps in preparation for the PDF enrichment
+tool."
+```
+
+---
+
+## Task 2: `tools/pdf.py::find_pdf_url` — resolve Paper to a PDF/HTML URL
+
+**Files:**
+- Create: `apps/agent-worker/src/agent_worker/tools/pdf.py`
+- Create: `apps/agent-worker/tests/test_pdf_tool.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/agent-worker/tests/test_pdf_tool.py`:
+
+```python
+"""Tests for tools/pdf.py — offline via pytest-httpx."""
+
+from __future__ import annotations
+
+import pytest
+from agent_worker.tools.pdf import find_pdf_url
+from mm_contracts import Paper
+
+
+def _arxiv_paper(arxiv_id: str = "2312.01234") -> Paper:
+    return Paper(
+        title="Arxiv Paper",
+        authors=["A. B."],
+        abstract="abs",
+        url=f"http://arxiv.org/abs/{arxiv_id}",
+        arxiv_id=arxiv_id,
+    )
+
+
+def _doi_paper(doi: str = "10.1234/example.2024.001") -> Paper:
+    return Paper(
+        title="Crossref Paper",
+        authors=["C. D."],
+        abstract="abs",
+        url=f"https://doi.org/{doi}",
+        doi=doi,
+    )
+
+
+async def test_find_pdf_url_returns_arxiv_pdf_for_arxiv_paper() -> None:
+    """arXiv papers are resolved without contacting Unpaywall."""
+    url = await find_pdf_url(_arxiv_paper("2312.01234"))
+    assert url == "https://arxiv.org/pdf/2312.01234.pdf"
+
+
+async def test_find_pdf_url_returns_oa_url_when_unpaywall_has_one(httpx_mock) -> None:
+    httpx_mock.add_response(
+        json={
+            "best_oa_location": {
+                "url_for_pdf": "https://example.org/paper.pdf",
+            }
+        }
+    )
+    url = await find_pdf_url(_doi_paper("10.1/abc"), mailto="bot@example.com")
+    assert url == "https://example.org/paper.pdf"
+    request = httpx_mock.get_request()
+    assert "10.1/abc" in str(request.url)
+    assert "email=bot%40example.com" in str(request.url)
+
+
+async def test_find_pdf_url_returns_none_when_unpaywall_has_no_oa(httpx_mock) -> None:
+    httpx_mock.add_response(json={"best_oa_location": None})
+    url = await find_pdf_url(_doi_paper("10.1/no-oa"), mailto="bot@example.com")
+    assert url is None
+
+
+async def test_find_pdf_url_returns_none_when_paper_has_neither_arxiv_nor_doi() -> None:
+    paper = Paper(
+        title="Web Hit",
+        authors=[],
+        abstract="",
+        url="https://blog.example/post",
+    )
+    url = await find_pdf_url(paper, mailto="bot@example.com")
+    assert url is None
+
+
+async def test_find_pdf_url_returns_none_when_unpaywall_5xx(httpx_mock) -> None:
+    httpx_mock.add_response(status_code=503)
+    url = await find_pdf_url(_doi_paper(), mailto="bot@example.com")
+    assert url is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_pdf_tool.py -v`
+Expected: All FAIL — `tools.pdf` does not exist.
+
+- [ ] **Step 3: Implement `find_pdf_url`**
+
+Create `apps/agent-worker/src/agent_worker/tools/pdf.py`:
+
+```python
+"""PDF / OA paper retrieval and text extraction.
+
+A thin async layer that:
+  - resolves a Paper (with arxiv_id or doi) to a fetchable PDF/HTML URL
+    (arXiv direct + Unpaywall API for DOIs)
+  - downloads + extracts the text via pdfplumber (PDF) or trafilatura (HTML)
+  - persists the top N papers' text under runs/<run_id>/papers/NN.md for
+    the Writer to consume
+
+Best-effort throughout: any failure returns None / [] / "" so the Searcher
+keeps running and SearchFindings.paper_fulltext_paths just stays empty.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+import httpx
+from mm_contracts import Paper
+
+_log = logging.getLogger(__name__)
+
+ARXIV_PDF_TEMPLATE = "https://arxiv.org/pdf/{arxiv_id}.pdf"
+UNPAYWALL_API_URL = "https://api.unpaywall.org/v2/{doi}"
+
+
+async def find_pdf_url(
+    paper: Paper,
+    *,
+    mailto: str | None = None,
+    timeout: float = 10.0,  # noqa: ASYNC109 — applied to the httpx client, not an asyncio primitive
+) -> str | None:
+    """Resolve a Paper to a fetchable PDF/HTML URL or None.
+
+    Resolution order:
+      1. arXiv ID present → arxiv.org/pdf/<id>.pdf (always available)
+      2. DOI present → Unpaywall API → best_oa_location.url_for_pdf
+      3. None
+    """
+    if paper.arxiv_id:
+        return ARXIV_PDF_TEMPLATE.format(arxiv_id=paper.arxiv_id)
+    if not paper.doi:
+        return None
+
+    # Unpaywall recommends including a mailto for the polite pool. Without
+    # one we still get a response, just with stricter rate limits.
+    params: dict[str, str] = {}
+    if mailto:
+        params["email"] = mailto
+    url = UNPAYWALL_API_URL.format(doi=paper.doi)
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            r = await client.get(url, params=params)
+            r.raise_for_status()
+            data = r.json()
+    except Exception as e:  # noqa: BLE001 — best-effort
+        _log.info("Unpaywall lookup failed for %s: %s", paper.doi, e)
+        return None
+
+    if not isinstance(data, dict):
+        return None
+    oa = data.get("best_oa_location")
+    if not isinstance(oa, dict):
+        return None
+    pdf_url = oa.get("url_for_pdf")
+    return pdf_url if isinstance(pdf_url, str) and pdf_url.strip() else None
+
+
+__all__ = [
+    "ARXIV_PDF_TEMPLATE",
+    "UNPAYWALL_API_URL",
+    "find_pdf_url",
+]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_pdf_tool.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agent-worker/src/agent_worker/tools/pdf.py apps/agent-worker/tests/test_pdf_tool.py
+git commit -m "feat(pdf): find_pdf_url resolves Paper to arXiv or Unpaywall URL"
+```
+
+---
+
+## Task 3: `tools/pdf.py::fetch_and_extract` — download + extract text
+
+**Files:**
+- Modify: `apps/agent-worker/src/agent_worker/tools/pdf.py` (append)
+- Modify: `apps/agent-worker/tests/test_pdf_tool.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/agent-worker/tests/test_pdf_tool.py`:
+
+```python
+from agent_worker.tools.pdf import fetch_and_extract
+
+
+# Minimal valid PDF byte stream that pdfplumber accepts. We do NOT actually
+# parse it — pdfplumber.open is monkey-patched in the test below.
+_FAKE_PDF_BYTES = b"%PDF-1.4\n%fake\n"
+
+
+class _FakePage:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def extract_text(self) -> str:
+        return self._text
+
+
+class _FakePdf:
+    def __init__(self, pages: list[_FakePage]) -> None:
+        self.pages = pages
+
+    def __enter__(self) -> "_FakePdf":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+
+async def test_fetch_and_extract_pdf(httpx_mock, monkeypatch) -> None:
+    httpx_mock.add_response(
+        content=_FAKE_PDF_BYTES,
+        headers={"content-type": "application/pdf"},
+    )
+    fake = _FakePdf([_FakePage("Hello, world."), _FakePage("Methods: ...")])
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.pdfplumber.open", lambda _: fake
+    )
+
+    text, parser = await fetch_and_extract("http://example.com/p.pdf")
+    assert "Hello, world." in text
+    assert "Methods" in text
+    assert parser == "pdfplumber"
+
+
+async def test_fetch_and_extract_html_uses_trafilatura(httpx_mock, monkeypatch) -> None:
+    html = b"<html><body><article>Main content here.</article></body></html>"
+    httpx_mock.add_response(
+        content=html, headers={"content-type": "text/html; charset=utf-8"}
+    )
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.trafilatura.extract",
+        lambda body, **_: "Main content here.",
+    )
+
+    text, parser = await fetch_and_extract("http://example.com/article")
+    assert text == "Main content here."
+    assert parser == "trafilatura"
+
+
+async def test_fetch_and_extract_rejects_oversized_response(httpx_mock) -> None:
+    httpx_mock.add_response(
+        content=b"x" * (21 * 1024 * 1024),
+        headers={"content-type": "application/pdf"},
+    )
+    text, parser = await fetch_and_extract(
+        "http://example.com/huge.pdf", max_bytes=20_000_000
+    )
+    assert text is None
+    assert parser == "none"
+
+
+async def test_fetch_and_extract_returns_none_on_timeout(httpx_mock) -> None:
+    httpx_mock.add_exception(httpx.ReadTimeout("slow"))
+    text, parser = await fetch_and_extract("http://example.com/slow.pdf")
+    assert text is None
+    assert parser == "none"
+
+
+async def test_fetch_and_extract_returns_none_when_extractor_returns_empty(
+    httpx_mock, monkeypatch
+) -> None:
+    httpx_mock.add_response(
+        content=_FAKE_PDF_BYTES,
+        headers={"content-type": "application/pdf"},
+    )
+    fake = _FakePdf([_FakePage("")])
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.pdfplumber.open", lambda _: fake
+    )
+
+    text, parser = await fetch_and_extract("http://example.com/empty.pdf")
+    assert text is None
+    assert parser == "none"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_pdf_tool.py -v`
+Expected: New tests FAIL — `fetch_and_extract` does not exist.
+
+- [ ] **Step 3: Implement `fetch_and_extract`**
+
+Append to `apps/agent-worker/src/agent_worker/tools/pdf.py`:
+
+```python
+import io
+
+import pdfplumber
+import trafilatura
+
+
+async def fetch_and_extract(
+    url: str,
+    *,
+    timeout: float = 15.0,  # noqa: ASYNC109 — applied to httpx, not an asyncio primitive
+    max_bytes: int = 20_000_000,
+) -> tuple[str | None, Literal["trafilatura", "pdfplumber", "none"]]:
+    """Fetch URL and return (extracted_text, parser_name).
+
+    text=None signals failure for any reason (network, oversize, parse,
+    or empty extraction). The caller never raises — the Searcher's
+    enrichment phase is best-effort. ``max_bytes`` rejects oversized
+    bodies to bound memory.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            r = await client.get(url, follow_redirects=True)
+            r.raise_for_status()
+    except Exception as e:  # noqa: BLE001 — best-effort
+        _log.info("fetch_and_extract: HTTP failure for %s: %s", url, e)
+        return None, "none"
+
+    content = r.content
+    if len(content) > max_bytes:
+        _log.info(
+            "fetch_and_extract: oversized response %d bytes for %s; rejecting",
+            len(content), url,
+        )
+        return None, "none"
+
+    ctype = (r.headers.get("content-type") or "").lower()
+    if "pdf" in ctype or url.lower().endswith(".pdf"):
+        try:
+            with pdfplumber.open(io.BytesIO(content)) as pdf:
+                pages_text = [p.extract_text() or "" for p in pdf.pages]
+            text = "\n\n".join(t for t in pages_text if t.strip())
+        except Exception as e:  # noqa: BLE001
+            _log.info("fetch_and_extract: pdfplumber failed for %s: %s", url, e)
+            return None, "none"
+        return (text, "pdfplumber") if text.strip() else (None, "none")
+
+    # HTML / other text content → trafilatura
+    try:
+        text = trafilatura.extract(
+            content,
+            include_comments=False,
+            include_tables=True,
+            favor_recall=True,
+            url=url,
+        )
+    except Exception as e:  # noqa: BLE001
+        _log.info("fetch_and_extract: trafilatura failed for %s: %s", url, e)
+        return None, "none"
+
+    if not text or not text.strip():
+        return None, "none"
+    return text, "trafilatura"
+```
+
+Update `__all__` at the bottom of `pdf.py`:
+
+```python
+__all__ = [
+    "ARXIV_PDF_TEMPLATE",
+    "UNPAYWALL_API_URL",
+    "fetch_and_extract",
+    "find_pdf_url",
+]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_pdf_tool.py -v`
+Expected: 10 passed (5 from Task 2 + 5 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agent-worker/src/agent_worker/tools/pdf.py apps/agent-worker/tests/test_pdf_tool.py
+git commit -m "feat(pdf): fetch_and_extract via pdfplumber (PDFs) or trafilatura (HTML)"
+```
+
+---
+
+## Task 4: `tools/pdf.py::batch_enrich_papers` — orchestrate top-N enrichment
+
+**Files:**
+- Modify: `apps/agent-worker/src/agent_worker/tools/pdf.py` (append)
+- Modify: `apps/agent-worker/tests/test_pdf_tool.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/agent-worker/tests/test_pdf_tool.py`:
+
+```python
+from pathlib import Path
+
+from agent_worker.tools.pdf import batch_enrich_papers
+
+
+async def test_batch_enrich_papers_writes_files_for_arxiv_sources(
+    tmp_path: Path, httpx_mock, monkeypatch
+) -> None:
+    # Three arXiv papers — no Unpaywall calls, direct PDF URLs.
+    papers = [_arxiv_paper(f"2401.{i:05d}") for i in range(1, 4)]
+    # Each pdf fetch returns a parseable PDF byte stream.
+    for _ in papers:
+        httpx_mock.add_response(
+            content=b"%PDF-1.4\n",
+            headers={"content-type": "application/pdf"},
+        )
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.pdfplumber.open",
+        lambda _: _FakePdf([_FakePage("paper body")]),
+    )
+
+    runs_papers_dir = tmp_path / "papers"
+    paths = await batch_enrich_papers(
+        papers, runs_papers_dir=runs_papers_dir, top_n=3
+    )
+    assert paths == ["papers/01.md", "papers/02.md", "papers/03.md"]
+    for rel in paths:
+        assert (tmp_path / rel).read_text("utf-8") == "paper body"
+
+
+async def test_batch_enrich_papers_caps_at_top_n(
+    tmp_path: Path, httpx_mock, monkeypatch
+) -> None:
+    """Given 5 papers and top_n=3, only the first 3 are processed."""
+    papers = [_arxiv_paper(f"2401.{i:05d}") for i in range(1, 6)]
+    for _ in range(3):
+        httpx_mock.add_response(
+            content=b"%PDF-1.4\n",
+            headers={"content-type": "application/pdf"},
+        )
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.pdfplumber.open",
+        lambda _: _FakePdf([_FakePage("body")]),
+    )
+
+    paths = await batch_enrich_papers(
+        papers, runs_papers_dir=tmp_path / "papers", top_n=3
+    )
+    assert len(paths) == 3
+
+
+async def test_batch_enrich_papers_skips_failed_papers(
+    tmp_path: Path, httpx_mock, monkeypatch
+) -> None:
+    """Paper 2 fails; results contain only 01 and 03 with correct numbering."""
+    papers = [_arxiv_paper(f"2401.{i:05d}") for i in range(1, 4)]
+    # Paper 1: success
+    httpx_mock.add_response(
+        content=b"%PDF-1.4\n", headers={"content-type": "application/pdf"}
+    )
+    # Paper 2: HTTP failure
+    httpx_mock.add_response(status_code=503)
+    # Paper 3: success
+    httpx_mock.add_response(
+        content=b"%PDF-1.4\n", headers={"content-type": "application/pdf"}
+    )
+    monkeypatch.setattr(
+        "agent_worker.tools.pdf.pdfplumber.open",
+        lambda _: _FakePdf([_FakePage("body")]),
+    )
+
+    paths = await batch_enrich_papers(
+        papers, runs_papers_dir=tmp_path / "papers", top_n=3, concurrency=1
+    )
+    # Numbering matches original index (01, 03) — 02 dropped.
+    assert paths == ["papers/01.md", "papers/03.md"]
+
+
+async def test_batch_enrich_papers_returns_empty_when_all_fail(
+    tmp_path: Path, httpx_mock
+) -> None:
+    papers = [_arxiv_paper(f"2401.{i:05d}") for i in range(1, 4)]
+    for _ in range(3):
+        httpx_mock.add_response(status_code=503)
+    paths = await batch_enrich_papers(
+        papers, runs_papers_dir=tmp_path / "papers", top_n=3
+    )
+    assert paths == []
+
+
+async def test_batch_enrich_papers_empty_list_input() -> None:
+    paths = await batch_enrich_papers([], runs_papers_dir=Path("/nonexistent"))
+    assert paths == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_pdf_tool.py -v`
+Expected: 5 new tests FAIL — `batch_enrich_papers` not implemented.
+
+- [ ] **Step 3: Implement `batch_enrich_papers`**
+
+Append to `apps/agent-worker/src/agent_worker/tools/pdf.py`:
+
+```python
+import asyncio
+from pathlib import Path
+
+
+async def batch_enrich_papers(
+    papers: list[Paper],
+    runs_papers_dir: Path,
+    top_n: int = 3,
+    *,
+    mailto: str | None = None,
+    concurrency: int = 3,
+) -> list[str]:
+    """Enrich the top N papers concurrently and persist successes.
+
+    For each paper in papers[:top_n], in parallel (bounded by ``concurrency``):
+      1. Resolve a PDF/HTML URL via find_pdf_url.
+      2. Fetch + extract via fetch_and_extract.
+      3. On success, write the text to ``runs_papers_dir / f"{idx:02d}.md"``
+         where ``idx`` is the 1-based original position in papers[:top_n].
+
+    Returns a list of relative paths under runs_papers_dir.parent, in
+    original index order, suitable for SearchFindings.paper_fulltext_paths.
+    Failed papers are not represented in the output.
+    """
+    if not papers:
+        return []
+    runs_papers_dir.mkdir(parents=True, exist_ok=True)
+    sem = asyncio.Semaphore(concurrency)
+
+    async def enrich_one(idx: int, paper: Paper) -> tuple[int, str | None]:
+        async with sem:
+            pdf_url = await find_pdf_url(paper, mailto=mailto)
+            if not pdf_url:
+                return idx, None
+            text, parser = await fetch_and_extract(pdf_url)
+            if not text:
+                _log.info(
+                    "enrich: extraction empty for paper #%d (%s)", idx, pdf_url
+                )
+                return idx, None
+            rel_path = f"papers/{idx:02d}.md"
+            (runs_papers_dir / f"{idx:02d}.md").write_text(text, encoding="utf-8")
+            _log.info(
+                "enrich: paper #%d via %s (%d chars)", idx, parser, len(text)
+            )
+            return idx, rel_path
+
+    results = await asyncio.gather(
+        *(enrich_one(i, p) for i, p in enumerate(papers[:top_n], start=1))
+    )
+    return [rel for _, rel in sorted(results) if rel is not None]
+```
+
+Update `__all__`:
+
+```python
+__all__ = [
+    "ARXIV_PDF_TEMPLATE",
+    "UNPAYWALL_API_URL",
+    "batch_enrich_papers",
+    "fetch_and_extract",
+    "find_pdf_url",
+]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_pdf_tool.py -v`
+Expected: 15 passed (5 + 5 + 5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agent-worker/src/agent_worker/tools/pdf.py apps/agent-worker/tests/test_pdf_tool.py
+git commit -m "feat(pdf): batch_enrich_papers orchestrates top-N enrichment"
+```
+
+---
+
+## Task 5: SearcherAgent compaction method
+
+**Files:**
+- Modify: `apps/agent-worker/src/agent_worker/agents/searcher.py` (add method + constants)
+- Create: `apps/agent-worker/tests/test_searcher_compaction.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/agent-worker/tests/test_searcher_compaction.py`:
+
+```python
+"""Tests for SearcherAgent._compact_oversized_papers."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from agent_worker.agents import SearcherAgent
+from agent_worker.agents.searcher import COMPACT_THRESHOLD_CHARS
+
+
+class _FakeEmitter:
+    def __init__(self) -> None:
+        self.run_id = uuid4()
+        self.events: list[tuple[str, dict, str | None]] = []
+
+    async def emit(self, kind, payload=None, agent=None):  # noqa: ANN001
+        self.events.append((kind, payload or {}, agent))
+
+
+class _ScriptedGateway:
+    def __init__(self, response: str | Exception) -> None:
+        self._response = response
+
+    async def stream_completion(self, **_: object) -> AsyncIterator[str]:
+        if isinstance(self._response, Exception):
+            raise self._response
+        yield self._response
+
+    async def close(self) -> None:
+        pass
+
+
+def _make_agent(response):  # noqa: ANN001
+    return SearcherAgent(_ScriptedGateway(response), _FakeEmitter())  # type: ignore[arg-type]
+
+
+async def test_compact_skips_files_under_threshold(tmp_path: Path) -> None:
+    """Files under the threshold are not touched and the LLM is not called."""
+    agent = _make_agent(RuntimeError("LLM must not be called for short files"))
+    runs_papers_dir = tmp_path / "papers"
+    runs_papers_dir.mkdir()
+    short = "short content" * 100  # well below 24k chars
+    (runs_papers_dir / "01.md").write_text(short, encoding="utf-8")
+
+    paths = await agent._compact_oversized_papers(runs_papers_dir, ["papers/01.md"])
+    assert paths == ["papers/01.md"]
+    assert (runs_papers_dir / "01.md").read_text("utf-8") == short
+
+
+async def test_compact_overwrites_oversized_file_with_llm_output(tmp_path: Path) -> None:
+    compacted = "## Methods\n\n" + ("dense " * 100)
+    agent = _make_agent(compacted)
+    runs_papers_dir = tmp_path / "papers"
+    runs_papers_dir.mkdir()
+    long_text = "x" * (COMPACT_THRESHOLD_CHARS + 1000)
+    (runs_papers_dir / "01.md").write_text(long_text, encoding="utf-8")
+
+    paths = await agent._compact_oversized_papers(runs_papers_dir, ["papers/01.md"])
+    assert paths == ["papers/01.md"]
+    assert (runs_papers_dir / "01.md").read_text("utf-8") == compacted
+
+
+async def test_compact_keeps_raw_on_llm_failure(tmp_path: Path) -> None:
+    agent = _make_agent(RuntimeError("provider 502"))
+    runs_papers_dir = tmp_path / "papers"
+    runs_papers_dir.mkdir()
+    long_text = "x" * (COMPACT_THRESHOLD_CHARS + 1000)
+    (runs_papers_dir / "01.md").write_text(long_text, encoding="utf-8")
+
+    paths = await agent._compact_oversized_papers(runs_papers_dir, ["papers/01.md"])
+    assert paths == ["papers/01.md"]
+    # File untouched.
+    assert (runs_papers_dir / "01.md").read_text("utf-8") == long_text
+
+
+async def test_compact_keeps_raw_when_llm_output_too_short(tmp_path: Path) -> None:
+    agent = _make_agent("tiny")  # << COMPACT_MIN_OUTPUT_CHARS
+    runs_papers_dir = tmp_path / "papers"
+    runs_papers_dir.mkdir()
+    long_text = "x" * (COMPACT_THRESHOLD_CHARS + 1000)
+    (runs_papers_dir / "01.md").write_text(long_text, encoding="utf-8")
+
+    paths = await agent._compact_oversized_papers(runs_papers_dir, ["papers/01.md"])
+    assert (runs_papers_dir / "01.md").read_text("utf-8") == long_text
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_searcher_compaction.py -v`
+Expected: All FAIL — `_compact_oversized_papers` and `COMPACT_THRESHOLD_CHARS` not defined.
+
+- [ ] **Step 3: Add constants + method to SearcherAgent**
+
+Edit `apps/agent-worker/src/agent_worker/agents/searcher.py`. Just BEFORE the `class SearcherAgent` declaration, add module-level constants:
+
+```python
+# --- PDF enrichment / compaction tuning -------------------------------------
+# Raw extracted text above this character count triggers an LLM compaction
+# pass. ~24k chars ≈ 6k tokens, leaving Writer headroom for 3 papers.
+COMPACT_THRESHOLD_CHARS = 24_000
+# Output ceiling for the compaction LLM call. Used in the prompt as a hint;
+# we accept output up to ~32k before Writer-side soft truncation kicks in.
+COMPACT_TARGET_CHARS = 24_000
+# Below this, treat compaction output as a failure and keep the raw file.
+COMPACT_MIN_OUTPUT_CHARS = 1_000
+
+_COMPACT_SYSTEM_PROMPT = """You compress an academic paper into a high-density summary for downstream LLM citation. Preserve verbatim:
+- Mathematical formulas (LaTeX or plain)
+- Parameter definitions and units
+- Methodology steps in order
+- Experimental setup (sample size, data source, conditions)
+- Numerical results with confidence intervals or error bars
+- Key claims that Writer might cite
+
+Drop entirely:
+- Boilerplate (acknowledgments, ethics, conflicts of interest)
+- Related-work prose (the Writer has SearchFindings.papers for that)
+- Narrative filler ("In this paper we propose...")
+- Reference list
+- Repeated information
+
+Preserve the source language. If the input is Chinese, output Chinese.
+If English, output English. Do not translate.
+
+Output: dense markdown, ≤24000 characters. Keep section headings
+(## Methods, ## Results, etc.) so Writer can grep for them.
+Respond with the compacted markdown only."""
+```
+
+Then inside `class SearcherAgent` (after `_refine_queries`, before `_synthesize` works), add the two methods:
+
+```python
+async def _compact_oversized_papers(
+    self, runs_papers_dir: Path, paths: list[str]
+) -> list[str]:
+    """Compact any persisted paper text exceeding COMPACT_THRESHOLD_CHARS.
+
+    Overwrites in place. Compaction failure leaves the raw file untouched
+    — the Writer side has its own char-budget soft truncation as a safety
+    net.
+
+    Returns the same paths argument unchanged (compaction never drops a
+    paper; it either improves the file or leaves it alone).
+    """
+    # runs_papers_dir is the .../papers/ subdir. Resolve relative paths
+    # (e.g. "papers/01.md") against its parent so the math works out the
+    # same as how Writer reconstructs the path.
+    run_dir = runs_papers_dir.parent
+    for rel_path in paths:
+        abs_path = run_dir / rel_path
+        try:
+            raw = abs_path.read_text("utf-8")
+        except OSError as e:  # missing / unreadable
+            _log = self._log if hasattr(self, "_log") else None
+            await self.emitter.emit(
+                "log",
+                {
+                    "level": "warning",
+                    "message": f"compact: could not read {rel_path}: {e}",
+                },
+                agent=self.AGENT_NAME,
+            )
+            continue
+        if len(raw) <= COMPACT_THRESHOLD_CHARS:
+            continue
+        compacted = await self._compact_one(raw)
+        if not compacted or len(compacted) < COMPACT_MIN_OUTPUT_CHARS:
+            await self.emitter.emit(
+                "log",
+                {
+                    "level": "warning",
+                    "message": (
+                        f"compact: keeping raw for {rel_path} "
+                        f"(compaction unusable)"
+                    ),
+                },
+                agent=self.AGENT_NAME,
+            )
+            continue
+        abs_path.write_text(compacted, encoding="utf-8")
+        await self.emitter.emit(
+            "log",
+            {
+                "level": "info",
+                "message": (
+                    f"compact: {rel_path} {len(raw)} → {len(compacted)} chars"
+                ),
+            },
+            agent=self.AGENT_NAME,
+        )
+    return paths
+
+
+async def _compact_one(self, raw_text: str) -> str | None:
+    """Run one LLM call to compress raw paper text. None on failure."""
+    model = self._model_override or self.prompt.model_preference[0]
+    user_text = (
+        "Compact this paper text into ≤24000 characters of dense markdown, "
+        "preserving the source language verbatim.\n\nRaw paper text:\n\n"
+        + raw_text
+    )
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": _COMPACT_SYSTEM_PROMPT},
+        {"role": "user", "content": user_text},
+    ]
+    try:
+        text = await self._stream_and_collect(model, messages)
+    except Exception as e:  # noqa: BLE001
+        await self.emitter.emit(
+            "log",
+            {
+                "level": "warning",
+                "message": f"compact: LLM call failed: {e}",
+            },
+            agent=self.AGENT_NAME,
+        )
+        return None
+    text = text.strip() if isinstance(text, str) else ""
+    return text or None
+```
+
+Note: `_stream_and_collect` in this codebase requests `response_format={"type": "json_object"}`. The compaction output is markdown, not JSON. If `_stream_and_collect` always sets json_object, override here. Inspect `_stream_and_collect` (in searcher.py) — if it forces JSON, add a temporary unset by writing a small `_stream_and_collect_text` helper, or relax the response_format for non-JSON-needed calls. Read its body before editing; if it's hardcoded, the cleanest fix is to add an optional `response_format: dict | None = None` parameter defaulting to `{"type": "json_object"}` (current behavior preserved) and pass `None` from `_compact_one`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_searcher_compaction.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agent-worker/src/agent_worker/agents/searcher.py apps/agent-worker/tests/test_searcher_compaction.py
+git commit -m "feat(searcher): compaction LLM pass for oversized paper text
+
+24k-char threshold triggers a single LLM call that preserves formulas /
+methodology / numerical results and drops boilerplate. Source-language
+preserving (Chinese stays Chinese). Failure keeps the raw file —
+Writer-side soft truncation handles the long case."
+```
+
+---
+
+## Task 6: Wire enrichment + compaction into `SearcherAgent.run_for`
+
+**Files:**
+- Modify: `apps/agent-worker/src/agent_worker/agents/searcher.py` (constructor, run_for)
+- Modify: `apps/agent-worker/src/agent_worker/pipeline.py` (pass `runs_dir` when constructing the SearcherAgent)
+- Modify: `apps/agent-worker/tests/test_searcher_agent.py` (extend existing tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/agent-worker/tests/test_searcher_agent.py` (the file you extended in Task 1 of the prior PR — model it after `test_searcher_emits_expected_events`):
+
+```python
+from pathlib import Path
+
+from agent_worker.tools.pdf import batch_enrich_papers as _real_batch  # noqa: F401
+
+
+async def test_searcher_populates_paper_fulltext_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    problem: ProblemInput,
+    analysis: AnalyzerOutput,
+    tmp_path: Path,
+) -> None:
+    """When runs_dir is provided and enrichment succeeds, paths land on SearchFindings."""
+    papers = _sample_papers()
+
+    async def fake_batch(queries, max_per_query=5, concurrency=2):  # noqa: ANN001
+        return {q: papers for q in queries[:1]} | {q: [] for q in queries[1:]}
+
+    async def fake_empty(queries, **_):  # noqa: ANN001, ANN003
+        return {q: [] for q in queries}
+
+    async def fake_enrich(papers_arg, runs_papers_dir, top_n=3, **_):  # noqa: ANN001, ANN003
+        # Confirm the Searcher chose the right cap.
+        assert top_n == 3
+        runs_papers_dir.mkdir(parents=True, exist_ok=True)
+        (runs_papers_dir / "01.md").write_text("body 1", encoding="utf-8")
+        return ["papers/01.md"]
+
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_arxiv", fake_batch
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_openalex", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_crossref", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_web", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_enrich_papers", fake_enrich
+    )
+
+    gateway = _FakeGateway([_FINDINGS_JSON])
+    emitter = _FakeEmitter()
+
+    agent = SearcherAgent(gateway, emitter, runs_dir=tmp_path)  # type: ignore[arg-type]
+    out = await agent.run_for(problem, analysis)
+
+    assert out.paper_fulltext_paths == ["papers/01.md"]
+    paper_file = tmp_path / str(emitter.run_id) / "papers" / "01.md"
+    assert paper_file.exists()
+
+
+async def test_searcher_skips_enrichment_when_no_papers(
+    monkeypatch: pytest.MonkeyPatch,
+    problem: ProblemInput,
+    analysis: AnalyzerOutput,
+    tmp_path: Path,
+) -> None:
+    """No papers → no enrichment call → empty paper_fulltext_paths."""
+    async def fake_batch_empty(queries, max_per_query=5, concurrency=2):  # noqa: ANN001
+        return {q: [] for q in queries}
+
+    async def fake_empty(queries, **_):  # noqa: ANN001, ANN003
+        return {q: [] for q in queries}
+
+    enrich_called = False
+
+    async def fake_enrich(*_a, **_kw):  # noqa: ANN001, ANN003
+        nonlocal enrich_called
+        enrich_called = True
+        return []
+
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_arxiv", fake_batch_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_openalex", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_crossref", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_search_web", fake_empty
+    )
+    monkeypatch.setattr(
+        "agent_worker.agents.searcher.batch_enrich_papers", fake_enrich
+    )
+
+    class _NoopGateway:
+        async def stream_completion(self, **_: object) -> AsyncIterator[str]:
+            raise AssertionError("LLM must not be called")
+            yield ""
+
+        async def close(self) -> None:
+            pass
+
+    emitter = _FakeEmitter()
+    agent = SearcherAgent(_NoopGateway(), emitter, runs_dir=tmp_path)  # type: ignore[arg-type]
+    out = await agent.run_for(problem, analysis)
+
+    assert out.papers == []
+    assert out.paper_fulltext_paths == []
+    assert enrich_called is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_searcher_agent.py::test_searcher_populates_paper_fulltext_paths tests/test_searcher_agent.py::test_searcher_skips_enrichment_when_no_papers -v`
+Expected: FAIL — `runs_dir` constructor kwarg unknown OR `batch_enrich_papers` import path missing OR `paper_fulltext_paths` not populated.
+
+- [ ] **Step 3: Update SearcherAgent constructor to accept `runs_dir`**
+
+Edit `apps/agent-worker/src/agent_worker/agents/searcher.py`. Find the `__init__` of `SearcherAgent` and add `runs_dir: Path | None = None` parameter. Store on `self._runs_dir`. Add `from pathlib import Path` to imports if not present.
+
+```python
+class SearcherAgent:
+    def __init__(
+        self,
+        gateway: GatewayClient,
+        emitter: EventEmitter,
+        prompt_version: str = "v1",
+        run_effort: ReasoningEffort = "medium",
+        long_context: bool = False,
+        model_override: str | None = None,
+        runs_dir: Path | None = None,
+    ) -> None:
+        # ... existing assignments ...
+        self._runs_dir = runs_dir
+```
+
+Add at the top of the file:
+```python
+from agent_worker.tools.pdf import batch_enrich_papers
+```
+
+- [ ] **Step 4: Wire Phase 3.5 + 3.6 into `run_for`**
+
+In `run_for`, locate the line where `findings = await self._synthesize(...)` is assigned (or where the empty-skip branch sets `findings = SearchFindings(queries=queries)`). After that block — but before the existing `agent.output` emit — add:
+
+```python
+# Phase 3.5: enrich top papers with full text for Writer context.
+# Skip when runs_dir wasn't injected (test fixtures) or there are no
+# papers to enrich.
+if findings.papers and self._runs_dir is not None:
+    runs_papers_dir = (
+        self._runs_dir / str(self.emitter.run_id) / "papers"
+    )
+    paths = await batch_enrich_papers(
+        findings.papers,
+        runs_papers_dir=runs_papers_dir,
+        top_n=3,
+        mailto=settings.polite_mailto or None,
+    )
+    # Phase 3.6: compact oversized files in place.
+    paths = await self._compact_oversized_papers(runs_papers_dir, paths)
+    findings = findings.model_copy(update={"paper_fulltext_paths": paths})
+    await self.emitter.emit(
+        "log",
+        {
+            "level": "info",
+            "message": (
+                f"enriched {len(paths)} of top 3 papers with full text"
+            ),
+        },
+        agent=self.AGENT_NAME,
+    )
+```
+
+- [ ] **Step 5: Wire `runs_dir` into pipeline.py at construction**
+
+Edit `apps/agent-worker/src/agent_worker/pipeline.py`. Find the line constructing `SearcherAgent(...)` inside `run_pipeline`. Add `runs_dir=runs_dir` to its kwargs. There is already a `runs_dir = Path(settings.runs_dir).resolve()` line earlier in the function; reuse it.
+
+```python
+searcher = SearcherAgent(gateway, emitter, runs_dir=runs_dir, **kwargs)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_searcher_agent.py --tb=short -q`
+Expected: All existing tests pass + 2 new ones (8 → 10 in this file).
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_searcher_orchestration.py --tb=short -q`
+Expected: All 12 orchestration tests still pass.
+
+Run the full agent-worker suite:
+
+```bash
+cd apps/agent-worker && uv run pytest --tb=short -q
+```
+
+Expected: Around 312 passed (293 from Task 1 + 10 PDF tool + 4 compaction + 5 searcher extensions; some are double-counted). Investigate any new failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/agent-worker/src/agent_worker/agents/searcher.py apps/agent-worker/src/agent_worker/pipeline.py apps/agent-worker/tests/test_searcher_agent.py
+git commit -m "feat(searcher): wire PDF enrichment + compaction into pipeline
+
+Phase 3.5: batch_enrich_papers persists top 3 cited papers' full text to
+runs/<id>/papers/NN.md. Phase 3.6: _compact_oversized_papers compresses
+files > 24k chars in place. SearchFindings.paper_fulltext_paths carries
+the persisted paths to Writer. SearcherAgent constructor gains runs_dir
+(None in test fixtures => enrichment skipped, existing tests unaffected)."
+```
+
+---
+
+## Task 7: Writer prompt template + integration
+
+**Files:**
+- Modify: `apps/agent-worker/src/agent_worker/prompts/writer/v1.toml` (add `paper_fulltexts` variable)
+- Modify: `apps/agent-worker/src/agent_worker/agents/writer.py` (load paths, soft truncate, render)
+- Modify: `apps/agent-worker/tests/test_writer_agent.py` (extend; if no such file, create)
+
+- [ ] **Step 1: Decide test file location**
+
+Run: `ls apps/agent-worker/tests/ | grep writer`
+
+If `test_writer_agent.py` exists, you'll extend it. If not, you'll create a minimal one. The exact file name surfaces from `ls`; use it. Pick a writer test that already covers the `run_for` happy path and extend or mirror its style.
+
+- [ ] **Step 2: Write the failing test**
+
+Append (or create) a test that verifies the prompt body contains the full-text block when `paper_fulltext_paths` is non-empty. Example template — adapt the imports and helper fakes to whatever the existing test file uses:
+
+```python
+from pathlib import Path
+
+from agent_worker.agents import WriterAgent
+from mm_contracts import SearchFindings
+
+
+async def test_writer_includes_paper_fulltexts_when_paths_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    # ... existing fixtures (problem, analysis, model_spec, coder_output) ...
+) -> None:
+    run_dir = tmp_path / "run"
+    papers_dir = run_dir / "papers"
+    papers_dir.mkdir(parents=True)
+    (papers_dir / "01.md").write_text("paper 1 full text", encoding="utf-8")
+    (papers_dir / "02.md").write_text("paper 2 full text", encoding="utf-8")
+
+    captured_messages: list[dict] = []
+
+    class _CapturingGateway:
+        async def stream_completion(self, **kwargs):  # noqa: ANN003
+            captured_messages.extend(kwargs.get("messages") or [])
+            # Yield a minimally valid PaperDraft JSON so the test doesn't crash.
+            yield (
+                '{"title":"T","abstract":"a","sections":'
+                '[{"title":"Intro","body_markdown":"x"}],'
+                '"references":[],"figure_refs":[]}'
+            )
+
+        async def close(self) -> None:
+            pass
+
+    emitter = _FakeEmitter()
+    findings = SearchFindings(
+        queries=["q"],
+        papers=[],  # Writer doesn't need filled papers for this assertion
+        key_findings=[],
+        datasets_mentioned=[],
+        paper_fulltext_paths=["papers/01.md", "papers/02.md"],
+    )
+    agent = WriterAgent(_CapturingGateway(), emitter, run_dir=run_dir)  # type: ignore[arg-type]
+    await agent.run_for(problem, analysis, model_spec, coder_output, findings)
+
+    body = "\n".join(m.get("content", "") for m in captured_messages)
+    assert "paper 1 full text" in body
+    assert "paper 2 full text" in body
+```
+
+The exact WriterAgent constructor signature may differ — inspect `apps/agent-worker/src/agent_worker/agents/writer.py` to find how `run_dir` is currently surfaced (it may already be a constructor arg or it may need to be added).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_writer_agent.py -v -k paper_fulltexts`
+Expected: FAIL — either `run_dir` kwarg unknown, or assert fails because Writer prompt does not include the new block.
+
+- [ ] **Step 4: Add `paper_fulltexts` variable to the Writer prompt**
+
+Edit `apps/agent-worker/src/agent_worker/prompts/writer/v1.toml`. Locate the user template (it's the section under `[user_template]` with `text = """..."""`). Just BEFORE the closing `"""`, insert a section:
+
+```
+## Supplementary full text for citation grounding
+
+The following are the full text (or compacted summaries) of the top
+papers retrieved by the Searcher. Use them to ground specific
+citations — refer to equations, methodology details, and numerical
+results verbatim where appropriate. When this block is empty, fall
+back to title+abstract citation from the Sources list.
+
+{{ paper_fulltexts }}
+```
+
+Keep the existing template variables (`problem_text`, `competition_type`, `analysis_json`, etc.) intact. Add `paper_fulltexts` as a new key wherever the template expects its render-arg map.
+
+- [ ] **Step 5: Load paths and render in WriterAgent**
+
+Edit `apps/agent-worker/src/agent_worker/agents/writer.py`. Add module-level constant near the top:
+
+```python
+WRITER_SOFT_TRUNCATE_CHARS = 32_000  # per-paper Writer-side budget
+```
+
+In the `run_for` method, just before constructing `messages = [...]` for the LLM call, build the supplementary block:
+
+```python
+fulltexts_block = ""
+if findings.paper_fulltext_paths and self._run_dir is not None:
+    blocks: list[str] = []
+    for idx, rel_path in enumerate(findings.paper_fulltext_paths, start=1):
+        abs_path = self._run_dir / rel_path
+        if not abs_path.exists():
+            continue
+        try:
+            text = abs_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if len(text) > WRITER_SOFT_TRUNCATE_CHARS:
+            text = (
+                text[:WRITER_SOFT_TRUNCATE_CHARS].rsplit("\n\n", 1)[0]
+                + "\n\n[...truncated]"
+            )
+        blocks.append(
+            f"### Paper {idx} (cite as findings.papers[{idx - 1}])\n\n{text}"
+        )
+    fulltexts_block = "\n\n".join(blocks)
+```
+
+Pass `paper_fulltexts=fulltexts_block` into `self.prompt.render_user(...)` alongside the existing template variables.
+
+If WriterAgent does not yet take `run_dir`, add it:
+
+```python
+class WriterAgent:
+    def __init__(
+        self,
+        gateway: GatewayClient,
+        emitter: EventEmitter,
+        # ... existing args ...
+        run_dir: Path | None = None,
+    ) -> None:
+        # ... existing assignments ...
+        self._run_dir = run_dir
+```
+
+- [ ] **Step 6: Wire `run_dir` into pipeline.py for WriterAgent**
+
+Edit `apps/agent-worker/src/agent_worker/pipeline.py`. Find the `WriterAgent(...)` construction. The pipeline already has `run_dir = runs_dir / str(run_id)` available (used for paper.md / paper.meta.json writes). Pass it:
+
+```python
+writer = WriterAgent(gateway, emitter, run_dir=run_dir, **kwargs)
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd apps/agent-worker && uv run pytest tests/test_writer_agent.py --tb=short -q`
+Expected: All existing writer tests pass + new one passes.
+
+Then the full suite:
+
+```bash
+cd apps/agent-worker && uv run pytest --tb=short -q
+```
+
+Expected: All pass.
+
+Run lint:
+
+```bash
+cd /Users/cornna/project/math_agent && uvx ruff check .
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/agent-worker/src/agent_worker/agents/writer.py apps/agent-worker/src/agent_worker/pipeline.py apps/agent-worker/src/agent_worker/prompts/writer/v1.toml apps/agent-worker/tests/test_writer_agent.py
+git commit -m "feat(writer): inline paper full text from SearchFindings.paper_fulltext_paths
+
+Writer reads runs/<id>/papers/NN.md (raw or compacted) and inlines into
+prompt with 32k-char soft truncate at paragraph boundary as the last
+safety net. New paper_fulltexts template variable in writer/v1.toml.
+Falls back cleanly to abstract-only citation when paths are empty."
+```
+
+---
+
+## Task 8: End-to-end local verification
+
+**Files:** None (manual verification step)
+
+- [ ] **Step 1: Push the branch + open PR**
+
+```bash
+git push -u origin <current-branch>
+gh pr create --base main --title "feat(searcher): PDF enrichment with compaction (top 3 papers)" --body "Implements docs/superpowers/specs/2026-05-11-searcher-pdf-enrichment-design.md. Top 3 cited papers in SearchFindings get their full text fetched (arXiv direct + Unpaywall for DOIs), extracted via pdfplumber/trafilatura, compacted via an inline LLM call when > 24k chars, and inlined into Writer's prompt for grounded citations."
+```
+
+- [ ] **Step 2: Wait for CI**
+
+```bash
+gh pr checks <PR-NUM> --watch
+```
+
+Expected: All checks pass (python ruff+pytest, rust, web typecheck, contracts-drift). If anything fails, fix root cause and push.
+
+- [ ] **Step 3: Squash merge**
+
+After CI green and any review comments addressed:
+
+```bash
+gh pr merge <PR-NUM> --squash --delete-branch
+```
+
+- [ ] **Step 4: Optional — rebuild local stack and verify on a real run**
+
+If you want to verify end-to-end before tagging a release:
+
+```bash
+docker compose -f docker-compose.prod.yml build worker
+docker compose -f docker-compose.prod.yml up -d
+curl -sS -X POST http://127.0.0.1:8080/runs \
+  -H "Authorization: Bearer dev-local-insecure-token" \
+  -H "Content-Type: application/json" \
+  -d '{"problem_text": "请用排队论分析一个有 2 个服务台的银行网点高峰期等候时间，给出 M/M/c 模型与建议", "competition_type": "cumcm", "reasoning_effort": "low", "model_override": "gpt-5.4"}'
+```
+
+Then wait for completion and inspect `runs/<id>/papers/` to confirm 1-3 `.md` files were written.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task that implements |
+|---|---|
+| `tools/pdf.py::find_pdf_url` | Task 2 |
+| `tools/pdf.py::fetch_and_extract` | Task 3 |
+| `tools/pdf.py::batch_enrich_papers` | Task 4 |
+| `SearchFindings.paper_fulltext_paths` contract | Task 1 |
+| trafilatura + pdfplumber deps | Task 1 |
+| TS mirror | Task 1 |
+| SearcherAgent constructor `runs_dir` | Task 6 |
+| SearcherAgent.run_for Phase 3.5 wiring | Task 6 |
+| SearcherAgent compaction method + constants | Task 5 |
+| Compaction prompt (preserve language) | Task 5 |
+| WriterAgent prompt `paper_fulltexts` | Task 7 |
+| WriterAgent file loading + 32k soft truncate | Task 7 |
+| pipeline.py SearcherAgent runs_dir injection | Task 6 |
+| pipeline.py WriterAgent run_dir injection | Task 7 |
+| Failure mode coverage in tests | Tasks 2, 3, 4, 5, 6 (each test class covers its own failure modes) |
+| End-to-end local verification | Task 8 |
+
+All spec sections accounted for.
+
+**Placeholder scan:** No "TBD", "TODO", "fill in", or "appropriate error handling". Every code step contains the full code. Test file paths are exact. The one acknowledged unknown — whether `WriterAgent.__init__` already takes `run_dir` — is paired with explicit "inspect first, then add only if missing" guidance.
+
+**Type consistency:**
+- `paper_fulltext_paths: list[str]` (Pydantic, max_length=3) consistent across Task 1, 6, 7
+- `find_pdf_url(paper, *, mailto=None) -> str | None` consistent in Task 2, 4
+- `fetch_and_extract(url, *, timeout=15, max_bytes=20_000_000) -> tuple[str | None, Literal[...]]` consistent in Task 3, 4
+- `batch_enrich_papers(papers, runs_papers_dir, top_n=3, *, mailto=None, concurrency=3) -> list[str]` consistent in Task 4, 6
+- `_compact_oversized_papers(self, runs_papers_dir, paths) -> list[str]` consistent in Task 5, 6
+- `_compact_one(self, raw_text) -> str | None` consistent in Task 5
+- `COMPACT_THRESHOLD_CHARS = 24_000`, `COMPACT_TARGET_CHARS = 24_000`, `COMPACT_MIN_OUTPUT_CHARS = 1_000`, `WRITER_SOFT_TRUNCATE_CHARS = 32_000` consistent throughout

--- a/docs/superpowers/specs/2026-05-11-searcher-pdf-enrichment-design.md
+++ b/docs/superpowers/specs/2026-05-11-searcher-pdf-enrichment-design.md
@@ -1,0 +1,362 @@
+# Searcher PDF Enrichment
+
+**Date:** 2026-05-11
+**Status:** Approved (brainstorming)
+**Author:** brainstorming session with project owner
+
+## Problem
+
+Today the Searcher emits a `SearchFindings` whose `papers[]` carries only
+title + abstract per paper (the metadata available from arXiv / OpenAlex /
+Crossref retrieval). Downstream the Writer cites these papers but cannot
+ground specific claims in section-level content — every reference reads
+"according to [12]" without distinguishing whether [12] supports a
+specific formula, an experimental setup detail, or a numerical result.
+
+v0.5.2 end-to-end verification on a Chinese M/M/c bank-queueing problem
+illustrated this gap: 8 retained papers (Indonesia/Bangladesh/Nigeria bank
+case studies, classic Erlang C work) — Writer could only reference them
+generically because their full text was never fetched.
+
+## Goal
+
+Enrich `SearchFindings` with full-text content for the top 3 papers so the
+Writer can cite specific equations, methodology details, and experimental
+numbers. Fail gracefully when full text is unavailable.
+
+## Non-goals
+
+- Tavily / open-webSearch web hits are **not** treated as papers — no PDF
+  extraction for non-academic URLs.
+- Modeler does **not** consume full text — stage stays focused on HMML and
+  the Analyzer output.
+- No cross-run FTS5 cache (separate optimization candidate, out of scope).
+- No paywalled content scraping. Unpaywall-only OA discovery for DOIs.
+
+## Architecture
+
+```
+SearchFindings produced (existing path)
+        │
+        ▼
+[NEW] Phase 3.5: batch_enrich_papers(findings.papers[:3])
+        │
+        │  per paper (concurrency=3):
+        │    ├─ find_pdf_url()
+        │    │    ├─ arXiv ID present → https://arxiv.org/pdf/<id>.pdf
+        │    │    └─ DOI present       → Unpaywall API → best_oa_location.url_for_pdf
+        │    │                          (None when no OA version exists)
+        │    └─ fetch_and_extract()
+        │         ├─ Content-Type contains "pdf"  → pdfplumber
+        │         └─ Content-Type contains "html" → trafilatura
+        ▼
+runs/<run_id>/papers/01.md, 02.md, 03.md  (raw extracted text;
+                                            failed papers are not written)
+        │
+        ▼
+[NEW] Phase 3.6: _compact_oversized_papers()
+        │
+        │  per saved file:
+        │    └─ if len(text) > 24000 chars:
+        │         └─ one LLM call → compacted markdown → overwrite file
+        ▼
+SearchFindings.paper_fulltext_paths = ["papers/01.md", "papers/02.md", ...]
+        │
+        ▼
+Writer reads paths, inlines content into prompt with 32k-char paragraph-
+  boundary soft truncation as last-resort safety net
+```
+
+## Why these choices
+
+| Decision | Rationale |
+|---|---|
+| Top 3 papers | Caps Writer context bloat (~45-90k tokens worst case) while keeping ≥3 citable sources for an MCM-grade paper |
+| Writer-only consumption | Modeler/Coder paths stay focused on their own concerns; one consumer = simpler debugging |
+| arXiv direct + Unpaywall for DOIs | arXiv is always-open; Unpaywall covers the long tail of OA versions for Crossref/OpenAlex sources without paywall scraping |
+| Paths in contract, content on disk | SearchFindings stays small; historical runs can re-read; matches existing `notebook_path` / `paper_path` convention |
+| Compaction over truncation | Truncation can cut the methodology section that has the equation we wanted to cite; compaction preserves citable density |
+| Compaction as Searcher method, not new Agent | Same pattern as `_refine_queries` — internal LLM utility, not a Critic-evaluable stage. Avoids stage.start/done noise and per-paper Critic budget. |
+
+## Interfaces
+
+### New tool: `apps/agent-worker/src/agent_worker/tools/pdf.py`
+
+```python
+class PdfFetchResult(BaseModel):
+    paper_url: str
+    pdf_url: str | None
+    text: str | None
+    bytes_fetched: int = 0
+    parser: Literal["trafilatura", "pdfplumber", "none"] = "none"
+    error: str | None = None
+
+
+async def find_pdf_url(
+    paper: Paper, *, mailto: str | None = None
+) -> str | None:
+    """Resolve a Paper to a fetchable PDF URL.
+
+    Resolution order:
+      1. arXiv ID present → derive `https://arxiv.org/pdf/<id>.pdf`
+      2. DOI present → Unpaywall API
+         (https://api.unpaywall.org/v2/<doi>?email=<mailto>) →
+         `best_oa_location.url_for_pdf`
+      3. Otherwise None
+    """
+
+
+async def fetch_and_extract(
+    url: str, *, timeout: float = 15.0, max_bytes: int = 20_000_000
+) -> tuple[str | None, str]:
+    """Fetch URL and extract plain text.
+
+    Returns (text, parser_name). text=None signals failure. 20MB ceiling
+    rejects oversized PDFs to bound memory.
+    """
+
+
+async def batch_enrich_papers(
+    papers: list[Paper],
+    runs_papers_dir: Path,
+    top_n: int = 3,
+    *,
+    mailto: str | None = None,
+    concurrency: int = 3,
+) -> list[str]:
+    """Enrich the top N papers concurrently and persist successes.
+
+    Returns a list of relative paths under runs/<run_id>/, e.g.
+    ['papers/01.md', 'papers/03.md']. Failed papers do not appear.
+    Index in the filename matches the original `papers[]` index.
+    """
+```
+
+### Contract change
+
+`packages/py-contracts/src/mm_contracts/agent_io.py`:
+
+```python
+class SearchFindings(BaseModel):
+    # ...existing fields unchanged
+    paper_fulltext_paths: list[str] = Field(
+        default_factory=list, max_length=3
+    )
+```
+
+`packages/ts-contracts/src/index.ts`:
+
+```ts
+export interface SearchFindings {
+  // ...existing
+  paper_fulltext_paths?: string[];
+}
+```
+
+Backward compatible: default empty list, optional in TS.
+
+### Searcher integration
+
+`apps/agent-worker/src/agent_worker/agents/searcher.py` constructor gains
+`runs_dir: Path` (pipeline.py already has `settings.runs_dir` at hand).
+
+`SearcherAgent.run_for()` after `findings = await self._synthesize(...)`:
+
+```python
+# Phase 3.5: enrich top papers with full text for Writer.
+if findings.papers:
+    runs_papers_dir = self._runs_dir / str(self.emitter.run_id) / "papers"
+    runs_papers_dir.mkdir(parents=True, exist_ok=True)
+    paths = await batch_enrich_papers(
+        findings.papers,
+        runs_papers_dir=runs_papers_dir,
+        top_n=3,
+        mailto=settings.polite_mailto or None,
+    )
+    # Phase 3.6: compact oversized papers in place.
+    paths = await self._compact_oversized_papers(runs_papers_dir, paths)
+    findings = findings.model_copy(update={"paper_fulltext_paths": paths})
+    await self.emitter.emit(
+        "log",
+        {
+            "level": "info",
+            "message": f"enriched {len(paths)}/3 top papers with PDF text",
+        },
+        agent=self.AGENT_NAME,
+    )
+```
+
+### Compaction
+
+Constants on SearcherAgent:
+
+```python
+COMPACT_THRESHOLD_CHARS = 24_000   # ~6k tokens; raw files above this compact
+COMPACT_TARGET_CHARS    = 24_000   # output ceiling
+COMPACT_MIN_OUTPUT_CHARS = 1_000   # below this, treat compaction as failed
+WRITER_SOFT_TRUNCATE_CHARS = 32_000  # Writer-side last-resort safety
+```
+
+Method:
+
+```python
+async def _compact_oversized_papers(
+    self, runs_papers_dir: Path, paths: list[str]
+) -> list[str]:
+    """Compact any file whose raw text > THRESHOLD. Overwrite in place.
+
+    On LLM failure or short output, leaves the raw file untouched —
+    the Writer side has its own char-budget soft truncation.
+    """
+```
+
+Compaction prompt (inline, no TOML):
+
+```
+SYSTEM: You compress an academic paper into a high-density summary for
+downstream LLM citation. Preserve verbatim:
+- Mathematical formulas (LaTeX or plain)
+- Parameter definitions and units
+- Methodology steps in order
+- Experimental setup (sample size, data source, conditions)
+- Numerical results with confidence intervals or error bars
+- Key claims that Writer might cite
+
+Drop entirely:
+- Boilerplate (acknowledgments, ethics, conflicts of interest)
+- Related-work prose (the Writer has SearchFindings.papers for that)
+- Narrative filler ("In this paper we propose...")
+- Reference list
+- Repeated information
+
+Preserve the source language. If the input is Chinese, output Chinese.
+If English, output English. Do not translate.
+
+Output: dense markdown, ≤24000 characters. Keep section headings
+(## Methods, ## Results, etc.) so Writer can grep for them.
+Respond with the compacted markdown only.
+
+USER: <raw extracted text>
+```
+
+### Writer integration
+
+`apps/agent-worker/src/agent_worker/agents/writer.py` reads paths before
+LLM call, applies Writer-side soft truncation, and injects via prompt
+template variable `{{ paper_fulltexts }}`:
+
+```python
+fulltexts_block = ""
+if findings.paper_fulltext_paths:
+    blocks = []
+    for idx, rel_path in enumerate(findings.paper_fulltext_paths, start=1):
+        abs_path = run_dir / rel_path
+        if not abs_path.exists():
+            continue
+        text = abs_path.read_text(encoding="utf-8")
+        if len(text) > WRITER_SOFT_TRUNCATE_CHARS:
+            text = (
+                text[:WRITER_SOFT_TRUNCATE_CHARS].rsplit("\n\n", 1)[0]
+                + "\n\n[...truncated]"
+            )
+        blocks.append(
+            f"### Paper {idx} (cite as findings.papers[{idx-1}])\n\n{text}"
+        )
+    fulltexts_block = "\n\n".join(blocks)
+```
+
+The Writer prompt TOML (`prompts/writer/v1.toml`) gains a `paper_fulltexts`
+template variable in its user template, e.g.:
+
+```
+## Supplementary full text for citation grounding
+
+{{ paper_fulltexts }}
+
+(If empty, fall back to title+abstract citation from findings.papers.)
+```
+
+## Failure modes
+
+| Failure | Behavior | User-visible effect |
+|---|---|---|
+| Paper has neither arxiv_id nor DOI | `find_pdf_url` returns None | That slot empty |
+| Unpaywall returns no OA version for DOI | `find_pdf_url` returns None | That slot empty |
+| PDF download HTTP 5xx / timeout | `fetch_and_extract` returns (None, "none") | That slot empty |
+| PDF size > 20MB | Rejected before parse | That slot empty |
+| pdfplumber raises | Caught, returns (None, "none") | That slot empty |
+| trafilatura returns empty | Treated as failure | That slot empty |
+| All 3 enrichment fail | `paper_fulltext_paths=[]` | Writer falls back to abstract-only (current v0.5.3 behavior) |
+| `SearchFindings.papers` already empty | Skip enrich entirely | No change |
+| Compaction LLM call fails | Keep raw file | Writer-side soft truncate kicks in |
+| Compaction returns < 1000 chars | Treat as failure, keep raw | Same as above |
+| Compaction output still > 32k | Accept it | Writer-side soft truncate kicks in |
+
+## Cost & latency
+
+| Item | Worst-case |
+|---|---|
+| Network fetches | 3 papers × (1 Unpaywall + 1 PDF download) = 6 HTTP requests, ~5s wall time at concurrency=3 |
+| pdfplumber CPU | 3 papers × 5-10s = 15-30s; can run in process pool to parallelize, but 5-10s sync is acceptable |
+| Compaction LLM | Up to 3 × ~$0.005 = ~$0.015 added per run; only triggers when raw > 24k chars |
+| Writer context | +45-90k tokens to Writer's user prompt (3 papers × 15-30k chars each) |
+| Image size | +30-50MB (trafilatura + pdfplumber + transitive deps) |
+
+## Dependencies
+
+`apps/agent-worker/pyproject.toml`:
+
+```toml
+trafilatura = "^1.12"
+pdfplumber = "^0.11"
+```
+
+Both pure Python; no system libraries, no Docker change.
+
+## Tests
+
+| File | New/Modified | Coverage |
+|---|---|---|
+| `tests/test_pdf_tool.py` | new (8 tests) | find_pdf_url (3 paths: arxiv / DOI→OA / DOI→no OA); fetch_and_extract (PDF + HTML + timeout + 20MB ceiling); batch_enrich_papers (concurrency cap + failure isolation) |
+| `tests/test_searcher_compaction.py` | new (4 tests) | Compaction triggers / does not trigger; LLM failure keeps raw; empty response keeps raw |
+| `tests/test_searcher_agent.py` | extended (+2 tests) | `paper_fulltext_paths` is populated; empty list when all enrichment fails |
+| `tests/test_writer_agent.py` | extended (+1 test) | Writer prompt includes full text block when paths non-empty |
+
+All HTTP/PDF use `httpx_mock`. Unpaywall API mocked at fixture level.
+pdfplumber tested against a minimal real-PDF byte stream stored under
+`tests/fixtures/sample-paper.pdf` (5KB).
+
+Target: 290 (current main) + 15 new = ~305 tests passed.
+
+## Implementation order
+
+1. **Dependencies + contract**
+   - `uv add trafilatura pdfplumber` in agent-worker
+   - Extend `Paper` doc / `SearchFindings` with `paper_fulltext_paths`
+   - TS mirror in `packages/ts-contracts/src/index.ts`
+2. **Tool layer**
+   - `tools/pdf.py` with `find_pdf_url`, `fetch_and_extract`, `batch_enrich_papers`
+   - `tests/test_pdf_tool.py`
+3. **Searcher integration**
+   - Inject `runs_dir` constructor arg (also touch pipeline.py construction site)
+   - Add `_compact_oversized_papers` + `_compact_one` methods + constants
+   - Wire Phase 3.5 + 3.6 into `run_for`
+   - `tests/test_searcher_compaction.py` + extensions to `test_searcher_agent.py`
+4. **Writer integration**
+   - Prompt TOML gains `paper_fulltexts` variable
+   - `run_for` loads paths, applies soft truncate, renders
+   - Extension to `tests/test_writer_agent.py`
+5. **End-to-end**
+   - Single PR with all of the above
+   - CI green → local stack rebuild → repeat v0.5.2 Chinese M/M/c run →
+     verify `runs/<id>/papers/01-03.md` exist and Writer cites specific
+     equations / parameter values
+
+## Open questions resolved during brainstorming
+
+- Compaction language: preserve source language (no translation).
+- Compaction is an internal Searcher method, not a separate Agent class
+  (no Critic evaluation, no stage events).
+- Out-of-band file storage with path-in-contract over inline content in
+  contract.
+- One PR over multi-PR (logic is tightly coupled).

--- a/packages/py-contracts/src/mm_contracts/agent_io.py
+++ b/packages/py-contracts/src/mm_contracts/agent_io.py
@@ -447,6 +447,11 @@ class SearchFindings(BaseModel):
     key_findings: list[str] = Field(default_factory=list, max_length=10)
     # short synthesized bullets for Writer
     datasets_mentioned: list[str] = Field(default_factory=list, max_length=10)
+    # NEW: relative paths under runs/<run_id>/ pointing at extracted full-text
+    # markdown for the top 3 cited papers. Empty when enrichment did not run
+    # or every paper's PDF was unreachable / parse failed. The Writer reads
+    # these to ground specific citations; failure to load is non-fatal.
+    paper_fulltext_paths: list[str] = Field(default_factory=list, max_length=3)
 
 
 class RunResult(BaseModel):

--- a/packages/ts-contracts/src/index.ts
+++ b/packages/ts-contracts/src/index.ts
@@ -132,3 +132,26 @@ export interface SearchConfig {
   tavily_depth: "basic" | "advanced";
   fallback_threshold: number;
 }
+
+// Hand-written Searcher agent output contract. Mirrors
+// `packages/py-contracts/src/mm_contracts/agent_io.py::Paper` and
+// `SearchFindings`. Consumed by downstream agents (Writer, etc.) to
+// ground citations and retrieve enriched paper metadata.
+export interface Paper {
+  title: string;
+  authors?: string[];
+  abstract?: string;
+  url: string;
+  arxiv_id?: string | null;
+  doi?: string | null;
+  published?: string | null;
+  relevance_reason?: string | null;
+}
+
+export interface SearchFindings {
+  queries?: string[];
+  papers?: Paper[];
+  key_findings?: string[];
+  datasets_mentioned?: string[];
+  paper_fulltext_paths?: string[];
+}

--- a/packages/ts-contracts/src/index.ts
+++ b/packages/ts-contracts/src/index.ts
@@ -139,19 +139,19 @@ export interface SearchConfig {
 // ground citations and retrieve enriched paper metadata.
 export interface Paper {
   title: string;
-  authors?: string[];
-  abstract?: string;
+  authors: string[];
+  abstract: string;
   url: string;
-  arxiv_id?: string | null;
-  doi?: string | null;
-  published?: string | null;
-  relevance_reason?: string | null;
+  arxiv_id: string | null;
+  doi: string | null;
+  published: string | null;
+  relevance_reason: string | null;
 }
 
 export interface SearchFindings {
-  queries?: string[];
-  papers?: Paper[];
-  key_findings?: string[];
-  datasets_mentioned?: string[];
-  paper_fulltext_paths?: string[];
+  queries: string[];
+  papers: Paper[];
+  key_findings: string[];
+  datasets_mentioned: string[];
+  paper_fulltext_paths: string[];
 }

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,7 @@ dependencies = [
     { name = "numpy" },
     { name = "orjson" },
     { name = "pandas" },
+    { name = "pdfplumber" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rank-bm25" },
@@ -40,6 +41,7 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "structlog" },
+    { name = "trafilatura" },
 ]
 
 [package.dev-dependencies]
@@ -63,6 +65,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0" },
     { name = "orjson", specifier = ">=3.10" },
     { name = "pandas", specifier = ">=2.2" },
+    { name = "pdfplumber", specifier = ">=0.11" },
     { name = "pydantic", specifier = ">=2.8" },
     { name = "pydantic-settings", specifier = ">=2.4" },
     { name = "rank-bm25", specifier = ">=0.2.2" },
@@ -70,6 +73,7 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.5" },
     { name = "scipy", specifier = ">=1.13" },
     { name = "structlog", specifier = ">=24.4" },
+    { name = "trafilatura", specifier = ">=1.12" },
 ]
 
 [package.metadata.requires-dev]
@@ -144,6 +148,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
 ]
 
 [[package]]
@@ -301,6 +314,20 @@ wheels = [
 ]
 
 [[package]]
+name = "courlan"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "tld" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/54/6d6ceeff4bed42e7a10d6064d35ee43a810e7b3e8beb4abeae8cff4713ae/courlan-1.3.2.tar.gz", hash = "sha256:0b66f4db3a9c39a6e22dd247c72cfaa57d68ea660e94bb2c84ec7db8712af190", size = 206382, upload-time = "2024-10-29T16:40:20.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/ca/6a667ccbe649856dcd3458bab80b016681b274399d6211187c6ab969fc50/courlan-1.3.2-py3-none-any.whl", hash = "sha256:d0dab52cf5b5b1000ee2839fbc2837e93b2514d3cb5bb61ae158a55b7a04c6be", size = 33848, upload-time = "2024-10-29T16:40:18.325Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -352,6 +379,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/2d/a0ccdb78788064fa0dc901b8524e50615c42be1d78b78d646d0b28d09180/dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4", size = 321512, upload-time = "2026-03-26T09:56:10.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/0b/3c3bb7cbe757279e693a0be6049048012f794d01f81099609ecd53b899f0/dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378", size = 300379, upload-time = "2026-03-26T09:56:08.409Z" },
 ]
 
 [[package]]
@@ -502,6 +544,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
     { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
     { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
+name = "htmldate"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "dateparser" },
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/10/ead9dabc999f353c3aa5d0dc0835b1e355215a5ecb489a7f4ef2ddad5e33/htmldate-1.9.4.tar.gz", hash = "sha256:1129063e02dd0354b74264de71e950c0c3fcee191178321418ccad2074cc8ed0", size = 44690, upload-time = "2025-11-04T17:46:44.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/bd/adfcdaaad5805c0c5156aeefd64c1e868c05e9c1cd6fd21751f168cd88c7/htmldate-1.9.4-py3-none-any.whl", hash = "sha256:1b94bcc4e08232a5b692159903acf95548b6a7492dddca5bb123d89d6325921c", size = 31558, upload-time = "2025-11-04T17:46:43.258Z" },
 ]
 
 [[package]]
@@ -747,6 +805,18 @@ wheels = [
 ]
 
 [[package]]
+name = "justext"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml", extra = ["html-clean"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f3/45890c1b314f0d04e19c1c83d534e611513150939a7cf039664d9ab1e649/justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05", size = 828521, upload-time = "2025-02-25T20:21:49.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ac/52f4e86d1924a7fc05af3aeb34488570eccc39b4af90530dd6acecdf16b5/justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7", size = 837940, upload-time = "2025-02-25T20:21:44.179Z" },
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -804,6 +874,71 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/5d/3bccad330292946f97962df9d5f2d3ae129cce6e212732a781e856b91e07/lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9", size = 8526232, upload-time = "2026-04-18T04:27:40.389Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/adc8826570a112f83bb4ddb3a2ab510bbc2ccd62c1b9fe1f34fae2d90b57/lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50", size = 4595448, upload-time = "2026-04-18T04:27:44.208Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/5a9ec07cbe1d2334a6465f863b949a520d2699a755738986dcd3b6b89e3f/lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5", size = 4923771, upload-time = "2026-04-18T04:32:17.402Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/23/851cfa33b6b38adb628e45ad51fb27105fa34b2b3ba9d1d4aa7a9428dfe0/lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e", size = 5068101, upload-time = "2026-04-18T04:32:21.437Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/38/41bf99c2023c6b79916ba057d83e9db21d642f473cac210201222882d38b/lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512", size = 5002573, upload-time = "2026-04-18T04:32:25.373Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/053aa10bdc39747e1e923ce2d45413075e84f70a136045bb09e5eaca41d3/lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c", size = 5202816, upload-time = "2026-04-18T04:32:29.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/bc710fad8bf04b93baee752c192eaa2210cd3a84f969d0be7830fea55802/lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5", size = 5329999, upload-time = "2026-04-18T04:32:34.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/bf035dedbdf7fab49411aa52e4236f3445e98d38647d85419e6c0d2806b9/lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289", size = 4659643, upload-time = "2026-04-18T04:32:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/22be31f33727a5e4c7b01b0a874503026e50329b259d3587e0b923cf964b/lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a", size = 5265963, upload-time = "2026-04-18T04:32:41.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2b/d44d0e5c79226017f4ab8c87a802ebe4f89f97e6585a8e4166dffcdd7b6e/lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3", size = 5045444, upload-time = "2026-04-18T04:32:44.512Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c3/3f034fec1594c331a6dbf9491238fdcc9d66f68cc529e109ec75b97197e1/lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9", size = 4712703, upload-time = "2026-04-18T04:32:47.16Z" },
+    { url = "https://files.pythonhosted.org/packages/12/16/0b83fccc158218aca75a7aa33e97441df737950734246b9fffa39301603d/lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11", size = 5252745, upload-time = "2026-04-18T04:32:50.427Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ee/12e6c1b39a77666c02eaa77f94a870aaf63c4ac3a497b2d52319448b01c6/lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4", size = 5226822, upload-time = "2026-04-18T04:32:53.437Z" },
+    { url = "https://files.pythonhosted.org/packages/34/20/c7852904858b4723af01d2fc14b5d38ff57cb92f01934a127ebd9a9e51aa/lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3", size = 3594026, upload-time = "2026-04-18T04:27:31.903Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/d60c732b56da5085175c07c74b2df4e6d181b0c9a61e1691474f06ef4b39/lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7", size = 4025114, upload-time = "2026-04-18T04:27:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/df/c84dcc175fd690823436d15b41cb920cd5ba5e14cd8bfb00949d5903b320/lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39", size = 3667742, upload-time = "2026-04-18T04:27:38.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/88/55143966481409b1740a3ac669e611055f49efd68087a5ce41582325db3e/lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842", size = 3930134, upload-time = "2026-04-18T04:32:35.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/97/28b985c2983938d3cb696dd5501423afb90a8c3e869ef5d3c62569282c0f/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c", size = 4210749, upload-time = "2026-04-18T04:36:03.626Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/dfab2b7d58214921935ccea7ce9b3df9b7d46f305d12f0f532ac7cf6b804/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de", size = 4318463, upload-time = "2026-04-18T04:36:06.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a2/4ac7eb32a4d997dd352c32c32399aae27b3f268d440e6f9cfa405b575d2f/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635", size = 4251124, upload-time = "2026-04-18T04:36:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/d6abd850bb4822f9b720cfe36b547a558e694881010ff7d012191e8769c6/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037", size = 4401758, upload-time = "2026-04-18T04:36:11.803Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/3ee09a5b60cb44c4f2fbc1c9015cfd6ff5afc08f991cab295d3024dcbf2d/lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace", size = 3508860, upload-time = "2026-04-18T04:32:48.619Z" },
+]
+
+[package.optional-dependencies]
+html-clean = [
+    { name = "lxml-html-clean" },
+]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/a4/5c62acfacd69ff4f5db395100f5cfb9b54e7ac8c69a235e4e939fd13f021/lxml_html_clean-0.4.4.tar.gz", hash = "sha256:58f39a9d632711202ed1d6d0b9b47a904e306c85de5761543b90e3e3f736acfb", size = 23899, upload-time = "2026-02-27T09:35:52.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/76/7ffc1d3005cf7749123bc47cb3ea343cd97b0ac2211bab40f57283577d0e/lxml_html_clean-0.4.4-py3-none-any.whl", hash = "sha256:ce2ef506614ecb85ee1c5fe0a2aa45b06a19514ec7949e9c8f34f06925cfabcb", size = 14565, upload-time = "2026-02-27T09:35:51.86Z" },
 ]
 
 [[package]]
@@ -1131,6 +1266,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pdfminer-six"
+version = "20251230"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/9a/d79d8fa6d47a0338846bb558b39b9963b8eb2dfedec61867c138c1b17eeb/pdfminer_six-20251230.tar.gz", hash = "sha256:e8f68a14c57e00c2d7276d26519ea64be1b48f91db1cdc776faa80528ca06c1e", size = 8511285, upload-time = "2025-12-30T15:49:13.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/d7/b288ea32deb752a09aab73c75e1e7572ab2a2b56c3124a5d1eb24c62ceb3/pdfminer_six-20251230-py3-none-any.whl", hash = "sha256:9ff2e3466a7dfc6de6fd779478850b6b7c2d9e9405aa2a5869376a822771f485", size = 6591909, upload-time = "2025-12-30T15:49:10.76Z" },
+]
+
+[[package]]
+name = "pdfplumber"
+version = "0.11.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pdfminer-six" },
+    { name = "pillow" },
+    { name = "pypdfium2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload-time = "2026-01-05T08:10:29.072Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", size = 60045, upload-time = "2026-01-05T08:10:27.512Z" },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1414,6 +1576,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdfium2"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/3d/dc934d3b606c51c3ecc95b6731d84b7dd7ab8e513a50b0e98a4da6c8a719/pypdfium2-5.8.0.tar.gz", hash = "sha256:049397c647e50f83115ee951c49394dab9e9ba52ebdd5a11ab1109390eb3d34e", size = 271934, upload-time = "2026-05-04T17:39:43.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/8c/6b75b923cb81368fa3ea7c48a0616b839620a3aeff899885bd930449b89e/pypdfium2-5.8.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:f67b6c74b716d9ac725ad1af49ae786ad813ac20823d45606d59f1fc06caa8af", size = 3374554, upload-time = "2026-05-04T17:39:05.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/61/a885c7f36efba89ec98e3d1fe95c83b48c2d6dea321e9194ac6460e7a834/pypdfium2-5.8.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:53e82bf3e6a2da170b1bda83f93b7eec57cb6efe3cacd05cba78823879a85203", size = 2831667, upload-time = "2026-05-04T17:39:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1f/04b5627f6dba312d3e707e5b019c9f24d8b03b5aa366866a9e02ec00f8d4/pypdfium2-5.8.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:085e633dcc89b65ff4035a4787e98ce7ae636836eb39c83dd0db26113d9774bc", size = 3450815, upload-time = "2026-05-04T17:39:09.551Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/77/8e3a2aba2bc4aef5abe1b1306d05b00588dc0bf7f5c850d1adf6164c786b/pypdfium2-5.8.0-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:bc84b7c6efede88fcfb9467f81daf416f26b973a54fc1cf4d3410d622fda6d7a", size = 3634395, upload-time = "2026-05-04T17:39:11.225Z" },
+    { url = "https://files.pythonhosted.org/packages/93/11/6f2b1847d9fa457b3b7251afc2bba2706d104a0c6f01431dfae5d679a839/pypdfium2-5.8.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a63bf09b2e13ba8545c930d243f0650c664a1b51314daa3b5f38df6d1a17b4bc", size = 3617413, upload-time = "2026-05-04T17:39:13.139Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/fd/99ce639de5ca06d21743c740dd988cd209dda623bc763ae10b8a162022e1/pypdfium2-5.8.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:937881c1698456749ed203a58db1895baa5eb7178cdb837ef84867790638da28", size = 3347639, upload-time = "2026-05-04T17:39:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/47/82864cc6e26dd8969d5594c168635acb16458d35cf5fed65d6b2e32abb42/pypdfium2-5.8.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6be9dc2b84a8694ad7e626bab133244e8241014d5ed1930d865a9bdf90df1e24", size = 3746404, upload-time = "2026-05-04T17:39:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/82/58/e41e49bba951f61921bac7289e67fe02af5ac57192d0bbfb5f459dc3691d/pypdfium2-5.8.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7f27bd82891ae302dd02d736b14809661f6d1220ee1e96dbed9b23e2811922a3", size = 4177893, upload-time = "2026-05-04T17:39:18.729Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/15/fa7031010d5cf6853dadb4864680a0bfb7782c5bb6a1a401e0c25c4fca87/pypdfium2-5.8.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26c1089cdbbdc7fe1248f6d17fe3f30214be4f287dd0196b31aaee18a1564240", size = 3665152, upload-time = "2026-05-04T17:39:20.207Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/5a3520a8b0cfa8d7fdc3f03a07ad9d6146c28ffd519330706f64fd8939a8/pypdfium2-5.8.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1c038a9290864aaa4862dd32e591993d82551ca4d152b4e8ce6d43ba37dc04a8", size = 3095365, upload-time = "2026-05-04T17:39:22.054Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d3/845bae4de3cfa36865959046156edb5bf9baea400ccdecdd84fdd911b0f5/pypdfium2-5.8.0-py3-none-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f104bc1a6d8bfc1ff088aa50db13b9729cfdb3722b44975c3c457e9a7b9c7318", size = 2961801, upload-time = "2026-05-04T17:39:23.817Z" },
+    { url = "https://files.pythonhosted.org/packages/99/76/cf54eabee4a172241dfcfe63533bd1e11e2162114a983453a5a40bfec114/pypdfium2-5.8.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:04ca7c57a553facf8d46c6ea8ba6fa557e698670cfa4a58e0e01fdae2f6be87d", size = 4133067, upload-time = "2026-05-04T17:39:25.619Z" },
+    { url = "https://files.pythonhosted.org/packages/77/66/dcf871d19187ca04ea184a99801a6e7e556d8347aa49540fee33cda6dfc5/pypdfium2-5.8.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ad42b9c22477b32dbedcbc8232833f385d92fd0cf92822547b02383cf9a476d7", size = 3749100, upload-time = "2026-05-04T17:39:27.203Z" },
+    { url = "https://files.pythonhosted.org/packages/32/67/0d456c79660959ca45ad307b4d67161d29f9ed4083ee1e8fe8c6925b7c82/pypdfium2-5.8.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:388e3119cf5ca0979b7d5f6d40b7fcd5ab49e17ed4e6de6af89ba116061acfda", size = 4339212, upload-time = "2026-05-04T17:39:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/76/89/e5b0e0f7936be341c91c0f45cd70d693878894ed62aed93a6ee32e9c43c4/pypdfium2-5.8.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:aa05bbfa485ce7916217aa78d856c9f9cd86b08b20846c650392a67975ee72e9", size = 4383943, upload-time = "2026-05-04T17:39:31.287Z" },
+    { url = "https://files.pythonhosted.org/packages/82/21/4502ed255f082f579cd3537c2971cf1a57778d43703a08bcd1a92253189f/pypdfium2-5.8.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:f0813a16bb39d5ebd173ea5484430bb67a89b4b181db0a636c73b64ad063c3ea", size = 3925680, upload-time = "2026-05-04T17:39:33.241Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/4f/2e59723e7a07779439bd885c1b4960079c9710603308888d29ac926ae69a/pypdfium2-5.8.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:a3c78f7d20dd821bec6c072efdb21a1370b9efe10fdeeb68c969e67608e25385", size = 4269560, upload-time = "2026-05-04T17:39:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4e/7b6b1bde3788c8b880d4b8131d95d9d339cebafb3ad9102d82e234bb65be/pypdfium2-5.8.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:86d302e207c138c827b885a72784f7b306d840646ebeae07e8efdbc39321c629", size = 4182434, upload-time = "2026-05-04T17:39:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7b/6ed4782e0d7a5278330598ce8c4b2df7255f4585a0b3d04520fa580d6507/pypdfium2-5.8.0-py3-none-win32.whl", hash = "sha256:3f25fd436920a907291462b41bdc0ab9f8235c3944b4c9c15398da595ffd1fed", size = 3636680, upload-time = "2026-05-04T17:39:38.49Z" },
+    { url = "https://files.pythonhosted.org/packages/19/55/da7223d4202b2461f4f889b0baf10dddec3db7f88e6fd8c52db4a516eecd/pypdfium2-5.8.0-py3-none-win_amd64.whl", hash = "sha256:55592af0bddd2d62bed18e0053c546c9b72041430c5115e54870f7f6163125b0", size = 3754962, upload-time = "2026-05-04T17:39:40.13Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7a/f3dcefe6ee7389aad3ca1488c177e8fbf978206de21c7a99ccf487ea38ab/pypdfium2-5.8.0-py3-none-win_arm64.whl", hash = "sha256:3f17ed97ae8a5a1705301ca93af256a5b02f9009dee4e99c5e175831d46ebd7c", size = 3548362, upload-time = "2026-05-04T17:39:42.304Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1483,6 +1674,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
 ]
 
 [[package]]
@@ -1597,6 +1797,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
 ]
 
 [[package]]
@@ -1823,6 +2063,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tld"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5d/76b4383ac4e5b5e254e50c09807b3e13820bed6d6c11cd540264988d6802/tld-0.13.2.tar.gz", hash = "sha256:d983fa92b9d717400742fca844e29d5e18271079c7bcfabf66d01b39b4a14345", size = 467175, upload-time = "2026-03-06T23:50:34.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/90/39a85a4b63c84213e78b3c17d22e1bf45328acf8ebb33ef93be30d0a3911/tld-0.13.2-py2.py3-none-any.whl", hash = "sha256:9b8fdbdb880e7ba65b216a4937f2c94c49a7226723783d5838fc958ac76f4e0c", size = 296743, upload-time = "2026-03-06T23:50:32.465Z" },
+]
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1878,6 +2127,24 @@ wheels = [
 ]
 
 [[package]]
+name = "trafilatura"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "courlan" },
+    { name = "htmldate" },
+    { name = "justext" },
+    { name = "lxml" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/25/e3ebeefdebfdfae8c4a4396f5a6ea51fc6fa0831d63ce338e5090a8003dc/trafilatura-2.0.0.tar.gz", hash = "sha256:ceb7094a6ecc97e72fea73c7dba36714c5c5b577b6470e4520dca893706d6247", size = 253404, upload-time = "2024-12-03T15:23:24.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/b6/097367f180b6383a3581ca1b86fcae284e52075fa941d1232df35293363c/trafilatura-2.0.0-py3-none-any.whl", hash = "sha256:77eb5d1e993747f6f20938e1de2d840020719735690c840b9a1024803a4cd51d", size = 132557, upload-time = "2024-12-03T15:23:21.41Z" },
+]
+
+[[package]]
 name = "traitlets"
 version = "5.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1929,6 +2196,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-05-11-searcher-pdf-enrichment-design.md`. Brings full-paper-text into the Writer's context so citations can reference equations / methodology / numerical results verbatim instead of generic "according to [12]".

## Why
v0.5.2 verification on a Chinese M/M/c bank-queueing problem retrieved 8 on-topic papers from OpenAlex/Crossref, but Writer could only ever paraphrase the abstracts — full text was never fetched. Critic flagged "citation_coverage" as blocking. Closing that gap.

## What
- New `tools/pdf.py`: `find_pdf_url` (arXiv direct + Unpaywall for DOIs), `fetch_and_extract` (pdfplumber for PDFs, trafilatura for HTML, 20MB ceiling), `batch_enrich_papers` (top-3 concurrent orchestrator).
- New `SearchFindings.paper_fulltext_paths` field on the Pydantic + TS contract (max 3, default empty for backward compat).
- `SearcherAgent` gains `_compact_oversized_papers` + `_compact_one`: one LLM call rewrites files > 24k chars into ≤24k dense markdown preserving formulas / methodology / numerical results + source language (Chinese stays Chinese). Failure keeps the raw file.
- Phase 3.5 / 3.6 wired into `run_for`. `runs_dir` injected by `pipeline.py`.
- `WriterAgent` reads `paper_fulltext_paths`, applies 32k-char paragraph-boundary soft truncate, inlines into `paper_fulltexts` template variable in `writer/v1.toml`. Falls back cleanly to abstract-only when paths are empty.
- 9 commits with TDD-shaped tests for each phase: contract, pdf tools (×3), compaction, wiring, Writer.

## Test plan
- [x] Full agent-worker suite: **290 → 317 passed** (+27 new tests). All existing tests untouched in intent.
- [x] `uvx ruff check .` clean.
- [ ] CI on this PR validates: ruff + pytest, gateway cargo, web typecheck, contracts drift.
- [ ] Post-merge: tag v0.5.4, rebuild local stack, repeat v0.5.2 Chinese M/M/c run, verify `runs/<id>/papers/01-03.md` exist + Writer cites specific formulas.

## Compatibility
- `SearchFindings.paper_fulltext_paths` defaults to empty — old consumers ignore it.
- `WriterAgent.__init__` `run_dir` is optional; existing constructors continue to work.
- `_stream_and_collect` `response_format` parameter is optional with backward-compatible default.
- No Docker image changes (pure-Python deps).