### PR TITLE
fix(pdf): extract DOI from paper.url when doi field is null

### DIFF
--- a/apps/agent-worker/src/agent_worker/tools/pdf.py
+++ b/apps/agent-worker/src/agent_worker/tools/pdf.py
@@ -45,7 +45,20 @@ async def find_pdf_url(
     """
     if paper.arxiv_id:
         return ARXIV_PDF_TEMPLATE.format(arxiv_id=paper.arxiv_id)
-    if not paper.doi:
+
+    # LLM-synthesized SearchFindings often carry the DOI inside `url`
+    # (e.g. "https://doi.org/10.1287/...") while leaving `doi` itself null.
+    # Pull the DOI back out so Unpaywall lookup can still find an OA copy.
+    doi = paper.doi
+    if not doi and paper.url:
+        candidate = paper.url.strip()
+        lowered = candidate.lower()
+        for prefix in ("https://doi.org/", "http://doi.org/"):
+            if lowered.startswith(prefix):
+                doi = candidate[len(prefix):]
+                break
+
+    if not doi:
         return None
 
     # Unpaywall recommends including a mailto for the polite pool. Without
@@ -53,7 +66,7 @@ async def find_pdf_url(
     params: dict[str, str] = {}
     if mailto:
         params["email"] = mailto
-    url = UNPAYWALL_API_URL.format(doi=paper.doi)
+    url = UNPAYWALL_API_URL.format(doi=doi)
 
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:

--- a/apps/agent-worker/tests/test_pdf_tool.py
+++ b/apps/agent-worker/tests/test_pdf_tool.py
@@ -252,3 +252,65 @@ async def test_batch_enrich_papers_returns_empty_when_all_fail(
 async def test_batch_enrich_papers_empty_list_input() -> None:
     paths = await batch_enrich_papers([], runs_papers_dir=Path("/nonexistent"))
     assert paths == []
+
+
+async def test_find_pdf_url_extracts_doi_from_url_when_doi_field_missing(
+    httpx_mock,  # type: ignore[no-untyped-def]
+) -> None:
+    """LLM-synthesized SearchFindings often puts DOI in url but leaves doi=null.
+    find_pdf_url must still resolve via Unpaywall in that case."""
+    paper = Paper(
+        title="Bank Queueing Study",
+        authors=["X. Smith"],
+        abstract="abs",
+        url="https://doi.org/10.1287/msom.5.2.79.16071",
+        # NB: no doi= and no arxiv_id=  — both null
+    )
+    httpx_mock.add_response(
+        json={
+            "best_oa_location": {
+                "url_for_pdf": "https://example.org/oa.pdf",
+            }
+        }
+    )
+    url = await find_pdf_url(paper, mailto="bot@example.com")
+    assert url == "https://example.org/oa.pdf"
+
+    req = httpx_mock.get_request()
+    assert "10.1287/msom.5.2.79.16071" in str(req.url)
+
+
+async def test_find_pdf_url_extracts_doi_from_http_url_prefix(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    """Same fallback works for plain http:// doi.org URLs too (rare but valid)."""
+    paper = Paper(
+        title="Old Paper", authors=[], abstract="",
+        url="http://doi.org/10.1234/legacy",
+    )
+    httpx_mock.add_response(json={"best_oa_location": {"url_for_pdf": "https://x/o.pdf"}})
+    url = await find_pdf_url(paper, mailto="bot@example.com")
+    assert url == "https://x/o.pdf"
+
+
+async def test_find_pdf_url_ignores_non_doi_urls() -> None:
+    """A url that's not a doi.org URL doesn't trigger Unpaywall (no mock needed)."""
+    paper = Paper(
+        title="Blog Post", authors=[], abstract="",
+        url="https://blog.example/some-post",
+    )
+    url = await find_pdf_url(paper, mailto="bot@example.com")
+    assert url is None
+
+
+async def test_find_pdf_url_prefers_paper_doi_field_over_url(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    """When both doi field and url are set, doi field wins (deterministic)."""
+    paper = Paper(
+        title="Both", authors=[], abstract="",
+        url="https://doi.org/10.URL/wrong",
+        doi="10.FIELD/right",
+    )
+    httpx_mock.add_response(json={"best_oa_location": {"url_for_pdf": "https://x.pdf"}})
+    url = await find_pdf_url(paper, mailto="bot@example.com")
+    assert url == "https://x.pdf"
+    req = httpx_mock.get_request()
+    assert "10.FIELD/right" in str(req.url)
+    assert "10.URL/wrong" not in str(req.url)


### PR DESCRIPTION
Found during v0.5.4 e2e: LLM-synthesized SearchFindings papers carry the DOI inside the \`url\` field (e.g. \`https://doi.org/10.1287/msom.5.2.79.16071\`) but leave the \`doi\` field null. \`find_pdf_url\` returned None for all such papers, so the v0.5.4 PDF enrichment silently produced 0 paths on real runs.

## Reproduction (v0.5.4 stack)

Submitted Chinese M/M/c bank-queueing problem. Top 3 retained papers:

\`\`\`
{
  "top3_arxiv_ids": [null, null, null],
  "top3_dois":      [null, null, null],
  "top3_urls": [
    "https://doi.org/10.1287/msom.5.2.79.16071",
    "https://doi.org/10.14419/gjma.v3i3.4689",
    "https://doi.org/10.24198/jbm.v18i2.37"
  ]
}
\`\`\`

\`\`\`
[searcher/log] enriched 0 of top 3 papers with full text
SearchFindings.paper_fulltext_paths = []
\`\`\`

## Fix

\`find_pdf_url\` falls back to extracting the DOI from \`paper.url\` when \`paper.doi\` is absent. \`paper.doi\` still wins when both are set (deterministic).

\`\`\`python
if paper.arxiv_id:
    return ARXIV_PDF_TEMPLATE.format(arxiv_id=paper.arxiv_id)

# LLM-synthesized SearchFindings often carry the DOI inside \`url\`
# while leaving \`doi\` itself null. Pull it back out.
doi = paper.doi
if not doi and paper.url:
    candidate = paper.url.strip()
    lowered = candidate.lower()
    for prefix in ("https://doi.org/", "http://doi.org/"):
        if lowered.startswith(prefix):
            doi = candidate[len(prefix):]
            break
\`\`\`

## Tests

4 new tests in \`test_pdf_tool.py\` (cover https + http prefix, non-doi url passes through to None, paper.doi field wins over url). 15 → 19 in this file, 317 → 321 total.

## Why unit tests missed this

All v0.5.4 \`_doi_paper(doi=...)\` fixtures explicitly set the \`doi\` field. Real LLM output doesn't, and the regression test now reflects that.