### PR TITLE
feat(writer/modeler/critic): few-shot exemplars + sensitivity/anonymity evidence + CUMCM branch rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ packages/py-contracts/src/mm_contracts/generated.py
 # Claude Code runtime state (editor scheduler, local-only)
 /.claude/
 config/providers.toml.bak
+data/mcm/repos/
+data/mcm/logs/
+data/mcm/index/
+data/mcm/scripts/__pycache__/

--- a/apps/agent-worker/src/agent_worker/agents/evidence.py
+++ b/apps/agent-worker/src/agent_worker/agents/evidence.py
@@ -1,0 +1,290 @@
+"""Deterministic evidence-mining over Writer artifacts.
+
+Two scans run between Writer.run_for() and Critic.review():
+- `mine_sensitivity_evidence`: count parameters that appear with ±N% perturbation
+  numbers; F/O-prize papers consistently report ≥3.
+- `scan_anonymity_violations`: regex for common Chinese university / region /
+  team names; instant disqualifier under MCM rules.
+
+Output is converted into additional Critic criteria so the model is judged
+against deterministic facts about its own body text, not just its self-report.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mm_contracts import PaperDraft
+
+
+# --- sensitivity evidence -------------------------------------------------
+
+# Captures perturbation phrasing: "±10%", "+/- 20%", "5% increase", "±0.1"
+# Used to find sentences that quantify a parameter sensitivity test.
+_PERTURB_RE = re.compile(
+    r"(?:[±]|\+\/?\-|\bplus\s+or\s+minus\s+|增减|变化|波动|扰动)\s*\d+(?:\.\d+)?\s*%?",
+    re.IGNORECASE,
+)
+
+# Captures explicit pct change of an objective ("the objective fell by 4.3%").
+_PCT_DELTA_RE = re.compile(
+    r"\b\d+(?:\.\d+)?\s*%\b",
+)
+
+# Variants of "sensitivity analysis" headings in both languages.
+_SENS_HEADING_RE = re.compile(
+    r"\b(sensitivity\s+analys\w+|sensitivity\s+study|敏感性分析|灵敏度分析)\b",
+    re.IGNORECASE,
+)
+
+# Markers for typical sensitivity figure ids (Coder catalog).
+_SENS_FIGURE_TOKENS = (
+    "tornado",
+    "heatmap_sensitivity",
+    "monte_carlo",
+    "monte-carlo",
+    "敏感性",
+    "灵敏度",
+)
+
+
+@dataclass
+class SensitivityFindings:
+    """What deterministic scanning learned about the paper's sensitivity work."""
+
+    has_sensitivity_section: bool
+    perturb_mention_count: int
+    parameter_count_estimate: int
+    tornado_or_mc_referenced: bool
+    sample_evidence: list[str] = field(default_factory=list)
+
+    def passes_award_bar(self) -> bool:
+        return (
+            self.has_sensitivity_section
+            and self.parameter_count_estimate >= 3
+            and self.perturb_mention_count >= 3
+        )
+
+
+def mine_sensitivity_evidence(paper: PaperDraft) -> SensitivityFindings:
+    """Quick scan: does the body show ≥3 distinct parameters perturbed with quantitative deltas?"""
+    has_sens_section = False
+    perturb_count = 0
+    figure_refs = False
+    samples: list[str] = []
+
+    # Parameter-count proxy: catalog short variable tokens that appear near
+    # a perturbation phrase. Conservative — over-count is fine, under-count
+    # would let weak papers through.
+    parameter_tokens: set[str] = set()
+
+    # Patterns that explicitly bind a parameter to a perturbation phrase.
+    # Each pattern's group(1) is the parameter token.
+    _GREEK = "αβγδεζηθικλμνξορστυφχψω"
+    _PARAM_PATTERNS = [
+        # "perturbed α by ±10%" / "varying β over ±20%" / "increased X by 10%"
+        re.compile(
+            rf"(?:perturb(?:ed|ing)?|vary(?:ing)?|increas(?:e[ds]?|ing)|decreas(?:e[ds]?|ing)|chang(?:e[ds]?|ing))"
+            rf"\s+([{_GREEK}]|[A-Za-z](?:_?[A-Za-z0-9]{{0,8}})?)"
+            rf"\s+(?:by|of|over|at|with)?\s*{_PERTURB_RE.pattern}",
+            re.IGNORECASE,
+        ),
+        # "α by ±10%" / "γ at ±20%" / "X_init by 5%"
+        re.compile(
+            rf"\b([{_GREEK}]|[A-Za-z]_[A-Za-z0-9]{{1,8}}|[A-Za-z]{{1,3}})\s+(?:by|at|over)\s*{_PERTURB_RE.pattern}",
+            re.IGNORECASE,
+        ),
+        # "For α at ±10%" / "对 α 增减 10%"
+        re.compile(
+            rf"(?:For|对|参数)\s+([{_GREEK}]|[A-Za-z](?:_?[A-Za-z0-9]{{0,8}})?)"
+            rf"[^.。!?\n]{{0,30}}{_PERTURB_RE.pattern}",
+            re.IGNORECASE,
+        ),
+    ]
+
+    _PARAM_BLACKLIST = {
+        "the", "a", "an", "this", "that", "we", "for", "of", "by", "at",
+        "in", "on", "to", "is", "are", "was", "were", "be", "been",
+        "and", "or", "with", "from", "as", "it", "its", "all", "each",
+    }
+
+    for sec in paper.sections:
+        title = sec.title or ""
+        body = sec.body_markdown or ""
+        if _SENS_HEADING_RE.search(title) or _SENS_HEADING_RE.search(body):
+            has_sens_section = True
+        perturb_hits = _PERTURB_RE.findall(body)
+        perturb_count += len(perturb_hits)
+        for pat in _PARAM_PATTERNS:
+            for m in pat.finditer(body):
+                param = m.group(1).strip(" $\\")
+                if not param or param.lower() in _PARAM_BLACKLIST:
+                    continue
+                if len(param) > 30:
+                    continue
+                parameter_tokens.add(param)
+                if len(samples) < 6:
+                    samples.append(m.group(0).strip()[:200])
+        if any(tok in body.lower() for tok in _SENS_FIGURE_TOKENS):
+            figure_refs = True
+        for fig_id_match in re.finditer(r"\[\[FIG:([a-z0-9_]+)\]\]", body):
+            if any(tok in fig_id_match.group(1) for tok in _SENS_FIGURE_TOKENS):
+                figure_refs = True
+
+    return SensitivityFindings(
+        has_sensitivity_section=has_sens_section,
+        perturb_mention_count=perturb_count,
+        parameter_count_estimate=len(parameter_tokens),
+        tornado_or_mc_referenced=figure_refs,
+        sample_evidence=samples,
+    )
+
+
+def sensitivity_criteria(findings: SensitivityFindings) -> list[str]:
+    """Convert findings into appendable Critic criteria strings."""
+    crits: list[str] = []
+    if not findings.has_sensitivity_section:
+        crits.append(
+            "BLOCKING: No 'Sensitivity Analysis' / 敏感性分析 section detected in any "
+            "section title or body. F-prize / O-prize papers must include this section."
+        )
+    if findings.parameter_count_estimate < 3:
+        crits.append(
+            f"BLOCKING: Detected only ~{findings.parameter_count_estimate} parameter(s) "
+            "with quantitative perturbation tests. The Modeler's plan requires ≥3 — "
+            "expand the Sensitivity section with at least 3 distinct parameters at ±10% and ±20%."
+        )
+    if findings.perturb_mention_count < 3:
+        crits.append(
+            f"Found only {findings.perturb_mention_count} ±N% perturbation mentions in the "
+            "body. Award-level papers describe each parameter's effect with a concrete % change."
+        )
+    if not findings.tornado_or_mc_referenced:
+        crits.append(
+            "No tornado_sensitivity / heatmap_sensitivity / Monte Carlo figure referenced. "
+            "The Modeler's validation plan asks for these — embed them with [[FIG:<id>]] and "
+            "discuss the result in prose."
+        )
+    return crits
+
+
+# --- anonymity scanner ----------------------------------------------------
+
+# Universities frequently leaked in CUMCM / MCM violations. Conservative list
+# focused on ones likely to appear verbatim in student-written context.
+_UNIVERSITY_PATTERNS = [
+    r"Jilin\s+University",
+    r"Tsinghua\s+University",
+    r"Peking\s+University",
+    r"Fudan\s+University",
+    r"Shanghai\s+Jiao\s*tong\s+University",
+    r"Zhejiang\s+University",
+    r"Beihang\s+University",
+    r"University\s+of\s+Science\s+and\s+Technology\s+of\s+China",
+    r"Nanjing\s+University",
+    r"Xi[' ]?an\s+Jiao\s*tong\s+University",
+    r"吉林大学",
+    r"清华大学",
+    r"北京大学",
+    r"复旦大学",
+    r"上海交通大学",
+    r"浙江大学",
+    r"北京航空航天大学",
+    r"中国科学技术大学",
+    r"南京大学",
+    r"西安交通大学",
+    r"华中科技大学",
+    r"哈尔滨工业大学",
+    r"中山大学",
+    r"武汉大学",
+    r"同济大学",
+    r"东南大学",
+    r"国防科技大学",
+]
+
+# Chinese province + tier-1 city names that hint at team origin.
+_REGION_PATTERNS = [
+    r"\b(?:Beijing|Shanghai|Shenzhen|Guangzhou|Chengdu|Wuhan|Nanjing|Xi[' ]?an|Hangzhou|Tianjin|Chongqing)\b",
+    r"(?:北京|上海|深圳|广州|成都|武汉|南京|西安|杭州|天津|重庆|吉林省|辽宁省|山东省|江苏省|浙江省|广东省)",
+]
+
+# Common author-style intros that imply a real name follows.
+_AUTHOR_PATTERNS = [
+    r"\b(?:I am|My name is|We are students at|We the undersigned)\b",
+    r"^\s*作者[:：]\s*\S+",
+    r"^\s*指导教师[:：]\s*\S+",
+]
+
+_ALL_ANON_RES = [re.compile(p, re.IGNORECASE | re.MULTILINE) for p in (
+    *_UNIVERSITY_PATTERNS,
+    *_REGION_PATTERNS,
+    *_AUTHOR_PATTERNS,
+)]
+
+
+@dataclass
+class AnonymityFindings:
+    violations: list[tuple[str, str]] = field(default_factory=list)
+    # (section_title, matched_snippet)
+
+    @property
+    def has_violations(self) -> bool:
+        return bool(self.violations)
+
+
+def scan_anonymity_violations(paper: PaperDraft) -> AnonymityFindings:
+    """Regex sweep for school / region / author identity leaks.
+
+    Returns the first ~5 hits with context so Critic can be unambiguous about
+    what to remove. Conservative — we'd rather flag for human review than
+    miss a real DQ-causing leak.
+    """
+    finds: list[tuple[str, str]] = []
+    fields_to_scan: list[tuple[str, str]] = [
+        ("title", paper.title or ""),
+        ("abstract", paper.abstract or ""),
+    ]
+    for sec in paper.sections:
+        fields_to_scan.append((sec.title or "(section)", sec.body_markdown or ""))
+    # Also scan references — schools leak there too.
+    if getattr(paper, "references", None):
+        joined_refs = "\n".join(paper.references)
+        fields_to_scan.append(("references", joined_refs))
+
+    for label, text in fields_to_scan:
+        if not text:
+            continue
+        for pattern in _ALL_ANON_RES:
+            m = pattern.search(text)
+            if m:
+                snippet = text[max(0, m.start() - 30) : m.end() + 30].replace("\n", " ")
+                finds.append((label, snippet.strip()))
+                if len(finds) >= 5:
+                    return AnonymityFindings(violations=finds)
+    return AnonymityFindings(violations=finds)
+
+
+def anonymity_criteria(findings: AnonymityFindings) -> list[str]:
+    if not findings.has_violations:
+        return []
+    bullets = "\n".join(
+        f"  - in {label}: ...{snip}..." for label, snip in findings.violations[:5]
+    )
+    return [
+        "BLOCKING (DISQUALIFICATION RISK): identity leak detected — under MCM/CUMCM rules, "
+        "any school, region, author, or advisor name causes instant disqualification. "
+        f"Remove the following matches:\n{bullets}"
+    ]
+
+
+__all__ = [
+    "AnonymityFindings",
+    "SensitivityFindings",
+    "anonymity_criteria",
+    "mine_sensitivity_evidence",
+    "scan_anonymity_violations",
+    "sensitivity_criteria",
+]

--- a/apps/agent-worker/src/agent_worker/agents/modeler.py
+++ b/apps/agent-worker/src/agent_worker/agents/modeler.py
@@ -15,12 +15,35 @@ from mm_contracts import AnalyzerOutput, ModelSpec, ProblemInput, ReasoningEffor
 
 from agent_worker.agents.base import BaseAgent
 from agent_worker.events import EventEmitter
+from agent_worker.few_shot import FewShotLibrary, format_writer_block, get_default_library
 from agent_worker.gateway_client import GatewayClient
 
 if TYPE_CHECKING:
     from mm_contracts import MethodNode
 
     from agent_worker.hmml import HMMLService
+
+# Modeler benefits from seeing >1 prior approach to anchor its own
+# "compare 2 candidates" rule, but keep this lean to preserve token budget.
+MODELER_FEW_SHOT_K = 2
+
+_ZH_FAMILIES = {"cumcm", "huashu", "国赛"}
+
+
+def _modeler_language(competition_type: str) -> str:
+    s = (competition_type or "").lower()
+    if any(token in s for token in _ZH_FAMILIES) or "华数" in (competition_type or ""):
+        return "zh"
+    return "en"
+
+
+def _problem_letter_from_problem_text(problem_text: str) -> str | None:
+    import re
+
+    if not problem_text:
+        return None
+    m = re.search(r"Problem\s+([A-F])\b", problem_text, flags=re.IGNORECASE)
+    return m.group(1).upper() if m else None
 
 
 class ModelerAgent(BaseAgent):
@@ -38,6 +61,7 @@ class ModelerAgent(BaseAgent):
         run_effort: ReasoningEffort = "medium",
         long_context: bool = False,
         model_override: str | None = None,
+        few_shot_library: FewShotLibrary | None = None,
     ) -> None:
         super().__init__(
             gateway,
@@ -48,6 +72,11 @@ class ModelerAgent(BaseAgent):
             model_override=model_override,
         )
         self.hmml = hmml
+        self._few_shot: FewShotLibrary = (
+            few_shot_library
+            if few_shot_library is not None
+            else get_default_library()
+        )
 
     async def run_for(
         self, problem: ProblemInput, analysis: AnalyzerOutput
@@ -75,6 +104,19 @@ class ModelerAgent(BaseAgent):
                 )
 
         retrieved_ctx = self._render_retrieved(retrieved)
+        # Same-problem-type winning-paper exemplars — gives the LLM concrete
+        # anchor patterns for "chosen approach + rationale" that judges have
+        # historically rewarded. Missing index → empty block, silent fallback.
+        language = _modeler_language(problem.competition_type)
+        letter = _problem_letter_from_problem_text(problem.problem_text)
+        few_shot_block = format_writer_block(
+            self._few_shot.top_k(
+                competition_type=problem.competition_type,
+                problem_letter=letter,
+                k=MODELER_FEW_SHOT_K,
+            ),
+            language=language,
+        )
         output = await self.run(
             problem_text=problem.problem_text,
             competition_type=problem.competition_type,
@@ -82,6 +124,7 @@ class ModelerAgent(BaseAgent):
                 analysis.model_dump(mode="json"), ensure_ascii=False, indent=2
             ),
             retrieved_methods=retrieved_ctx,
+            few_shot_exemplars=few_shot_block,
         )
         assert isinstance(output, ModelSpec)
         return output

--- a/apps/agent-worker/src/agent_worker/agents/writer.py
+++ b/apps/agent-worker/src/agent_worker/agents/writer.py
@@ -21,12 +21,41 @@ from mm_contracts import (
 
 from agent_worker.agents.base import BaseAgent
 from agent_worker.events import EventEmitter
+from agent_worker.few_shot import FewShotLibrary, format_writer_block, get_default_library
 from agent_worker.gateway_client import GatewayClient
 
 # Per-paper Writer-side budget. Last-resort safety net: Searcher already
 # compacts files > 24k chars in Phase 3.6, but uncompacted survivors get
 # truncated here at a paragraph boundary so the prompt cannot explode.
 WRITER_SOFT_TRUNCATE_CHARS = 32_000
+
+# How many same-problem-type exemplars to inject into the Writer prompt.
+# 2 is a good trade-off: enough variety to anchor structure, not so many
+# that we blow past token_budget_in or risk style copying.
+WRITER_FEW_SHOT_K = 2
+
+_ZH_FAMILIES = {"cumcm", "huashu", "国赛"}
+
+
+def _writer_language(competition_type: str) -> str:
+    s = (competition_type or "").lower()
+    if any(token in s for token in _ZH_FAMILIES):
+        return "zh"
+    if "华数" in (competition_type or ""):
+        return "zh"
+    return "en"
+
+
+def _problem_letter_from_problem_text(problem_text: str) -> str | None:
+    """Best-effort: detect MCM/ICM problem letter from the prompt header."""
+    import re
+
+    if not problem_text:
+        return None
+    m = re.search(r"Problem\s+([A-F])\b", problem_text, flags=re.IGNORECASE)
+    if m:
+        return m.group(1).upper()
+    return None
 
 
 class WriterAgent(BaseAgent):
@@ -44,6 +73,7 @@ class WriterAgent(BaseAgent):
         long_context: bool = False,
         model_override: str | None = None,
         run_dir: Path | None = None,
+        few_shot_library: FewShotLibrary | None = None,
     ) -> None:
         super().__init__(
             gateway,
@@ -57,6 +87,13 @@ class WriterAgent(BaseAgent):
         # paths from `SearchFindings.paper_fulltext_paths`. Optional so
         # existing callers / tests that don't pass it still work.
         self._run_dir: Path | None = run_dir
+        # Process-singleton few-shot library by default. Tests can inject a
+        # custom one (e.g. an empty library) to keep prompts deterministic.
+        self._few_shot: FewShotLibrary = (
+            few_shot_library
+            if few_shot_library is not None
+            else get_default_library()
+        )
 
     async def run_for(
         self,
@@ -74,6 +111,17 @@ class WriterAgent(BaseAgent):
             else {"queries": [], "papers": [], "key_findings": [], "datasets_mentioned": []}
         )
         fulltexts_block = self._build_fulltexts_block(findings)
+        # Award-winning exemplars: top-K winning-paper Summary excerpts from
+        # the same competition family + problem letter. Empty when the index
+        # isn't built yet — Writer falls back to its baseline behaviour.
+        language = _writer_language(problem.competition_type)
+        letter = _problem_letter_from_problem_text(problem.problem_text)
+        exemplars = self._few_shot.top_k(
+            competition_type=problem.competition_type,
+            problem_letter=letter,
+            k=WRITER_FEW_SHOT_K,
+        )
+        few_shot_block = format_writer_block(exemplars, language=language)
         output = await self.run(
             problem_text=problem.problem_text,
             competition_type=problem.competition_type,
@@ -110,6 +158,7 @@ class WriterAgent(BaseAgent):
                 findings_payload, ensure_ascii=False, indent=2
             ),
             paper_fulltexts=fulltexts_block,
+            few_shot_exemplars=few_shot_block,
         )
         assert isinstance(output, PaperDraft)
         return output

--- a/apps/agent-worker/src/agent_worker/few_shot/__init__.py
+++ b/apps/agent-worker/src/agent_worker/few_shot/__init__.py
@@ -1,0 +1,34 @@
+"""Few-shot exemplar library for Writer/Modeler prompts.
+
+Loads structured snippets from MCM/ICM winning papers (built offline from
+the dick20 corpus, see `data/mcm/scripts/build_index.py`) and offers a
+small surface to fetch the top-K exemplars matching a competition_type +
+problem_letter and format them as a prompt block.
+
+Degrades silently when the index file is missing — agents fall back to
+their existing behaviour, no exemplars injected.
+"""
+
+from functools import lru_cache
+
+from agent_worker.few_shot.loader import (
+    DEFAULT_INDEX_PATH,
+    Exemplar,
+    FewShotLibrary,
+    format_writer_block,
+)
+
+
+@lru_cache(maxsize=1)
+def get_default_library() -> FewShotLibrary:
+    """Process-wide singleton, loaded lazily. Reset with `.cache_clear()` in tests."""
+    return FewShotLibrary.from_jsonl()
+
+
+__all__ = [
+    "DEFAULT_INDEX_PATH",
+    "Exemplar",
+    "FewShotLibrary",
+    "format_writer_block",
+    "get_default_library",
+]

--- a/apps/agent-worker/src/agent_worker/few_shot/loader.py
+++ b/apps/agent-worker/src/agent_worker/few_shot/loader.py
@@ -1,0 +1,255 @@
+"""Few-shot library loader."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+CompetitionFamily = Literal["mcm", "icm", "cumcm", "huashu"]
+
+# Default index location: <repo_root>/data/mcm/index/winning_papers.jsonl.
+# This file lives at apps/agent-worker/src/agent_worker/few_shot/loader.py, so
+# repo root is 5 directories up (parents[5]).
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+DEFAULT_INDEX_PATH = _REPO_ROOT / "data" / "mcm" / "index" / "winning_papers.jsonl"
+
+
+@dataclass(frozen=True)
+class Exemplar:
+    """A single winning-paper snippet usable as a prompt few-shot."""
+
+    paper_id: str
+    year: int
+    problem_letter: str  # 'A' .. 'F'
+    competition_type: CompetitionFamily
+    summary_text: str
+    section_headings: tuple[str, ...]
+    has_sensitivity_section: bool
+    has_strengths_weaknesses_section: bool
+
+
+class FewShotLibrary:
+    """In-memory index of winning-paper exemplars, keyed by (family, letter).
+
+    Loaded lazily from JSONL. Missing file → empty library, top_k returns [].
+    """
+
+    def __init__(self, exemplars: list[Exemplar]) -> None:
+        self._exemplars = exemplars
+        # Bucket by (family, letter) for fast lookup.
+        self._buckets: dict[tuple[str, str], list[Exemplar]] = {}
+        for ex in exemplars:
+            key = (ex.competition_type, ex.problem_letter)
+            self._buckets.setdefault(key, []).append(ex)
+        # Sort each bucket: prefer those with sensitivity + S/W sections
+        # (the very rules the Writer must satisfy), then by recency.
+        for _key, bucket in self._buckets.items():
+            bucket.sort(
+                key=lambda e: (
+                    -int(e.has_sensitivity_section),
+                    -int(e.has_strengths_weaknesses_section),
+                    -e.year,
+                )
+            )
+
+    @classmethod
+    def from_jsonl(cls, path: Path | None = None) -> FewShotLibrary:
+        """Load from JSONL. Non-existent / unreadable file → empty library."""
+        resolved = path or DEFAULT_INDEX_PATH
+        # Allow override via env var so users can point at a custom index.
+        if env_path := os.environ.get("MM_FEW_SHOT_INDEX"):
+            resolved = Path(env_path)
+        if not resolved.is_file():
+            return cls([])
+        rows: list[Exemplar] = []
+        try:
+            with resolved.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not (summary := obj.get("summary_text") or ""):
+                        # Skip records that failed text extraction —
+                        # they would just take prompt slots without value.
+                        continue
+                    rows.append(
+                        Exemplar(
+                            paper_id=str(obj.get("id", "")),
+                            year=int(obj.get("year", 0)),
+                            problem_letter=str(obj.get("problem_letter", "")).upper(),
+                            competition_type=str(
+                                obj.get("competition_type", "mcm")
+                            ).lower(),  # type: ignore[arg-type]
+                            summary_text=summary[:2000],
+                            section_headings=tuple(
+                                str(h) for h in obj.get("section_headings", [])
+                            ),
+                            has_sensitivity_section=bool(
+                                obj.get("has_sensitivity_section", False)
+                            ),
+                            has_strengths_weaknesses_section=bool(
+                                obj.get("has_strengths_weaknesses_section", False)
+                            ),
+                        )
+                    )
+        except OSError:
+            return cls([])
+        return cls(rows)
+
+    def __len__(self) -> int:
+        return len(self._exemplars)
+
+    def top_k(
+        self,
+        competition_type: str,
+        problem_letter: str | None,
+        k: int = 3,
+    ) -> list[Exemplar]:
+        """Return up to k exemplars matching the family + (optional) letter.
+
+        Matching strategy (each step falls through if it yields too few):
+        1. Exact (family, letter) bucket.
+        2. Same family, any letter — same competition culture/judging style.
+        3. Cross-family fallback (mcm↔icm and cumcm↔huashu share rubrics).
+        4. Anything in the library (last resort).
+        """
+        family = _normalize_family(competition_type)
+        letter = (problem_letter or "").upper() or None
+
+        picked: list[Exemplar] = []
+        seen: set[str] = set()
+
+        def _add(items: list[Exemplar]) -> None:
+            for ex in items:
+                if ex.paper_id in seen:
+                    continue
+                seen.add(ex.paper_id)
+                picked.append(ex)
+                if len(picked) >= k:
+                    return
+
+        if letter:
+            _add(self._buckets.get((family, letter), []))
+        if len(picked) < k:
+            same_family = [
+                e for e in self._exemplars if e.competition_type == family
+            ]
+            same_family.sort(
+                key=lambda e: (
+                    -int(e.has_sensitivity_section),
+                    -int(e.has_strengths_weaknesses_section),
+                    -e.year,
+                )
+            )
+            _add(same_family)
+        if len(picked) < k:
+            sibling = _SIBLING_FAMILY.get(family)
+            if sibling:
+                sibs = [
+                    e for e in self._exemplars if e.competition_type == sibling
+                ]
+                sibs.sort(
+                    key=lambda e: (
+                        -int(e.has_sensitivity_section),
+                        -int(e.has_strengths_weaknesses_section),
+                        -e.year,
+                    )
+                )
+                _add(sibs)
+        if len(picked) < k:
+            rest = sorted(
+                self._exemplars,
+                key=lambda e: (
+                    -int(e.has_sensitivity_section),
+                    -int(e.has_strengths_weaknesses_section),
+                    -e.year,
+                ),
+            )
+            _add(rest)
+
+        return picked[:k]
+
+
+_SIBLING_FAMILY: dict[str, str] = {
+    "mcm": "icm",
+    "icm": "mcm",
+    "cumcm": "huashu",
+    "huashu": "cumcm",
+}
+
+
+def _normalize_family(competition_type: str) -> str:
+    """Map raw competition_type strings to one of mcm/icm/cumcm/huashu."""
+    s = (competition_type or "").lower()
+    if "icm" in s:
+        return "icm"
+    if "mcm" in s:
+        return "mcm"
+    if "huashu" in s or "华数" in s:
+        return "huashu"
+    if "cumcm" in s or "国赛" in s:
+        return "cumcm"
+    return "mcm"
+
+
+def format_writer_block(exemplars: list[Exemplar], language: str = "en") -> str:
+    """Render exemplars as a prompt-injectable block.
+
+    `language` controls headings:
+    - "en" for MCM/ICM
+    - "zh" for CUMCM/华数杯
+
+    Empty input → empty string, so a missing index degrades silently.
+    """
+    if not exemplars:
+        return ""
+    if language == "zh":
+        header = (
+            "## 同题型获奖论文范本（仅供参考行文风格 + 章节结构，禁止照抄文字）\n"
+            "以下是 dick20 语料库中同题型 (problem_letter 匹配优先) 历年获奖论文的摘要 / 节选。"
+            "判官最看重的是：摘要里塞具体数字、敏感性章节定量、结论与开篇呼应。"
+            "请观察并复用其结构与论证密度，但**禁止抄写其文字或数据**——你的数字必须来自 Coder 的本次实验。\n"
+        )
+        item_label = "范本"
+    else:
+        header = (
+            "## Award-winning exemplars from prior years (style + structure reference only — do NOT copy text)\n"
+            "Each block is the Summary section (and detected section headings) of a past Outstanding / Finalist paper "
+            "on the same problem letter when available. Note how the abstract front-loads numerical findings, how the "
+            "Sensitivity Analysis section is structured, and how Strengths/Weaknesses ties back to modeling choices. "
+            "**You must NOT copy text or numbers from these exemplars.** Your own numbers must come from this run's "
+            "Coder output.\n"
+        )
+        item_label = "Exemplar"
+    parts = [header]
+    for i, ex in enumerate(exemplars, 1):
+        headings = ", ".join(ex.section_headings) if ex.section_headings else "(headings not detected)"
+        flags = []
+        if ex.has_sensitivity_section:
+            flags.append("✓Sensitivity")
+        if ex.has_strengths_weaknesses_section:
+            flags.append("✓Strengths/Weaknesses")
+        flag_str = (" [" + ", ".join(flags) + "]") if flags else ""
+        parts.append(
+            f"### {item_label} {i}: {ex.year} Problem {ex.problem_letter}"
+            f" ({ex.competition_type.upper()}){flag_str}\n"
+            f"Detected sections: {headings}\n\n"
+            f"Summary excerpt:\n{ex.summary_text.strip()}\n"
+        )
+    return "\n".join(parts)
+
+
+__all__ = [
+    "CompetitionFamily",
+    "DEFAULT_INDEX_PATH",
+    "Exemplar",
+    "FewShotLibrary",
+    "format_writer_block",
+]

--- a/apps/agent-worker/src/agent_worker/pipeline.py
+++ b/apps/agent-worker/src/agent_worker/pipeline.py
@@ -51,6 +51,12 @@ from agent_worker.agents import (
     SearcherAgent,
     WriterAgent,
 )
+from agent_worker.agents.evidence import (
+    anonymity_criteria,
+    mine_sensitivity_evidence,
+    scan_anonymity_violations,
+    sensitivity_criteria,
+)
 from agent_worker.config import get_settings
 from agent_worker.events import EventEmitter
 from agent_worker.gateway_client import GatewayClient
@@ -379,6 +385,42 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
             paper = await writer.run_for(
                 problem, analysis, spec, coder_out, findings
             )
+
+            # Deterministic evidence mining: surface concrete facts about the
+            # Writer's own output before the LLM Critic sees it. Two scanners:
+            # - sensitivity: ≥3 parameters perturbed at ±N% (F/O-prize bar)
+            # - anonymity: school/region/author names (MCM/CUMCM instant DQ)
+            # Findings turn into extra criteria so the Critic + revision loop
+            # gets pointed at real flaws rather than hallucinated ones.
+            base_writer_criteria = [
+                "Abstract follows award-mode numeric-result rules.",
+                "Every problem sub-question is answered explicitly.",
+                "Sensitivity analysis and strengths/weaknesses are present when applicable.",
+                "References are sufficient and cited in the body.",
+                "Figures are referenced using known figure ids and discussed with numbers.",
+                "No school, student, or identifying team information appears.",
+            ]
+            sens_findings = mine_sensitivity_evidence(paper)
+            anon_findings = scan_anonymity_violations(paper)
+            extra_criteria = sensitivity_criteria(sens_findings) + anonymity_criteria(
+                anon_findings
+            )
+            if extra_criteria:
+                await emitter.emit(
+                    "log",
+                    {
+                        "level": "warning" if anon_findings.has_violations else "info",
+                        "message": (
+                            "deterministic Writer scan flagged "
+                            f"{len(extra_criteria)} issue(s): "
+                            f"sensitivity_params={sens_findings.parameter_count_estimate}, "
+                            f"perturb_mentions={sens_findings.perturb_mention_count}, "
+                            f"anonymity_hits={len(anon_findings.violations)}"
+                        ),
+                    },
+                    agent="writer",
+                )
+
             paper = await _review_and_maybe_revise(
                 critic=critic,
                 producer=writer,
@@ -391,15 +433,20 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                     "spec": spec.model_dump(mode="json"),
                     "coder_output": coder_out.model_dump(mode="json"),
                     "search_findings": findings.model_dump(mode="json"),
+                    "evidence_scan": {
+                        "sensitivity": {
+                            "has_section": sens_findings.has_sensitivity_section,
+                            "parameter_count_estimate": sens_findings.parameter_count_estimate,
+                            "perturb_mentions": sens_findings.perturb_mention_count,
+                            "tornado_or_mc_referenced": sens_findings.tornado_or_mc_referenced,
+                        },
+                        "anonymity_violations": [
+                            {"location": loc, "snippet": snip}
+                            for loc, snip in anon_findings.violations
+                        ],
+                    },
                 },
-                criteria=[
-                    "Abstract follows award-mode numeric-result rules.",
-                    "Every problem sub-question is answered explicitly.",
-                    "Sensitivity analysis and strengths/weaknesses are present when applicable.",
-                    "References are sufficient and cited in the body.",
-                    "Figures are referenced using known figure ids and discussed with numbers.",
-                    "No school, student, or identifying team information appears.",
-                ],
+                criteria=base_writer_criteria + extra_criteria,
             )
             assert isinstance(paper, PaperDraft)
 

--- a/apps/agent-worker/src/agent_worker/prompts/modeler/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/modeler/v1.toml
@@ -36,6 +36,15 @@ Pick the simplest model that can answer the question. Only escalate (LP → MILP
 ## HMML method consultation
 You have access to a reference library (HMML). You will see the top 5 retrieved methods. For each retrieved method, evaluate its fit and include an entry in `consulted_methods` with `{id, name, reason}`. The `reason` is short: "selected as primary", "considered but inferior because <specific reason>", or "partial basis for hybrid approach". You do NOT have to pick from the retrieved set — if none fit, state so in the reason and propose your own approach.
 
+## Same-problem-type award-paper exemplars (style + approach reference)
+
+If the user message includes `few_shot_exemplars`, those are Summary excerpts from past O 奖 / F 奖 / 一等奖 papers on the same problem letter. Use them to:
+- Calibrate the **depth** of your `rationale` (judges expect 1-2 paragraphs comparing candidates, not 1 sentence).
+- See which kinds of models judges have historically rewarded for this problem family (e.g. Problem A frequently rewards continuous/PDE; Problem C rewards data-driven + interpretable; ICM E rewards system-dynamics).
+- Set your sensitivity-plan ambition (most prize papers do ≥3 parameters + Monte Carlo).
+
+**DO NOT copy their `chosen_approach` text or numbers.** Use them as anchors, not source.
+
 Respond with a single JSON object matching ModelSpec. Use ensure_ascii=False for any Chinese text. No markdown fences.
 """
 
@@ -51,6 +60,9 @@ Analyzer output (JSON):
 
 Retrieved methods from HMML (top 5 by BM25 relevance):
 {{ retrieved_methods }}
+
+Same-problem-type award-paper exemplars (structure reference, do NOT copy):
+{{ few_shot_exemplars }}
 
 Respond with a JSON object. Required top-level keys:
   chosen_approach (string),

--- a/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
@@ -60,6 +60,44 @@ Walk through this list mentally and fix anything that fails:
 (8) No forbidden filler phrases, no restated-problem openings.
 
 You may also see `findings_json` — papers and key findings from the Searcher. Use them to populate `references` and enrich the Introduction / Related Work sections. Cite by arXiv ID when appropriate (e.g. "Author et al., arXiv:2312.01234").
+
+# Competition-specific rules
+
+## MCM / ICM (English)
+- Page limit: 25 pages including the Summary Sheet (do NOT exceed 25 markdown pages of body; the rendered PDF will be ~25).
+- Summary Sheet is page 1; body starts page 2.
+- No 承诺书 / Statement of Authorship needed.
+- Citation style: numeric `[1]`, `[2]` inline; full reference list at the end (any consistent academic style is fine, but be consistent throughout).
+- ICM (Problems D / E / F) requires: clear stakeholder analysis, policy recommendations, ethical considerations, and discussion of broader societal impact — these are scoring weight that MCM A/B problems don't have.
+
+## CUMCM / 华数杯 (Chinese)
+- 页数上限 25 页（含摘要页，不含承诺书与目录）。
+- 第一页必须是「承诺书」(Statement of Authorship)；如果输入的 `competition_type` 是 cumcm/huashu，请在 sections 的第一个 section 输出标题为「承诺书」、body 为标准承诺文本（以队号代替姓名）的一段，让下游 LaTeX 模板渲染。
+- 第二页是「摘要」(Summary)，独立成页；不写「目录」。
+- 引用格式必须是 **GB/T 7714-2015**：`[1] 作者. 题名[J]. 期刊, 年, 卷(期): 页码.` 顺序编码；不要用 (Smith 2020) 这种著者-出版年制。
+- 标题、章节、图表、公式都用中文；阿拉伯数字编号；图表标题在下方（图 1：...），表标题在上方（表 1：...）。
+- 国赛判官特别看重：模型的「优化」（敏感性 + 误差分析 + 改进方向）、「推广」（一段写本模型在其他场景的适用性）、「亮点」（开篇摘要末段独立一句点明亮点）。
+- 关键词放在摘要末尾：3-5 个，分号分隔。
+
+# Award-level structural anchors
+
+These are the structural slots that O 奖 / F 奖 / 一等奖 papers consistently fill. Treat any missing one as a self-check failure:
+
+| 槽位 | MCM/ICM | CUMCM |
+|---|---|---|
+| Pre-summary | (none) | 承诺书 (statement of authorship) |
+| Page 1 | Summary Sheet (≤1 page, ≥2 numbers) | 摘要页 (≤1 页 ≤1000 字, ≥2 数字 + 3-5 关键词) |
+| Intro | Problem context + sub-question enumeration + literature pointer | 问题重述 + 文献综述 + 问题分析 |
+| Assumptions | {Assumption, Justification, Impact} triple | 三段式同上 |
+| Notation | Symbol table | 符号表 |
+| Model | First-principles derivation, ≥2 candidates, selection criterion | 同上 |
+| Algorithm | Numbered steps + complexity | 同上 |
+| Results | Numerical with units + 95% CI / σ | 同上 + 优化分析 |
+| Sensitivity | ≥3 params ±10%/±20%, tornado + heatmap | 同上 |
+| Strengths/Weaknesses | ≥3 strengths, ≥2 weaknesses tied to modeling | 优点/缺点;还要"推广" |
+| References | ≥15, inline-cited | ≥15, GB/T 7714 |
+
+If you see `few_shot_exemplars` in the user message, those are summary excerpts of historical O/F-prize papers on the same problem letter. Read them for structure and density, NOT for content. NEVER quote them; your numbers must come from THIS run's Coder output.
 """
 
 [user_template]
@@ -96,6 +134,10 @@ results verbatim where appropriate. When this block is empty, fall
 back to title+abstract citation from the Sources list.
 
 {{ paper_fulltexts }}
+
+## Same-problem-type O/F-prize exemplars (structure reference, do NOT copy)
+
+{{ few_shot_exemplars }}
 
 Respond with a JSON object. Required top-level keys:
   title (string),

--- a/apps/agent-worker/tests/test_evidence_mining.py
+++ b/apps/agent-worker/tests/test_evidence_mining.py
@@ -1,0 +1,116 @@
+"""Tests for sensitivity evidence mining + anonymity scanning."""
+
+from __future__ import annotations
+
+from agent_worker.agents.evidence import (
+    anonymity_criteria,
+    mine_sensitivity_evidence,
+    scan_anonymity_violations,
+    sensitivity_criteria,
+)
+from mm_contracts import PaperDraft, PaperSection
+
+
+def _draft(sections: list[tuple[str, str]], abstract: str = "abs", title: str = "T") -> PaperDraft:
+    return PaperDraft(
+        title=title,
+        abstract=abstract,
+        sections=[PaperSection(title=t, body_markdown=b) for t, b in sections],
+        references=["[1] Smith 2020"],
+        figure_refs=[],
+    )
+
+
+# --- sensitivity ----------------------------------------------------------
+
+
+def test_sensitivity_passes_bar_when_three_params_perturbed() -> None:
+    body = (
+        "Sensitivity Analysis. We perturbed α by ±10% and observed a 4.3% change in objective.\n"
+        "We perturbed β by ±20% (objective shifted 7.1%). For γ at ±10%, the result was 1.2%.\n"
+        "See [[FIG:tornado_sensitivity]] for the tornado plot and Monte Carlo N=2000."
+    )
+    p = _draft([("Sensitivity Analysis", body)])
+    findings = mine_sensitivity_evidence(p)
+    assert findings.has_sensitivity_section
+    assert findings.parameter_count_estimate >= 3
+    assert findings.perturb_mention_count >= 3
+    assert findings.tornado_or_mc_referenced
+    assert findings.passes_award_bar()
+    assert sensitivity_criteria(findings) == []
+
+
+def test_sensitivity_misses_when_no_section() -> None:
+    p = _draft([("Conclusion", "We did not analyze sensitivity.")])
+    findings = mine_sensitivity_evidence(p)
+    assert not findings.has_sensitivity_section
+    crits = sensitivity_criteria(findings)
+    assert any("BLOCKING" in c for c in crits)
+    assert any("Sensitivity Analysis" in c for c in crits)
+
+
+def test_sensitivity_misses_when_fewer_than_3_params() -> None:
+    body = "Sensitivity Analysis. We perturbed α by ±10% and saw 2% change. That was it."
+    p = _draft([("Sensitivity Analysis", body)])
+    findings = mine_sensitivity_evidence(p)
+    assert findings.has_sensitivity_section
+    assert findings.parameter_count_estimate < 3
+    crits = sensitivity_criteria(findings)
+    assert any("only ~1 parameter" in c or "only ~2 parameter" in c or "≥3" in c for c in crits)
+
+
+def test_sensitivity_finds_cn_heading() -> None:
+    body = "我们对参数 α 增减 10% 进行扰动，目标变化 4.3%。对 β 增减 20%，变化 7.1%。对 γ 增减 10%，变化 1.5%。"
+    p = _draft([("敏感性分析", body)])
+    findings = mine_sensitivity_evidence(p)
+    assert findings.has_sensitivity_section
+
+
+# --- anonymity ------------------------------------------------------------
+
+
+def test_anonymity_flags_chinese_university_name() -> None:
+    p = _draft(
+        [("Intro", "Our team from 吉林大学 has worked on this problem.")],
+        abstract="Clean abstract.",
+    )
+    findings = scan_anonymity_violations(p)
+    assert findings.has_violations
+    assert any("吉林大学" in snip for _, snip in findings.violations)
+    crits = anonymity_criteria(findings)
+    assert any("DISQUALIFICATION" in c for c in crits)
+
+
+def test_anonymity_flags_english_university_name_in_abstract() -> None:
+    p = _draft([("body", "model.")], abstract="From Jilin University we studied...")
+    findings = scan_anonymity_violations(p)
+    assert findings.has_violations
+
+
+def test_anonymity_flags_advisor_in_references() -> None:
+    p = PaperDraft(
+        title="T",
+        abstract="abs",
+        sections=[PaperSection(title="x", body_markdown="y")],
+        references=["指导教师：张教授. 数学建模指南. 2021."],
+        figure_refs=[],
+    )
+    findings = scan_anonymity_violations(p)
+    assert findings.has_violations
+
+
+def test_anonymity_clean_paper_passes() -> None:
+    p = _draft(
+        [("Body", "Team # 12345 modeled X with parameter α. No school mentioned.")],
+        abstract="Clean: predicted error 3.2%, fuel saved 17%.",
+    )
+    findings = scan_anonymity_violations(p)
+    assert not findings.has_violations
+    assert anonymity_criteria(findings) == []
+
+
+def test_anonymity_short_circuits_at_5_violations() -> None:
+    body = "吉林大学 清华大学 北京大学 复旦大学 上海交通大学 浙江大学 (extra)"
+    p = _draft([("Intro", body)])
+    findings = scan_anonymity_violations(p)
+    assert len(findings.violations) <= 5

--- a/apps/agent-worker/tests/test_few_shot_loader.py
+++ b/apps/agent-worker/tests/test_few_shot_loader.py
@@ -1,0 +1,210 @@
+"""Tests for FewShotLibrary: graceful degradation + correct ranking."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from agent_worker.few_shot import (
+    Exemplar,
+    FewShotLibrary,
+    format_writer_block,
+)
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def test_missing_file_yields_empty_library(tmp_path: Path) -> None:
+    lib = FewShotLibrary.from_jsonl(tmp_path / "does_not_exist.jsonl")
+    assert len(lib) == 0
+    assert lib.top_k("mcm", "A") == []
+
+
+def test_records_without_summary_are_skipped(tmp_path: Path) -> None:
+    idx = tmp_path / "winning.jsonl"
+    _write_jsonl(
+        idx,
+        [
+            {
+                "id": "2024_A_001",
+                "year": 2024,
+                "problem_letter": "A",
+                "competition_type": "mcm",
+                "summary_text": "",  # extraction failure
+                "section_headings": [],
+            },
+            {
+                "id": "2024_A_002",
+                "year": 2024,
+                "problem_letter": "A",
+                "competition_type": "mcm",
+                "summary_text": "Real summary with numbers like 3.2% and 17 kg.",
+                "section_headings": ["Introduction", "Model"],
+            },
+        ],
+    )
+    lib = FewShotLibrary.from_jsonl(idx)
+    assert len(lib) == 1
+
+
+def test_top_k_prefers_sensitivity_then_recency(tmp_path: Path) -> None:
+    idx = tmp_path / "winning.jsonl"
+    _write_jsonl(
+        idx,
+        [
+            {
+                "id": "old_no_sens",
+                "year": 2010,
+                "problem_letter": "A",
+                "competition_type": "mcm",
+                "summary_text": "old paper",
+                "section_headings": [],
+                "has_sensitivity_section": False,
+                "has_strengths_weaknesses_section": False,
+            },
+            {
+                "id": "new_with_sens",
+                "year": 2023,
+                "problem_letter": "A",
+                "competition_type": "mcm",
+                "summary_text": "new paper with sens",
+                "section_headings": ["Sensitivity"],
+                "has_sensitivity_section": True,
+                "has_strengths_weaknesses_section": True,
+            },
+            {
+                "id": "newest_no_sens",
+                "year": 2024,
+                "problem_letter": "A",
+                "competition_type": "mcm",
+                "summary_text": "newest no sens",
+                "section_headings": [],
+                "has_sensitivity_section": False,
+                "has_strengths_weaknesses_section": False,
+            },
+        ],
+    )
+    lib = FewShotLibrary.from_jsonl(idx)
+    top = lib.top_k("mcm", "A", k=3)
+    assert [e.paper_id for e in top] == ["new_with_sens", "newest_no_sens", "old_no_sens"]
+
+
+def test_top_k_falls_through_letter_then_sibling_family(tmp_path: Path) -> None:
+    idx = tmp_path / "winning.jsonl"
+    _write_jsonl(
+        idx,
+        [
+            # MCM A — wrong letter for our query, same family
+            {
+                "id": "mcm_A",
+                "year": 2024,
+                "problem_letter": "A",
+                "competition_type": "mcm",
+                "summary_text": "MCM A",
+                "section_headings": [],
+            },
+            # ICM D — sibling family (mcm↔icm), used as 3rd-tier fallback
+            {
+                "id": "icm_D",
+                "year": 2024,
+                "problem_letter": "D",
+                "competition_type": "icm",
+                "summary_text": "ICM D",
+                "section_headings": [],
+            },
+        ],
+    )
+    lib = FewShotLibrary.from_jsonl(idx)
+    # Query: MCM problem B (no exact match). Should pull from same family first.
+    top = lib.top_k("mcm", "B", k=2)
+    ids = [e.paper_id for e in top]
+    assert ids[0] == "mcm_A"
+    # Second item should fall through to sibling family
+    assert "icm_D" in ids
+
+
+def test_normalize_family_handles_cn_aliases(tmp_path: Path) -> None:
+    idx = tmp_path / "winning.jsonl"
+    _write_jsonl(
+        idx,
+        [
+            {
+                "id": "cumcm_A",
+                "year": 2023,
+                "problem_letter": "A",
+                "competition_type": "cumcm",
+                "summary_text": "国赛 A",
+                "section_headings": [],
+            }
+        ],
+    )
+    lib = FewShotLibrary.from_jsonl(idx)
+    # raw "国赛" should map to cumcm family
+    assert lib.top_k("国赛", "A", k=1)[0].paper_id == "cumcm_A"
+    # "huashu" should fall through to sibling cumcm
+    assert lib.top_k("huashu", "A", k=1)[0].paper_id == "cumcm_A"
+
+
+def test_format_writer_block_empty_returns_empty_string() -> None:
+    assert format_writer_block([]) == ""
+
+
+def test_format_writer_block_renders_zh_header_for_cumcm() -> None:
+    ex = Exemplar(
+        paper_id="x",
+        year=2022,
+        problem_letter="A",
+        competition_type="cumcm",
+        summary_text="摘要……",
+        section_headings=("引言", "模型"),
+        has_sensitivity_section=True,
+        has_strengths_weaknesses_section=False,
+    )
+    block = format_writer_block([ex], language="zh")
+    assert "同题型获奖论文范本" in block
+    assert "✓Sensitivity" in block
+    assert "禁止抄写其文字或数据" in block
+
+
+def test_format_writer_block_renders_en_header_for_mcm() -> None:
+    ex = Exemplar(
+        paper_id="y",
+        year=2024,
+        problem_letter="C",
+        competition_type="mcm",
+        summary_text="Summary with 3.2% accuracy.",
+        section_headings=("Introduction", "Sensitivity Analysis"),
+        has_sensitivity_section=True,
+        has_strengths_weaknesses_section=True,
+    )
+    block = format_writer_block([ex], language="en")
+    assert "Award-winning exemplars" in block
+    assert "must NOT copy" in block
+    assert "✓Sensitivity" in block
+    assert "✓Strengths/Weaknesses" in block
+
+
+def test_env_override_index_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    idx = tmp_path / "custom.jsonl"
+    _write_jsonl(
+        idx,
+        [
+            {
+                "id": "env_test",
+                "year": 2024,
+                "problem_letter": "A",
+                "competition_type": "mcm",
+                "summary_text": "via env",
+                "section_headings": [],
+            }
+        ],
+    )
+    monkeypatch.setenv("MM_FEW_SHOT_INDEX", str(idx))
+    lib = FewShotLibrary.from_jsonl()  # no explicit path
+    assert len(lib) == 1
+    assert lib.top_k("mcm", "A", k=1)[0].paper_id == "env_test"

--- a/data/mcm/GAP_ANALYSIS.md
+++ b/data/mcm/GAP_ANALYSIS.md
@@ -1,0 +1,77 @@
+# Mathodology → MCM Finalist (F 奖) 差距分析
+
+> 时间：2026-05-14。基于本仓 `apps/agent-worker` + `crates/gateway` 当前 main (HEAD `423ca43`)。
+> **F 奖定位说明**：MCM 奖项金字塔从高到低为 Outstanding Winner / Finalist / Meritorious / Honorable Mention / Successful Participant。**Finalist (F 奖) ≈ Top 1-2%**，比 Meritorious 高一档，比 Outstanding 低一档。
+
+## TL;DR
+
+项目已经具备 **Outstanding-level prompt 规则** 和 **Critic 多角色复评循环**，整体骨架接近 Finalist 要求。**关键差距集中在「证据厚度」而非「框架」**：缺真实数据接入、缺得奖论文 few-shot、缺 LaTeX 编译保险、缺人工审阅闭环、单线程缺备选模型回退。下表是按 ROI 排的差距清单。
+
+## 现状（已具备 ✅）
+
+| 维度 | 现状 |
+|---|---|
+| Pipeline | Analyzer → Searcher (arXiv+OpenAlex+Crossref+Tavily+open-webSearch) → Modeler → Coder (Jupyter, 7-turn) → Writer，5 stage + Critic loop |
+| Critic | 3 角色（modeling_coach / academic_reviewer / code_reviewer），分级 blocking/major/minor，2 轮 revision，预算保护 |
+| Writer prompt | 8 条 self-check、≤1 页摘要必含 ≥2 数值、≥15 ref、Sensitivity + Strengths/Weaknesses 强制 |
+| Modeler prompt | ≥2 候选模型 + 显式判据、量纲/极限/baseline 三检查、≥3 参数 ±10/20% + Monte Carlo |
+| Coder prompt | 20 类 chart catalog、styled_figure helper、5-8 图目标、`np.random.seed` 强制 |
+| 知识库 | HMML 31 个方法 (BM25)，按 9 类目录组织 |
+| 检索 | arXiv + OpenAlex + Crossref + Tavily + open-webSearch (Baidu/CSDN/Juejin)，top-3 PDF 全文注入 |
+| 多语言 | MCM/ICM 英文 + CUMCM/华数杯 中文双轨 |
+| 导出 | paper.md → PDF 流水线（tectonic + pandoc，12 个 format×competition 组合通过） |
+
+## 差距清单（按 ROI 排序）
+
+### 🔴 P0 — 直接决定能否进 F 奖名单（核心证据厚度）
+
+| # | 差距 | 后果 | 建议 |
+|---|---|---|---|
+| 1 | **没有真实数据接入** | MCM 现代题 (2018+) 普遍带 CSV/Excel/Image 附件；现在 Coder 只能"模拟数据"，判分被打骨折 | 加一个 **DataLoader agent**：解析附件→pandas DataFrame→schema 报告，喂给 Coder。能跟 Analyzer 的 `data_requirements` 闭环 |
+| 2 | **没有得奖论文 few-shot** | Prompt 全是抽象规则，LLM 缺"长这样才叫一等奖"的具象锚点；中等模型生成结果偏 Meritorious | 把刚下载的 dick20 (~150+ 篇 Outstanding/Finalist) 切片：抽 abstract、目录、sensitivity 章节做 BM25/向量库，Writer/Modeler prompt 注入 top-3 同题型示例 |
+| 3 | **Coder 7-turn 硬上限 + 单 Jupyter** | F 奖论文常有 8-15 图 + 二级模型；7 turn 不够，大数据集本地 Jupyter OOM | turn 上限按问题难度自适应 (5-12)；接 E2B/Daytona 云端 sandbox（roadmap 已列 Phase 4） |
+| 4 | **没有 PDF compile 早期失败检测** | tectonic 编译失败 ≠ 论文失败，但流水线只在最后一步 compile，错了无法回滚 | Writer 输出后立刻 dry-compile（quick mode），失败把错误回给 Writer 做 revision；F 奖必须有可读 PDF |
+| 5 | **Sensitivity 是建议、不是验收门** | Critic 会查"Sensitivity 章节存在"，不查"参数 ±20% 时目标变化率被报告" | Critic 加 evidence-mining：抓 `tornado_sensitivity` 图 + 章节内 "%" 数字、不达 ≥3 个参数就 blocking |
+
+### 🟠 P1 — 拉开 F 奖与 M 奖距离（说服力 + 完整性）
+
+| # | 差距 | 后果 | 建议 |
+|---|---|---|---|
+| 6 | **Modeler 只锁一个 chosen_approach** | F 奖论文常做 Model I/II 对比 (Pareto on 复杂度 vs 精度)；现在只比"在 rationale 里口头比" | Modeler 可选 dual-track：return `chosen_approach` + `baseline_approach`，Coder 同时跑两份，Writer 在 Results 章节对比 |
+| 7 | **缺人工/模型审阅"模拟判官"** | Critic 3 角色都看模型自身视角；MCM 判官关心 "5 分钟读完抓不抓得到亮点" | 加一个 **Judge-simulation pass**：截取 Title+Abstract+前 2 页+图 caption，让模型扮演 "10 分钟流水线评审"，强制选 keep/discard。低于阈值触发 Writer revision |
+| 8 | **没有 ICM 专用 prompt 分支** | ICM (C/D/E/F) 强调 policy/societal impact，跟 MCM 的 hard-modeling 不一样；当前 Writer prompt 是统一模板 | `competition_type` 加 `icm_d` / `icm_e` / `icm_f` 子分支，加 ICM 专用 rubric (stakeholder analysis、policy recommendations、ethical considerations) |
+| 9 | **References 数量 ≥15 是硬约束，但来源同质** | Searcher 偏向 arXiv；F 奖偏好工业报告/政府数据/经典教材的多元引用 | Searcher 加来源配额：≥30% 非 arXiv（政府/NGO/经典文献），数据集引用单独成行 |
+| 10 | **没有自动 plagiarism / anonymity 体检** | 校名/地名/姓名一次违反 = 直接 DQ；当前只在 prompt 里告诫 | 加 post-process regex+NER 扫描器，扫学校词典、中国地名词典、姓名词典，违规直接 fail run |
+
+### 🟡 P2 — 完成度抛光（不是 F 奖门槛但能提分）
+
+| # | 差距 | 建议 |
+|---|---|---|
+| 11 | 摘要质量没有独立打分 | 单独跑 abstract-quality model 打分（结构、数字、kicker），低分 revise |
+| 12 | 图表跟正文不互文 | Critic 加 `figure-discussion-coverage` 检查（每个 `[[FIG:<id>]]` 周围 ±200 字符必须出现 caption 里的数字 token） |
+| 13 | 没有 30/60/90 分钟 milestone | MCM 真实场景 = 3 天 96 小时；可以加预算 budget tracker (cost_rmb + 实际 wall clock)，在 25%/50%/75% 时 emit milestone |
+| 14 | LaTeX 模板没有官方 mcmthesis | yicheng 仓库里就有 `美赛LaTex模板/mcmthesis`，可以直接采用，比 pandoc default 更接近真实提交格式 |
+| 15 | 没有"提交前打包"步骤 | F 奖提交 = 控制号 + PDF + 代码 + summary；当前只产 paper.pdf，缺一键提交包 |
+
+## 已下载得奖论文 + 题目语料（本次新增）
+
+存放位置：`data/mcm/`（已加入 .gitignore 建议）
+
+| 来源 | 内容 | 用途 |
+|---|---|---|
+| `repos/dick20/` (2.3k★) | MCM/ICM 2004-2025 Outstanding (PDF + MATLAB/TeX) | **few-shot 主库**（差距 #2） |
+| `repos/guanglun/` (365★) | 2023-2026 winning papers + 源码 | 最新年份覆盖 |
+| `repos/yicheng/` (68★) | 2012-2016 Outstanding 论文集 + mcmthesis 模板 + 算法大全 | 模板（差距 #14） |
+| `comap_problems/` | 1999-2025 官方题目 PDF + judge commentary PDF | Analyzer 输入素材 / Critic 评分基准 |
+| `early_problems/` | 1985-1999 早期题目 PDF | 题目库完整性 |
+
+## 推荐落地顺序
+
+1. **本周（差距 #2 + #14）**：把 dick20 论文按"年份/题目/主题"切片做 BM25 索引，Writer prompt 加 top-3 同题型 abstract+目录 注入。同时切换 mcmthesis 模板。
+2. **下周（差距 #1 + #4）**：DataLoader agent；Writer 后挂 dry-compile gate。
+3. **再下周（差距 #5 + #7 + #10）**：Critic 加 evidence-mining + judge-simulation；anonymity 扫描器作 fail-fast gate。
+4. **Phase 4 一并（差距 #3）**：云沙箱（E2B/Daytona）。
+
+---
+
+**Why this matters**：F 奖年度全球只有约 1-2% 的队伍能拿到（按 2024 数据约 100-200 篇 / 全球 14000+ 队），它的门槛不是"会写论文"，而是"在 3 天内拿出可读、可信、可复现、亮点鲜明的论文"。我们目前的 prompt 已经在"会写"层面追上了，但**亮点鲜明 = 真实数据 + 充分敏感性 + 独到对比** 是当前最大欠缺。

--- a/data/mcm/README.md
+++ b/data/mcm/README.md
@@ -1,0 +1,146 @@
+# MCM/ICM 历年得奖论文 + 题目语料 (3.2G)
+
+> 2026-05-14 批量下载，三仓 git clone 合并。用途：(1) 为 Writer/Modeler prompt 注入 few-shot 同题型 abstract+sensitivity 章节示例；(2) 给 Critic 做"判官视角"的 anchor；(3) Coder 直接读真实数据附件做实验。
+
+## 奖项覆盖（重要）
+
+**本语料同时包含 O 奖 + F 奖 + 其它奖**，且 **O 奖（Outstanding Winner，特等奖）是绝对主体**。
+
+| 奖项 | 中文 | 全球获奖率 | 在本语料中的位置 |
+|---|---|---|---|
+| **Outstanding Winner** | **O 奖 / 特等奖** | ~0.2-0.5% | **dick20 主目录 + yicheng 全部，~500+ 篇**（主体） |
+| **Finalist** | **F 奖** | ~1-2% | dick20 `其他奖项/*-Finalist.pdf`（明确标 3 篇，更多与 O 奖混存在 `A/B/C/D/E/F/`） |
+| Meritorious | M 奖 / 一等奖 | ~7-9% | dick20 `其他奖项/` 部分；非主要 |
+| Honorable Mention | H 奖 / 二等奖 | ~21% | 不收 |
+| Successful Participant | S 奖 | rest | 不收 |
+
+> ⚠️ **dick20 / yicheng 命名"特等奖"= Outstanding Winner**。但 COMAP 实际每年每题只评 1-2 篇 Outstanding（全年合计约 30-40 篇），仓库里 502 篇 PDF 远超此数 — 所以 `YYYY美赛特等奖/A/B/C/.../` 子目录里**实际是 Outstanding + Finalist 合集**（中文圈把 F 奖也常归为"特等奖级别"）。判官评语 (`Results/*_Judges_Commentary_*.pdf`) 里有 Outstanding 队伍的 control number，可以反向精确切分。
+
+## 总量
+
+| 项 | 数量 |
+|---|---|
+| 论文/题目 PDF 总数 | **651** |
+| O 奖 + F 奖论文（2004-2025，22 年） | ~500 |
+| 题目 PDF（problem statements） | **67** |
+| 数据附件（CSV / XLSX / ZIP） | **34** |
+| 文件名带 "Finalist" 字样 | 3（其余 F 奖论文与 O 奖混在 `A/B/...` 目录） |
+| 总占用 | **3.2 GB** |
+
+## 仓库结构
+
+```
+data/mcm/
+├── GAP_ANALYSIS.md            ← 差距分析（项目→F 奖距离 + ROI 排序的 15 项 backlog）
+├── README.md                  ← 本文件
+├── logs/                      ← 旧抓取日志（COMAP 直抓失败，已 pivot 到 git clone）
+└── repos/
+    ├── dick20/   (2.1 GB, 502 PDFs)   ← 主语料：2004-2025 美赛特等奖
+    ├── guanglun/ (886 MB,  49 PDFs)   ← 2023-2026 + 源码 + 图素材
+    └── yicheng/  (265 MB, 100 PDFs)   ← 2012-2016 + mcmthesis LaTeX 模板
+```
+
+### `repos/dick20/` （核心语料）
+
+22 个年度目录，每年命名 `YYYY美赛特等奖/`：
+
+```
+2024美赛特等奖/
+├── problems/                     ← 题目 PDF + 真实数据附件
+│   ├── 2024_MCM_Problem_A_FINAL.pdf
+│   ├── 2024_MCM_Problem_C_FINAL.pdf
+│   ├── 2024_ICM_Problem_D_FINAL.pdf
+│   ├── Problem_D_Addendum.pdf
+│   ├── Problem_D_Great_Lakes.xlsx   ← 真实附件！
+│   ├── Wimbledon_featured_matches.csv
+│   └── data_dictionary.csv
+├── A/   ← 该年 A 题 Outstanding 论文（PDF 命名为 control number, e.g. 2425397.pdf）
+├── B/
+├── C/
+└── ...
+```
+
+**目录组织随年份演化**：
+- **2004-2009**：扁平 + `Results/` 子目录（含 Judge Commentary）
+- **2010-2017**：按题目 letter (`A题5篇/` 或 `A/`) 分；早期年份题目 PDF 在 `Results/`
+- **2018**：`2018_MCM-ICM_Problems/` 单独目录放题目
+- **2019**：`2019_MCM-ICM_Problems/` + 数据附件 (`ACS_*_DP02.zip`, `MCM_NFLIS_Data.xlsx`)
+- **2020+**：`problems/` 统一目录；`A/B/C/D/E/F/` 平铺论文
+
+**每年 Outstanding 论文数**：
+```
+2004:  5    2010: 17    2016: 37    2022: 50
+2005:  5    2011: 18    2017: 27    2023: 37
+2006: 12    2012: 21    2018: 38    2024: 12 (incomplete)
+2007: 10    2013: 17    2019: 41    2025:  8 (incomplete)
+2008:  7    2014: 25    2020: 37
+2009:  6    2015: 29    2021: 43
+```
+
+**精确切分 O 奖 vs F 奖（如果需要）**：
+- 文件名带 `-Finalist` 的明确是 F 奖（仅 3 篇，2011/2013/2015 各 1 篇）
+- 文件名是纯 control number（如 `2425397.pdf`）的需要交叉对照 `Results/*_Judges_Commentary*.pdf`：评语里点名的队伍 = Outstanding；其余按"特等奖"目录收录的 = Finalist
+- 对**当前用途（prompt few-shot）**：O 奖 + F 奖论文质量足够接近，**无须区分**，直接全用即可
+
+### `repos/guanglun/` （最新年份 + 源码）
+
+```
+guanglun/
+├── 2023_MCM_Problem_B.pdf
+├── 2023美赛B题-中文.pdf
+├── 2316192.pdf                   ← 一篇 2023 完整论文
+├── Code/                          ← Python 源码
+├── Data/                          ← 数据集
+├── Figure/                        ← 图素材库（生化环材类/机器学习/prize 三类）
+├── Word/                          ← Word 草稿
+├── AI-Report-2024/                ← 2024 年作者用 AI 协作的 report
+└── Note/
+    ├── 近年优秀论文资源/
+    └── O奖得主分享材料/            ← 西电 O 奖 2020 + 福州大学 O 奖 2022
+```
+
+### `repos/yicheng/` （早期 + 模板）
+
+```
+yicheng/
+├── 2012美国大学生数学建模特等奖论文集/
+├── 2013美国大学生数学建模特等奖论文集/
+├── 2014美国大学生数学建模特等奖论文集/
+├── 2015美国大学生数学建模特等奖论文集/
+├── 2016美国大学生数学建模特等奖论文集/
+├── 美赛LaTex模板/mcmthesis/        ← 真实 mcmthesis 模板（差距分析 #14 建议采用）
+└── 算法大全pdf/                    ← 司守奎《数学建模算法与应用》PDF
+```
+
+## 重新生成 / 更新
+
+```bash
+cd data/mcm/repos
+git -C dick20    pull   # 增量更新
+git -C guanglun  pull
+git -C yicheng   pull
+```
+
+## 缺失的部分
+
+- **1985-2003 题目 + 论文**：COMAP 把题目搬到 `comap.org/membership/member-resources/...` 会员墙；论文从未公开
+- **2024-2025 完整 Outstanding 集**：dick20 还在收集中（2024 只有 12 篇，2025 只有 8 篇）；guanglun 补一部分但不全
+- **题目 PDF 完整度**：67 个题目 PDF 覆盖 2010-2025（每年 6 题 × 16 年 = 96，差 ~30 个）；2004-2009 题目大多只能从 Outstanding 论文的 "Problem Statement" 章节反推
+
+## .gitignore 建议
+
+3.2G 不适合入库。建议项目根 `.gitignore` 追加：
+```
+data/mcm/repos/
+data/mcm/logs/
+```
+仅提交 `GAP_ANALYSIS.md` 和 `README.md`。
+
+## 下一步使用（对照 GAP_ANALYSIS.md）
+
+| 差距编号 | 操作 |
+|---|---|
+| #2（缺得奖论文 few-shot） | 用 dick20 / yicheng 切片：`pdfplumber` 提 abstract，按 (year, problem_letter, prize_level) 索引到 HMML 或新建 `award_corpus/` 表 |
+| #14（mcmthesis 模板） | 把 `yicheng/美赛LaTex模板/mcmthesis/` 拷到 `apps/agent-worker/.../prompts/templates/` 替换 pandoc default |
+| #1（真实数据接入） | DataLoader agent 读 `dick20/YYYY美赛特等奖/problems/*.{csv,xlsx,zip}` 做训练用例 |
+| #10（anonymity 扫描） | 用 dick20 论文 ground truth 反向验证（这些都是去名版本，不应误报） |

--- a/data/mcm/scripts/build_index.py
+++ b/data/mcm/scripts/build_index.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python3
+"""Build few-shot exemplar index from MCM/ICM winning-paper PDFs in dick20.
+
+Outputs:
+  - data/mcm/index/winning_papers.jsonl   one record per winning paper
+  - data/mcm/index/problems.jsonl         one record per problem statement
+  - data/mcm/index/STATS.md               counts + extraction failures
+
+Pure heuristic extraction (no LLM). Designed for ~502 PDFs in dick20.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import traceback
+from collections import Counter, defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import Optional
+
+import pdfplumber
+
+ROOT = Path("/Users/cornna/project/math_agent/data/mcm/repos/dick20")
+INDEX_DIR = Path("/Users/cornna/project/math_agent/data/mcm/index")
+INDEX_DIR.mkdir(parents=True, exist_ok=True)
+
+WINNING_OUT = INDEX_DIR / "winning_papers.jsonl"
+PROBLEMS_OUT = INDEX_DIR / "problems.jsonl"
+STATS_OUT = INDEX_DIR / "STATS.md"
+
+# Problem PDFs we want to skip from the winning-papers index.
+PROBLEM_FILENAME_RE = re.compile(
+    r"(?:MCM|ICM)[-_ ]?(?:Problem|2\d{3})|Problem[-_ ]?[A-F][_.]|"
+    r"Judges?_Commentary|Press|Results|Addendum|Contest_AI_Policy|SubProcess",
+    re.IGNORECASE,
+)
+# Letter subdir names we recognise.
+LETTER_DIR_RE = re.compile(r"^(?:MCM|ICM)?20\d{2}?([A-F])$|^([A-F])$|^([A-F])题\d+篇$")
+# 2018 zh style: "A题5篇"
+# 2019 zh style: "MCM2019A", "ICM2019D"
+
+PROBLEM_DIR_NAMES = {
+    "problems",
+    "2018_MCM-ICM_Problems",
+    "2019_MCM-ICM_Problems",
+    "Results",
+    "其他奖项",
+}
+# Year directory regex: "2024美赛特等奖"
+YEAR_DIR_RE = re.compile(r"^(20\d{2})美赛特等奖$")
+
+# Letter inference from filename for flat-year layouts.
+FILENAME_LETTER_RE = re.compile(r"^([A-F])(?:[-_类]|\d)", re.IGNORECASE)
+# Control number inference (5-7 digits anywhere; pick longest match early)
+CONTROL_NUMBER_RE = re.compile(r"\b(\d{4,7})\b")
+
+# Heading-related regexes.
+SUMMARY_PAT = re.compile(
+    r"(?im)^[ \t]*(?:Executive\s+)?(?:Summary(?:\s*Sheet)?|Abstract)\s*[:\n]"
+)
+HEADING_LINE_RE = re.compile(
+    r"^\s*((?:[0-9]+\.)?[0-9]+)(?:\s+|\.\s*)"
+    r"([A-Z][A-Za-z][^\n]{2,80})\s*$"
+)
+SENSITIVITY_RE = re.compile(r"sensitivity\s+analys", re.IGNORECASE)
+STRENGTHS_RE = re.compile(
+    r"strengths?\s*(?:&|and|/)\s*weakness|strengths?\s*and\s*weakness",
+    re.IGNORECASE,
+)
+NUMBERED_REF_RE = re.compile(r"\[\d{1,3}\]")
+AUTHOR_YEAR_RE = re.compile(r"\(([A-Z][a-zA-Z\-']+(?:\s+et\s+al\.?)?,?\s*\d{4}[a-z]?)\)")
+
+LETTERS = {"A", "B", "C", "D", "E", "F"}
+
+
+def comp_type(letter: str) -> str:
+    return "mcm" if letter in {"A", "B"} else "icm"
+
+
+def infer_letter(name: str, parent: str) -> Optional[str]:
+    """Try parent-dir then filename to detect problem letter."""
+    parent = parent.strip()
+    # parent like 'A', 'B', 'C', 'D', 'E', 'F'
+    if parent in LETTERS:
+        return parent
+    # zh: 'A题5篇'
+    m = re.match(r"^([A-F])题\d+篇$", parent)
+    if m:
+        return m.group(1)
+    # 2019: 'MCM2019A', 'ICM2019D'
+    m = re.match(r"^(?:MCM|ICM)20\d{2}([A-F])$", parent)
+    if m:
+        return m.group(1)
+    # filename starts like 'A-6749' or 'A76082' or 'A类-O奖--55069.pdf'
+    m = FILENAME_LETTER_RE.match(name)
+    if m:
+        return m.group(1).upper()
+    return None
+
+
+def infer_control_number(name: str) -> str:
+    """Find a control-number-looking integer in filename."""
+    # Strip extension
+    base = re.sub(r"\.pdf$", "", name, flags=re.IGNORECASE)
+    # Try patterns like '2425397', 'A-6749-Outstanding', 'A76082-...', 'A类-O奖--55069'
+    nums = re.findall(r"\d{4,7}", base)
+    if not nums:
+        return ""
+    # Pick the longest number (control numbers are typically 4-7 digits;
+    # 6-7 digits for modern years, 3-5 for older)
+    nums.sort(key=lambda s: (-len(s), -int(s)))
+    return nums[0]
+
+
+def looks_like_problem_pdf(name: str) -> bool:
+    """Heuristic: is this a problem-statement PDF rather than a winning paper?"""
+    return bool(PROBLEM_FILENAME_RE.search(name))
+
+
+def find_summary(text: str) -> str:
+    """Locate Summary/Abstract section in extracted text. Returns up to 2000 chars."""
+    if not text:
+        return ""
+    m = SUMMARY_PAT.search(text)
+    snippet = ""
+    if m:
+        start = m.end()
+        snippet = text[start : start + 2500].strip()
+    else:
+        # Fallback 1: look for the word "Summary" mid-line (e.g. "Summary Sheet").
+        idx = text.lower().find("summary sheet")
+        if idx >= 0:
+            after = text[idx:].split("\n", 1)
+            snippet = after[1].strip() if len(after) > 1 else ""
+        else:
+            idx = text.lower().find("abstract")
+            if idx >= 0:
+                snippet = text[idx + len("abstract") :].strip()
+
+    # Fallback 2: older papers may not have an Abstract — grab first
+    # substantial paragraph after an "Introduction" heading.
+    if not snippet or len(snippet) < 80:
+        intro = re.search(
+            r"(?im)^\s*(?:I\.\s*|1\s+|1\.\s*)?Introduction\b\s*\n", text
+        )
+        if intro:
+            tail = text[intro.end() : intro.end() + 3000]
+            snippet = tail.strip()
+
+    if not snippet:
+        return ""
+
+    # Trim to first "Introduction"/"Contents"/"Keywords" boundary if reached
+    for boundary in [
+        re.compile(r"\n\s*(?:1\s+|1\.\s*)?(?:Introduction|Contents)\b", re.IGNORECASE),
+        re.compile(r"\n\s*Keywords?\s*[:：]", re.IGNORECASE),
+    ]:
+        bm = boundary.search(snippet)
+        if bm and bm.start() > 200:
+            snippet = snippet[: bm.start()].strip()
+            break
+    # Normalize whitespace.
+    snippet = re.sub(r"[ \t]+", " ", snippet)
+    snippet = re.sub(r"\n{3,}", "\n\n", snippet)
+    snippet = snippet.strip()
+    # Reject obviously useless snippets (just dotted-leaders from TOC).
+    if snippet.count(".") > len(snippet) * 0.3:
+        return ""
+    return snippet[:2000].strip()
+
+
+def find_headings(text: str) -> list[str]:
+    """Detect numbered top-level headings (e.g. '1 Introduction', '3 Model')."""
+    if not text:
+        return []
+    headings: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for line in text.split("\n"):
+        line = line.strip()
+        # Skip lines that look like TOC entries (dotted leaders, trailing page #).
+        if "..." in line or re.search(r"\.{4,}\s*\d+$", line):
+            continue
+        m = HEADING_LINE_RE.match(line)
+        if not m:
+            continue
+        num, title = m.group(1), m.group(2).strip()
+        # Only top-level (single number) headings, e.g. '1', '2', not '2.1'.
+        if "." in num:
+            continue
+        # Strip trailing page numbers e.g. "Introduction 5"
+        title = re.sub(r"\s+\d{1,3}$", "", title)
+        if title.endswith("."):
+            title = title[:-1]
+        if len(title) < 3 or len(title) > 70:
+            continue
+        # de-dup on lowercased title
+        key = title.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        headings.append((num, title))
+    # Cap at 20.
+    return [t for _, t in headings[:20]]
+
+
+def count_refs(text: str) -> int:
+    if not text:
+        return 0
+    n1 = len(NUMBERED_REF_RE.findall(text))
+    n2 = len(AUTHOR_YEAR_RE.findall(text))
+    return n1 + n2
+
+
+def extract_text(pdf_path: Path, max_pages: int = 60) -> tuple[int, str, str]:
+    """Return (n_pages, head_text, full_text_capped).
+
+    head_text = first 3 pages (for summary/title)
+    full_text_capped = first max_pages pages joined (for headings/sensitivity/refs)
+    """
+    with pdfplumber.open(str(pdf_path)) as pdf:
+        n = len(pdf.pages)
+        head_parts: list[str] = []
+        full_parts: list[str] = []
+        for i, page in enumerate(pdf.pages[:max_pages]):
+            try:
+                t = page.extract_text() or ""
+            except Exception:
+                t = ""
+            full_parts.append(t)
+            if i < 3:
+                head_parts.append(t)
+        head = "\n".join(head_parts)
+        full = "\n".join(full_parts)
+    return n, head, full
+
+
+_TITLE_BLOCKLIST_RE = re.compile(
+    r"^(Team|For\s+office|Problem|MCM|ICM|20\d{2}|T\d|F\d|\d{4,7}|_+|Page\b|"
+    r"Contents\b|Table\s+of|Summary\b|Abstract\b|February|January|March|April|"
+    r"May|June|July|August|September|October|November|December|"
+    r"Mathematical\s+Contest|Group\s*#)",
+    re.IGNORECASE,
+)
+
+
+def guess_title(head_text: str) -> str:
+    """Heuristic title: line above 'Summary'/'Abstract' or the first all-caps-ish line."""
+    if not head_text:
+        return ""
+    lines = [ln.strip() for ln in head_text.split("\n")]
+    # Look for line right above Abstract/Summary
+    for i, ln in enumerate(lines):
+        if re.match(r"^(?:Executive\s+)?(?:Summary(?:\s*Sheet)?|Abstract)\s*$", ln, re.IGNORECASE):
+            # Look back up to 8 lines for a meaty title
+            for j in range(i - 1, max(0, i - 9), -1):
+                cand = lines[j].strip()
+                if 8 < len(cand) < 120 and not _TITLE_BLOCKLIST_RE.match(cand):
+                    if not cand.endswith("________________"):
+                        return cand
+            break
+    # Fallback: first line longer than 10 chars not matching boilerplate
+    for ln in lines[:30]:
+        if 10 < len(ln) < 120 and not _TITLE_BLOCKLIST_RE.match(ln):
+            return ln
+    return ""
+
+
+def process_winning_paper(
+    pdf_path: str, year: int, parent: str
+) -> tuple[Optional[dict], Optional[str]]:
+    """Extract a single winning paper record. Returns (record, error)."""
+    p = Path(pdf_path)
+    name = p.name
+    letter = infer_letter(name, parent)
+    cn = infer_control_number(name)
+    try:
+        n_pages, head, full = extract_text(p)
+    except Exception as e:
+        return None, f"{pdf_path}: extract failed: {e}"
+
+    # Prefer head (first 3 pages) when it contains a Summary/Abstract heading;
+    # otherwise scan a larger window of full text for fallback strategies.
+    summary_source = head if SUMMARY_PAT.search(head or "") else full[:12000]
+    summary = find_summary(summary_source)
+    headings = find_headings(full)
+    title = guess_title(head)
+    rid = f"{year}_{letter or 'X'}_{cn or 'unknown'}"
+    record = {
+        "id": rid,
+        "year": year,
+        "problem_letter": letter,
+        "competition_type": comp_type(letter) if letter else None,
+        "path": str(p),
+        "pages": n_pages,
+        "title": title,
+        "summary_text": summary,
+        "section_headings": headings,
+        "has_sensitivity_section": bool(SENSITIVITY_RE.search(full)),
+        "has_strengths_weaknesses_section": bool(STRENGTHS_RE.search(full)),
+        "ref_count_estimate": count_refs(full),
+    }
+    return record, None
+
+
+def process_problem_pdf(
+    pdf_path: str, year: int, letter: Optional[str]
+) -> tuple[Optional[dict], Optional[str]]:
+    p = Path(pdf_path)
+    try:
+        with pdfplumber.open(str(p)) as pdf:
+            n_pages = len(pdf.pages)
+            parts = []
+            for page in pdf.pages[:8]:
+                try:
+                    parts.append(page.extract_text() or "")
+                except Exception:
+                    parts.append("")
+            text = "\n".join(parts).strip()
+    except Exception as e:
+        return None, f"{pdf_path}: extract failed: {e}"
+
+    # Look up sibling data files
+    data_files: list[str] = []
+    siblings = list(p.parent.iterdir())
+    for s in siblings:
+        if s.is_file() and s.suffix.lower() in {".csv", ".xlsx", ".zip", ".xls"}:
+            data_files.append(str(s))
+    record = {
+        "year": year,
+        "problem_letter": letter,
+        "competition_type": comp_type(letter) if letter else None,
+        "path": str(p),
+        "pages": n_pages,
+        "problem_text": text[:8000],
+        "data_files": sorted(data_files),
+    }
+    return record, None
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_files() -> tuple[list[tuple[str, int, str]], list[tuple[str, int, Optional[str]]]]:
+    """Walk dick20 corpus and return (winning_paper_tasks, problem_tasks)."""
+    winning: list[tuple[str, int, str]] = []  # (path, year, parent_name)
+    problems: list[tuple[str, int, Optional[str]]] = []  # (path, year, letter)
+
+    for year_dir in sorted(ROOT.iterdir()):
+        if not year_dir.is_dir():
+            continue
+        m = YEAR_DIR_RE.match(year_dir.name)
+        if not m:
+            continue
+        year = int(m.group(1))
+
+        for root, dirs, files in os.walk(year_dir):
+            rel_root = Path(root)
+            parent_name = rel_root.name
+            # Decide if this dir is a problem dir
+            is_problem_dir = parent_name in PROBLEM_DIR_NAMES
+            is_other_award_dir = parent_name == "其他奖项"
+            # Skip 其他奖项: per README those are not Outstanding/Finalist papers
+            # we want for few-shot. We'll keep them anyway since user said
+            # "winning papers" broadly. README says we just need O+F so skip.
+            if is_other_award_dir:
+                # Skip these papers for the index per spec
+                # (they're Meritorious/Honorable, not our target)
+                dirs[:] = []
+                continue
+
+            for fname in files:
+                if not fname.lower().endswith(".pdf"):
+                    continue
+                full = str(rel_root / fname)
+
+                if is_problem_dir:
+                    # Skip judges commentaries, addenda, AI policy, sub-process docs
+                    if re.search(
+                        r"Judges?_Commentary|Commentary|Addendum|Contest_AI_Policy|"
+                        r"SubProcess|Results|Press",
+                        fname,
+                        re.IGNORECASE,
+                    ):
+                        continue
+                    # try to find problem letter
+                    # filename patterns:
+                    #   2024_MCM_Problem_A_FINAL.pdf
+                    #   2024_ICM_Problem_D_FINAL.pdf
+                    #   2018_ICM_Problem_D.pdf
+                    #   2010_MCM_Problem_A.pdf  (in Results/)
+                    #   2011-Problem-A.pdf
+                    mlet = re.search(
+                        r"Problem[_\- ]?([A-F])(?:[_\- .]|$)", fname, re.IGNORECASE
+                    )
+                    if mlet:
+                        problems.append((full, year, mlet.group(1).upper()))
+                    # else skip: it's a results / commentary / press file
+                    continue
+
+                # Otherwise: candidate winning paper
+                if looks_like_problem_pdf(fname):
+                    # Skip judge triage guides / commentaries / press releases etc.
+                    if re.search(
+                        r"Triage|Judges?_Commentary|Commentary|Press|Results|"
+                        r"Addendum|AI_Policy|SubProcess|Tips",
+                        fname,
+                        re.IGNORECASE,
+                    ):
+                        continue
+                    # Edge case: in flat-year dir, problem-statement PDFs sometimes appear at top level
+                    mlet = re.search(
+                        r"Problem[_\- ]?([A-F])(?:[_\- .]|$)", fname, re.IGNORECASE
+                    )
+                    if mlet:
+                        problems.append((full, year, mlet.group(1).upper()))
+                    continue
+
+                winning.append((full, year, parent_name))
+
+    return winning, problems
+
+
+# ---------------------------------------------------------------------------
+# Workers (top-level for ProcessPoolExecutor pickling)
+# ---------------------------------------------------------------------------
+
+def _worker_winning(args):
+    pdf_path, year, parent = args
+    try:
+        return process_winning_paper(pdf_path, year, parent)
+    except Exception as e:
+        return None, f"{pdf_path}: worker exception: {e}\n{traceback.format_exc()}"
+
+
+def _worker_problem(args):
+    pdf_path, year, letter = args
+    try:
+        return process_problem_pdf(pdf_path, year, letter)
+    except Exception as e:
+        return None, f"{pdf_path}: worker exception: {e}\n{traceback.format_exc()}"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    t0 = time.time()
+    winning_tasks, problem_tasks = discover_files()
+    print(
+        f"Discovered {len(winning_tasks)} winning-paper PDFs, "
+        f"{len(problem_tasks)} problem PDFs",
+        flush=True,
+    )
+
+    winning_records: list[dict] = []
+    winning_errors: list[str] = []
+
+    problem_records: list[dict] = []
+    problem_errors: list[str] = []
+
+    # Use a process pool for parallel PDF parsing
+    max_workers = max(2, (os.cpu_count() or 4) - 1)
+    print(f"Using {max_workers} workers", flush=True)
+
+    with ProcessPoolExecutor(max_workers=max_workers) as ex:
+        futures = {ex.submit(_worker_winning, t): t for t in winning_tasks}
+        done = 0
+        total = len(futures)
+        for fut in as_completed(futures):
+            rec, err = fut.result()
+            done += 1
+            if err:
+                winning_errors.append(err)
+            if rec:
+                winning_records.append(rec)
+            if done % 50 == 0 or done == total:
+                print(
+                    f"  winning: {done}/{total} (ok={len(winning_records)}, err={len(winning_errors)})",
+                    flush=True,
+                )
+
+    with ProcessPoolExecutor(max_workers=max_workers) as ex:
+        futures = {ex.submit(_worker_problem, t): t for t in problem_tasks}
+        done = 0
+        total = len(futures)
+        for fut in as_completed(futures):
+            rec, err = fut.result()
+            done += 1
+            if err:
+                problem_errors.append(err)
+            if rec:
+                problem_records.append(rec)
+            if done % 20 == 0 or done == total:
+                print(
+                    f"  problems: {done}/{total} (ok={len(problem_records)}, err={len(problem_errors)})",
+                    flush=True,
+                )
+
+    # Sort outputs for determinism
+    winning_records.sort(key=lambda r: (r.get("year", 0), r.get("problem_letter") or "Z", r.get("id") or ""))
+    problem_records.sort(key=lambda r: (r.get("year", 0), r.get("problem_letter") or "Z"))
+
+    with WINNING_OUT.open("w", encoding="utf-8") as f:
+        for r in winning_records:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    with PROBLEMS_OUT.open("w", encoding="utf-8") as f:
+        for r in problem_records:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    # Stats
+    by_year_total: Counter = Counter()
+    by_year_with_summary: Counter = Counter()
+    by_letter: Counter = Counter()
+    sens_count = 0
+    sw_count = 0
+    title_count = 0
+    no_letter = 0
+    summary_empty: list[str] = []
+    for r in winning_records:
+        y = r["year"]
+        by_year_total[y] += 1
+        if r["summary_text"]:
+            by_year_with_summary[y] += 1
+        else:
+            summary_empty.append(r["path"])
+        let = r.get("problem_letter") or "?"
+        by_letter[let] += 1
+        if let == "?":
+            no_letter += 1
+        if r.get("has_sensitivity_section"):
+            sens_count += 1
+        if r.get("has_strengths_weaknesses_section"):
+            sw_count += 1
+        if r.get("title"):
+            title_count += 1
+
+    n_w = len(winning_records)
+    n_p = len(problem_records)
+    pct_summary = 100.0 * sum(by_year_with_summary.values()) / n_w if n_w else 0.0
+    elapsed = time.time() - t0
+
+    # Build markdown stats
+    lines: list[str] = []
+    lines.append("# MCM/ICM dick20 corpus index — STATS")
+    lines.append("")
+    lines.append(f"- Generated: {time.strftime('%Y-%m-%d %H:%M:%S')}  ")
+    lines.append(f"- Elapsed: {elapsed:.1f}s  ")
+    lines.append(f"- Source root: `{ROOT}`  ")
+    lines.append("")
+    lines.append("## Overview")
+    lines.append("")
+    lines.append(f"- Winning papers indexed: **{n_w}**  ")
+    lines.append(f"- Winning papers with non-empty summary: **{sum(by_year_with_summary.values())}** ({pct_summary:.1f}%)  ")
+    lines.append(f"- Winning papers with title: **{title_count}**  ")
+    lines.append(f"- Winning papers with sensitivity section: **{sens_count}**  ")
+    lines.append(f"- Winning papers with strengths/weaknesses section: **{sw_count}**  ")
+    lines.append(f"- Winning papers with no detectable problem letter: **{no_letter}**  ")
+    lines.append(f"- Problem PDFs indexed: **{n_p}**  ")
+    lines.append("")
+    lines.append("## Papers by year")
+    lines.append("")
+    lines.append("| Year | Total | With summary | % |")
+    lines.append("|------|-------|--------------|---|")
+    for y in sorted(by_year_total):
+        tot = by_year_total[y]
+        wsum = by_year_with_summary[y]
+        pct = 100.0 * wsum / tot if tot else 0
+        lines.append(f"| {y} | {tot} | {wsum} | {pct:.0f}% |")
+    lines.append("")
+    lines.append("## Papers by problem letter")
+    lines.append("")
+    lines.append("| Letter | Type | Count |")
+    lines.append("|--------|------|-------|")
+    for let in sorted(by_letter):
+        ct = comp_type(let) if let in LETTERS else "?"
+        lines.append(f"| {let} | {ct} | {by_letter[let]} |")
+    lines.append("")
+    lines.append("## Problem statements by year")
+    lines.append("")
+    p_by_year: Counter = Counter()
+    p_by_letter: Counter = Counter()
+    for r in problem_records:
+        p_by_year[r["year"]] += 1
+        p_by_letter[r.get("problem_letter") or "?"] += 1
+    lines.append("| Year | Count |")
+    lines.append("|------|-------|")
+    for y in sorted(p_by_year):
+        lines.append(f"| {y} | {p_by_year[y]} |")
+    lines.append("")
+    lines.append("## Problem statements by letter")
+    lines.append("")
+    lines.append("| Letter | Count |")
+    lines.append("|--------|-------|")
+    for let in sorted(p_by_letter):
+        lines.append(f"| {let} | {p_by_letter[let]} |")
+    lines.append("")
+    lines.append(f"## Extraction failures ({len(winning_errors)} winning, {len(problem_errors)} problems)")
+    lines.append("")
+    if winning_errors:
+        lines.append("### Winning-paper failures")
+        for e in winning_errors[:40]:
+            lines.append(f"- {e}")
+        if len(winning_errors) > 40:
+            lines.append(f"- ... and {len(winning_errors) - 40} more")
+        lines.append("")
+    if problem_errors:
+        lines.append("### Problem-PDF failures")
+        for e in problem_errors[:20]:
+            lines.append(f"- {e}")
+        lines.append("")
+    lines.append(f"## Papers with empty summary_text ({len(summary_empty)})")
+    lines.append("")
+    for path in summary_empty[:40]:
+        lines.append(f"- {path}")
+    if len(summary_empty) > 40:
+        lines.append(f"- ... and {len(summary_empty) - 40} more")
+    lines.append("")
+    lines.append("## Outputs")
+    lines.append("")
+    lines.append(f"- `{WINNING_OUT}`")
+    lines.append(f"- `{PROBLEMS_OUT}`")
+    lines.append("")
+
+    STATS_OUT.write_text("\n".join(lines), encoding="utf-8")
+
+    # Print final summary
+    print()
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"Winning papers indexed: {n_w}")
+    print(f"  with non-empty summary_text: {sum(by_year_with_summary.values())} ({pct_summary:.1f}%)")
+    print(f"  with sensitivity section: {sens_count}")
+    print(f"  with strengths/weaknesses section: {sw_count}")
+    print(f"Problem PDFs indexed: {n_p}")
+    print()
+    print("By year (papers / with_summary):")
+    for y in sorted(by_year_total):
+        print(f"  {y}: {by_year_total[y]:4d}  ({by_year_with_summary[y]:4d} w/summary)")
+    print()
+    print("By letter:")
+    for let in sorted(by_letter):
+        print(f"  {let}: {by_letter[let]}")
+    print()
+    print(f"Failures: {len(winning_errors)} winning, {len(problem_errors)} problems")
+    print(f"Elapsed: {elapsed:.1f}s")
+    print()
+    print(f"Wrote: {WINNING_OUT}")
+    print(f"Wrote: {PROBLEMS_OUT}")
+    print(f"Wrote: {STATS_OUT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Bundle four award-quality improvements from `data/mcm/GAP_ANALYSIS.md` — directly addresses **P0 #2 / #5 / #10** and **P1 #8** in one coherent vertical slice. Targets MCM Outstanding / Finalist + CUMCM 一等奖 quality.

### What changed

- **Few-shot exemplars** (`few_shot/loader.py` + agent wiring): `FewShotLibrary` loads **364 O/F-prize paper abstracts** indexed by (competition_family, problem_letter). Writer + Modeler inject top-2 same-problem-type exemplars; 4-tier fallback (exact → same family → sibling family → any). Empty index → silent degradation.
- **Deterministic evidence-mining** (`agents/evidence.py`): runs between Writer.run_for() and Critic.review().
  - `mine_sensitivity_evidence`: regex-counts perturbed parameters at ±N%. Fewer than 3 → BLOCKING criterion appended.
  - `scan_anonymity_violations`: 28 universities (CN/EN) + 11 regions + 3 author-style patterns. Any hit → "DISQUALIFICATION RISK" criterion (MCM/CUMCM rules instant-DQ on identity leak).
  - Findings flow into the Critic's `context.evidence_scan` and additional `criteria` strings, so the Critic enforces real facts about the body text, not its self-report.
- **CUMCM/华数杯 branched prompt rules** (`prompts/writer/v1.toml`): 25-page limit, 承诺书 in `sections[0]`, **GB/T 7714 sequential numbering** (no author-year), 3-5 keywords, 推广 paragraph; double-language structural-anchors table.
- **Award-paper exemplars guidance for Modeler** (`prompts/modeler/v1.toml`): use prior winning chosen_approach as anchor (without copying) for rationale depth and sensitivity-plan ambition.

### Why now

The `data/mcm/` corpus (3.2 GB, 22 years of MCM/ICM) landed in the previous turn but was unused. Prompt rules in `project_award_mode` (memory) gave abstract guidance only; this PR makes them concrete by injecting prior-year exemplars and giving the Critic deterministic numbers to score against. Pre-existing Critic checklist had every `passed` field LLM-self-reported; we now augment it with regex truth-claims about the artifact.

### Files
- New: `agents/evidence.py`, `few_shot/{__init__,loader}.py`, `tests/test_evidence_mining.py`, `tests/test_few_shot_loader.py`, `data/mcm/{GAP_ANALYSIS.md,README.md,scripts/build_index.py}`
- Modified: `agents/{writer,modeler}.py`, `pipeline.py`, `prompts/{writer,modeler}/v1.toml`, `.gitignore`
- `data/mcm/repos/` (3.2 GB winning-paper corpus) and `data/mcm/index/` (offline-built JSONL) remain gitignored.

## Test plan

- [x] `uv run --frozen pytest apps/agent-worker` — **339 passed, 1 deselected** (+18 new tests in this PR)
- [x] `uvx ruff check apps/agent-worker/src apps/agent-worker/tests` — clean
- [x] FewShotLibrary smoke-test against real index — loads 364 exemplars, top_k MCM A returns 3 2024 papers all with sensitivity sections
- [ ] End-to-end run on a real MCM problem (follow-up — out of scope for this PR; live LLM keys required)

## Out of scope (next phase)
- P0 #1 DataLoader agent (real CSV/XLSX attachment parsing)
- P0 #4 dry-compile gate (worker-side LaTeX try-compile before `done` event)
- P2 #14 mcmthesis template replacement (yicheng .cls + tectonic font compatibility)