### PR TITLE
feat: MATLAB/Octave backend + Phase-3 quality (stacked on #27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ data/mcm/repos/
 data/mcm/logs/
 data/mcm/index/
 data/mcm/scripts/__pycache__/
+data/cumcm/repos/

--- a/apps/agent-worker/src/agent_worker/agents/base.py
+++ b/apps/agent-worker/src/agent_worker/agents/base.py
@@ -38,7 +38,7 @@ class BaseAgent:
         gateway: GatewayClient,
         emitter: EventEmitter,
         prompt_version: str = "v1",
-        run_effort: ReasoningEffort = "medium",
+        run_effort: ReasoningEffort = "high",
         long_context: bool = False,
         model_override: str | None = None,
     ) -> None:
@@ -166,7 +166,13 @@ class BaseAgent:
         critique: CritiqueReport,
         context: dict[str, Any],
     ) -> BaseModel:
-        """Ask the producing agent to revise its own structured output once."""
+        """Ask the producing agent to revise its own structured output.
+
+        Mirrors `run()`'s parse-retry-once policy: long-generation runs on
+        some models (e.g. gpt-5.5) occasionally emit token-level corruption
+        in the JSON stream. Without retry, a single bad reroll fails the
+        whole pipeline. We do one retry with the parse error appended.
+        """
         model = self._model_override or self.prompt.model_preference[0]
         messages: list[dict[str, Any]] = [
             {"role": "system", "content": self.prompt.system["text"]},
@@ -186,8 +192,27 @@ class BaseAgent:
                 ),
             },
         ]
-        text = await self._stream_and_collect(model, messages)
-        return self._parse_output(text)
+        last_err: Exception | None = None
+        for _attempt in range(2):
+            try:
+                text = await self._stream_and_collect(model, messages)
+                return self._parse_output(text)
+            except AgentParseError as e:
+                last_err = e
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            f"Your previous revision could not be parsed as JSON "
+                            f"matching {self.OUTPUT_MODEL.__name__}. Error: {e}. "
+                            f"Return ONLY a valid JSON object this time, "
+                            f"with all field names quoted correctly and no token-level corruption."
+                        ),
+                    }
+                )
+        raise AgentError(
+            f"{self.AGENT_NAME} revision produced unparseable output after 2 attempts"
+        ) from last_err
 
 
 async def _stream_with_retry(
@@ -204,11 +229,13 @@ async def _stream_with_retry(
 ) -> str:
     """Stream + collect with retries against upstream flakiness.
 
-    Handles two failure modes uniformly:
+    Handles three failure modes uniformly:
     - Transport exceptions from httpx (RemoteProtocolError / ReadTimeout /
       ConnectError / PoolTimeout)
     - Empty stream completion: 200 OK with zero content deltas (seen on
       cornna/gpt-5.4 intermittently)
+    - HTTP 5xx from the gateway (upstream provider timeout / network error
+      surfaces as 502/503/504; we treat these as transient and retry)
 
     Backoff schedule: 0s, 5s, 15s, 30s before attempts 1..4. Shared by
     BaseAgent subclasses and CoderAgent (which does not inherit BaseAgent).
@@ -258,6 +285,12 @@ async def _stream_with_retry(
             httpx.ConnectError,
             httpx.PoolTimeout,
         ) as e:
+            last_err = e
+        except httpx.HTTPStatusError as e:
+            # 5xx → upstream had a transient problem; retry. 4xx is our bug
+            # (auth, malformed request) and should fail loud, not retry.
+            if e.response.status_code < 500:
+                raise
             last_err = e
     raise AgentError(
         f"{agent_name} stream failed after {len(BACKOFFS)} attempts: {last_err}"

--- a/apps/agent-worker/src/agent_worker/agents/coder.py
+++ b/apps/agent-worker/src/agent_worker/agents/coder.py
@@ -33,6 +33,7 @@ from agent_worker.chart_catalog import render_index_markdown
 from agent_worker.events import EventEmitter
 from agent_worker.gateway_client import GatewayClient
 from agent_worker.kernel import KernelSession
+from agent_worker.matlab import MatlabSession
 from agent_worker.prompts import load_prompt
 
 # Iteration budget for the Coder loop. Originally 3 (MVP), bumped to 7 so the
@@ -66,6 +67,12 @@ class CoderDirective(BaseModel):
     # these IDs and only verifies the PNG exists on disk; missing files are
     # dropped with a warning so one bad savefig doesn't kill the run.
     figures_saved: list[FigureMeta] = Field(default_factory=list)
+    # Which backend to route this turn's code to. "python" (default) executes
+    # in the persistent Jupyter kernel; "matlab" hands the source to
+    # MatlabSession (matlab -batch in prod, octave --no-gui in dev). State
+    # does NOT persist across MATLAB turns — use .mat files for handoff.
+    # Unknown values are normalized to "python" by the agent.
+    language: str = "python"
 
 
 class CoderAgent:
@@ -80,13 +87,17 @@ class CoderAgent:
         emitter: EventEmitter,
         kernel: KernelSession,
         prompt_version: str = "v1",
-        run_effort: ReasoningEffort = "medium",
+        run_effort: ReasoningEffort = "high",
         long_context: bool = False,
         model_override: str | None = None,
+        matlab_session: MatlabSession | None = None,
     ) -> None:
         self.gateway = gateway
         self.emitter = emitter
         self.kernel = kernel
+        # Optional MATLAB backend. None → directive.language='matlab' degrades
+        # to an error-typed CellExecution so the model can recover next turn.
+        self.matlab_session = matlab_session
         self.prompt = load_prompt(self.AGENT_NAME, prompt_version)
         self._run_effort: ReasoningEffort = run_effort
         self._long_context: bool = long_context
@@ -140,14 +151,38 @@ class CoderAgent:
             for i in range(max_iterations):
                 directive = await self._ask_llm(model, messages)
 
+                lang = (directive.language or "python").lower()
+                if lang not in ("python", "matlab"):
+                    lang = "python"
                 await self.emitter.emit(
                     "log",
-                    {"level": "info", "message": f"executing cell {i}"},
+                    {
+                        "level": "info",
+                        "message": f"executing cell {i} [{lang}]",
+                    },
                     agent=self.AGENT_NAME,
                 )
-                cell = await self.kernel.execute(
-                    directive.code, cell_index=i, emitter=self.emitter
-                )
+                if lang == "matlab":
+                    if self.matlab_session is None:
+                        cell = CellExecution(
+                            index=i,
+                            source=directive.code,
+                            language="matlab",
+                            error=(
+                                "MATLAB backend not provisioned for this run; "
+                                "switch to language='python' or install MATLAB/Octave."
+                            ),
+                        )
+                    else:
+                        cell = await self.matlab_session.execute(
+                            directive.code, cell_index=i, emitter=self.emitter
+                        )
+                        cell.language = "matlab"
+                else:
+                    cell = await self.kernel.execute(
+                        directive.code, cell_index=i, emitter=self.emitter
+                    )
+                    cell.language = "python"
                 cells.append(cell)
                 # Register figures the LLM claims to have saved, guarded by
                 # on-disk existence: LLMs occasionally hallucinate a savefig.
@@ -157,6 +192,8 @@ class CoderAgent:
                         continue
                     png_rel = f"figures/{fm.id}.png"
                     svg_rel = f"figures/{fm.id}.svg"
+                    # Both backends share the same run_dir/figures/ tree, so
+                    # this lookup is correct regardless of which one wrote it.
                     png_abs = self.kernel.run_dir / png_rel
                     if not png_abs.is_file():
                         await self.emitter.emit(

--- a/apps/agent-worker/src/agent_worker/agents/critic.py
+++ b/apps/agent-worker/src/agent_worker/agents/critic.py
@@ -68,7 +68,7 @@ class CriticAgent(BaseAgent):
         gateway: GatewayClient,
         emitter: EventEmitter,
         prompt_version: str = "v1",
-        run_effort: ReasoningEffort = "medium",
+        run_effort: ReasoningEffort = "high",
         long_context: bool = False,
         model_override: str | None = None,
     ) -> None:

--- a/apps/agent-worker/src/agent_worker/agents/modeler.py
+++ b/apps/agent-worker/src/agent_worker/agents/modeler.py
@@ -58,7 +58,7 @@ class ModelerAgent(BaseAgent):
         emitter: EventEmitter,
         hmml: HMMLService | None = None,
         prompt_version: str = "v1",
-        run_effort: ReasoningEffort = "medium",
+        run_effort: ReasoningEffort = "high",
         long_context: bool = False,
         model_override: str | None = None,
         few_shot_library: FewShotLibrary | None = None,

--- a/apps/agent-worker/src/agent_worker/agents/searcher.py
+++ b/apps/agent-worker/src/agent_worker/agents/searcher.py
@@ -161,7 +161,7 @@ class SearcherAgent:
         gateway: GatewayClient,
         emitter: EventEmitter,
         prompt_version: str = "v1",
-        run_effort: ReasoningEffort = "medium",
+        run_effort: ReasoningEffort = "high",
         long_context: bool = False,
         model_override: str | None = None,
         runs_dir: Path | None = None,

--- a/apps/agent-worker/src/agent_worker/agents/writer.py
+++ b/apps/agent-worker/src/agent_worker/agents/writer.py
@@ -69,7 +69,7 @@ class WriterAgent(BaseAgent):
         gateway: GatewayClient,
         emitter: EventEmitter,
         prompt_version: str = "v1",
-        run_effort: ReasoningEffort = "medium",
+        run_effort: ReasoningEffort = "high",
         long_context: bool = False,
         model_override: str | None = None,
         run_dir: Path | None = None,

--- a/apps/agent-worker/src/agent_worker/config.py
+++ b/apps/agent-worker/src/agent_worker/config.py
@@ -30,6 +30,18 @@ class Settings(BaseSettings):
     worker_concurrency: int = Field(default=2, alias="WORKER_CONCURRENCY")
     runs_dir: str = Field(default="./runs", alias="RUNS_DIR")
 
+    # --- PDF auto-export --------------------------------------------------
+    # After the Writer produces paper.md, the worker calls the gateway's
+    # /export/pdf endpoint and writes paper.pdf into the run dir. The PDF
+    # path is then included in the terminal `done` event. Failure does NOT
+    # fail the run — paper.md remains the source of truth.
+    auto_export_pdf: bool = Field(default=True, alias="MM_AUTO_EXPORT_PDF")
+    # tectonic cold-start downloads ~200 MB of TeXLive on the first compile;
+    # subsequent runs are ~30-60s. Allow a generous ceiling.
+    auto_export_timeout_s: float = Field(
+        default=600.0, alias="MM_AUTO_EXPORT_TIMEOUT_S"
+    )
+
     # --- open-webSearch MCP (Searcher auxiliary retrieval) ----------------
     # Node CLI that speaks MCP over stdio. Defaults to the binary on PATH;
     # absolute path (e.g. /opt/homebrew/bin/open-websearch) is fine too.

--- a/apps/agent-worker/src/agent_worker/events.py
+++ b/apps/agent-worker/src/agent_worker/events.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 from uuid import UUID
 
@@ -12,6 +13,22 @@ from redis.asyncio import Redis
 
 EVENTS_MAXLEN = 5000
 
+# Event kinds persisted to disk for post-mortem. Token events are deliberately
+# excluded — they dominate volume (~100k+ per run on long generations) and add
+# no forensic value vs the aggregated cost / agent.output events.
+_PERSISTED_KINDS: frozenset[str] = frozenset(
+    {
+        "stage.start",
+        "stage.done",
+        "agent.output",
+        "error",
+        "log",
+        "cost",
+        "done",
+        "kernel.figure",
+    }
+)
+
 
 class EventEmitter:
     """Per-run event emitter.
@@ -20,14 +37,25 @@ class EventEmitter:
     INCR, which is the single source of truth shared with the Rust gateway's
     token/cost fan-out. The in-memory `_seq` attribute caches the last value
     we received for logging only.
+
+    When `events_log_path` is set, non-token events are also appended to a
+    JSONL file. Redis stream capping (MAXLEN=5000) drops ~96% of events on
+    long generations, so the JSONL is the forensic source of truth; the
+    Redis stream is for live WS replay only.
     """
 
-    def __init__(self, redis: Redis, run_id: UUID) -> None:
+    def __init__(
+        self,
+        redis: Redis,
+        run_id: UUID,
+        events_log_path: Path | None = None,
+    ) -> None:
         self._redis = redis
         self._run_id = run_id
         self._stream_key = f"mm:events:{run_id}"
         self._seq_key = f"mm:seq:{run_id}"
         self._seq = 0
+        self._events_log_path = events_log_path
 
     @property
     def run_id(self) -> UUID:
@@ -53,7 +81,17 @@ class EventEmitter:
             ts=datetime.now(UTC),
             payload=payload or {},
         )
-        body = orjson.dumps(event.model_dump(mode="json")).decode("utf-8")
+        dumped = event.model_dump(mode="json")
+        body = orjson.dumps(dumped).decode("utf-8")
+        # Persist forensic events to disk before the Redis stream MAXLEN
+        # rolls them off. Failures here must NOT block the live stream.
+        if self._events_log_path is not None and kind in _PERSISTED_KINDS:
+            try:
+                with self._events_log_path.open("ab") as f:  # noqa: ASYNC230
+                    f.write(orjson.dumps(dumped))
+                    f.write(b"\n")
+            except OSError:
+                pass
         return await self._redis.xadd(
             self._stream_key,
             {"payload": body},

--- a/apps/agent-worker/src/agent_worker/gateway_client.py
+++ b/apps/agent-worker/src/agent_worker/gateway_client.py
@@ -33,6 +33,32 @@ class GatewayClient:
     async def close(self) -> None:
         await self._client.aclose()
 
+    async def export_paper(
+        self,
+        *,
+        run_id: UUID,
+        format: str,
+        template: str | None = None,
+        compile_timeout_s: float = 300.0,
+    ) -> bytes:
+        """Fetch a rendered paper artifact (pdf/tex/docx/md) as raw bytes.
+
+        Long timeout because tectonic's first invocation downloads ~200 MB
+        of TeXLive bundles. Subsequent runs are ~30-60s.
+        """
+        url = f"{self._base}/runs/{run_id}/export/{format}"
+        params: dict[str, str] = {}
+        if template:
+            params["template"] = template
+        resp = await self._client.get(
+            url,
+            headers=self._headers,
+            params=params or None,
+            timeout=httpx.Timeout(compile_timeout_s, connect=5.0, read=compile_timeout_s),
+        )
+        resp.raise_for_status()
+        return resp.content
+
     def _build_headers(self, run_id: UUID, agent: str) -> dict[str, str]:
         return {
             **self._headers,

--- a/apps/agent-worker/src/agent_worker/matlab/__init__.py
+++ b/apps/agent-worker/src/agent_worker/matlab/__init__.py
@@ -1,0 +1,30 @@
+"""MATLAB/Octave execution layer for the Coder agent.
+
+Mirrors the Jupyter `KernelSession` API so the Coder can run MATLAB-style
+code blocks alongside Python ones. Backend selection is automatic:
+real MATLAB (`matlab -batch`) is preferred, Octave (`octave --no-gui`)
+is the fallback, and a NoOp backend reports a graceful error when
+neither is installed.
+"""
+
+from __future__ import annotations
+
+from agent_worker.matlab.backends import (
+    BackendUnavailable,
+    MatlabBackend,
+    MatlabBatchBackend,
+    NoOpBackend,
+    OctaveCliBackend,
+    detect_backend,
+)
+from agent_worker.matlab.session import MatlabSession
+
+__all__ = [
+    "BackendUnavailable",
+    "MatlabBackend",
+    "MatlabBatchBackend",
+    "MatlabSession",
+    "NoOpBackend",
+    "OctaveCliBackend",
+    "detect_backend",
+]

--- a/apps/agent-worker/src/agent_worker/matlab/backends.py
+++ b/apps/agent-worker/src/agent_worker/matlab/backends.py
@@ -1,0 +1,197 @@
+"""Subprocess backends for MATLAB / Octave execution.
+
+Each backend exposes a single coroutine `run(code, cwd, timeout_s)` that
+returns `(stdout, stderr, exit_code)`. Backends never raise on user code
+errors — they propagate the exit code so the caller can build a
+`CellExecution` record. They DO raise `BackendUnavailable` if the
+underlying binary disappears between detection and run-time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import shutil
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+from uuid import uuid4
+
+
+class BackendUnavailable(RuntimeError):
+    """Raised when the chosen backend's binary is not on PATH at run-time."""
+
+
+@runtime_checkable
+class MatlabBackend(Protocol):
+    """Protocol every concrete backend must satisfy."""
+
+    name: str
+
+    async def run(
+        self,
+        code: str,
+        cwd: Path,
+        timeout_s: float,
+    ) -> tuple[str, str, int]:
+        """Execute `code` in `cwd` and return (stdout, stderr, exit_code).
+
+        Implementations must kill the subprocess on `timeout_s` and surface
+        a non-zero exit code with a descriptive stderr message rather than
+        bubbling `TimeoutError`.
+        """
+        ...
+
+
+async def _run_subprocess(
+    argv: list[str],
+    cwd: Path,
+    timeout_s: float,
+) -> tuple[str, str, int]:
+    """Spawn `argv`, capture stdout/stderr, kill on timeout.
+
+    Returns (stdout, stderr, exit_code). A timeout yields exit_code=124
+    (the conventional shell value for `timeout(1)`) and an explanatory
+    stderr suffix.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        cwd=str(cwd),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout_s
+        )
+    except TimeoutError:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        return (
+            "",
+            f"execution timed out after {timeout_s:.1f}s",
+            124,
+        )
+    return (
+        stdout_b.decode("utf-8", errors="replace"),
+        stderr_b.decode("utf-8", errors="replace"),
+        proc.returncode if proc.returncode is not None else -1,
+    )
+
+
+class MatlabBatchBackend:
+    """Runs code via `matlab -batch`. Each call writes a temp `.m` file."""
+
+    name = "matlab"
+
+    async def run(
+        self,
+        code: str,
+        cwd: Path,
+        timeout_s: float,
+    ) -> tuple[str, str, int]:
+        binary = shutil.which("matlab")
+        if binary is None:
+            raise BackendUnavailable("matlab binary not found on PATH")
+        # MATLAB -batch wants a function/script name, not a path. We add the
+        # parent dir to the MATLAB path and call by stem to keep the command
+        # portable when cwd contains spaces.
+        script = cwd / f"_mm_exec_{uuid4().hex}.m"
+        script.write_text(code, encoding="utf-8")
+        try:
+            stem = script.stem
+            argv = [
+                binary,
+                "-batch",
+                f"addpath('{cwd}'); {stem}",
+            ]
+            return await _run_subprocess(argv, cwd, timeout_s)
+        finally:
+            with contextlib.suppress(OSError):
+                script.unlink()
+
+
+class OctaveCliBackend:
+    """Runs code via `octave --no-gui --quiet <script.m>`.
+
+    The `.m` script is preferred over `--eval` because it survives quotes
+    and newlines in user code. `graphics_toolkit("gnuplot")` is prepended
+    so headless plot calls don't crash on macOS / Linux without a display.
+    """
+
+    name = "octave"
+
+    # Wrapped in try/catch so a missing gnuplot install doesn't abort
+    # plot-free scripts. When gnuplot IS available this still selects it,
+    # which is what we want for headless rendering on macOS / Linux.
+    _PREAMBLE = (
+        'try; graphics_toolkit("gnuplot"); catch; end_try_catch;\n'
+    )
+
+    async def run(
+        self,
+        code: str,
+        cwd: Path,
+        timeout_s: float,
+    ) -> tuple[str, str, int]:
+        binary = shutil.which("octave")
+        if binary is None:
+            raise BackendUnavailable("octave binary not found on PATH")
+        script = cwd / f"_mm_exec_{uuid4().hex}.m"
+        script.write_text(self._PREAMBLE + code, encoding="utf-8")
+        try:
+            argv = [
+                binary,
+                "--no-gui",
+                "--quiet",
+                str(script),
+            ]
+            return await _run_subprocess(argv, cwd, timeout_s)
+        finally:
+            with contextlib.suppress(OSError):
+                script.unlink()
+
+
+class NoOpBackend:
+    """Sentinel backend used when no MATLAB-compatible runtime is present.
+
+    Returns a synthetic failure rather than raising so the session can
+    build a `CellExecution` with a friendly error message.
+    """
+
+    name = "noop"
+
+    async def run(
+        self,
+        code: str,
+        cwd: Path,
+        timeout_s: float,
+    ) -> tuple[str, str, int]:
+        # Trivial await to keep this honestly async — and to make sure the
+        # event loop gets a chance to schedule other tasks.
+        await asyncio.sleep(0)
+        del code, cwd, timeout_s
+        return ("", "MATLAB/Octave not installed", 127)
+
+
+def detect_backend() -> MatlabBackend:
+    """Pick the best available backend.
+
+    Order: MATLAB (proprietary, better fidelity) → Octave → NoOp.
+    """
+    if shutil.which("matlab") is not None:
+        return MatlabBatchBackend()
+    if shutil.which("octave") is not None:
+        return OctaveCliBackend()
+    return NoOpBackend()
+
+
+__all__ = [
+    "BackendUnavailable",
+    "MatlabBackend",
+    "MatlabBatchBackend",
+    "NoOpBackend",
+    "OctaveCliBackend",
+    "detect_backend",
+]

--- a/apps/agent-worker/src/agent_worker/matlab/session.py
+++ b/apps/agent-worker/src/agent_worker/matlab/session.py
@@ -1,0 +1,184 @@
+"""`MatlabSession` — one run's MATLAB/Octave working directory.
+
+Mirrors `KernelSession.execute()` so the CoderAgent can dispatch to either
+backend without branching. The session owns a `<runs_dir>/<run_id>/matlab/`
+working directory and emits the same event kinds as the Jupyter path
+(`kernel.stdout`, `kernel.figure`, `kernel.error`, `log`).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from mm_contracts import CellExecution
+
+from agent_worker.matlab.backends import MatlabBackend, detect_backend
+
+if TYPE_CHECKING:
+    from agent_worker.events import EventEmitter
+
+
+# Match the Jupyter session — 4 KB per stdout chunk so large prints stream
+# rather than land in a single jumbo event.
+_STDOUT_CHUNK_SIZE = 4096
+# Stderr tail size sent in kernel.error.traceback. Anything longer makes the
+# event payload unwieldy and the live UI truncates it anyway.
+_STDERR_TAIL = 2000
+
+
+class MatlabSession:
+    """One MATLAB/Octave working directory per run.
+
+    Constructing a session is cheap: it makes the working dir and figures
+    dir on disk but does not spawn any subprocess. The backend is only
+    invoked on `execute()`.
+    """
+
+    def __init__(
+        self,
+        run_id: UUID,
+        runs_dir: Path,
+        backend: MatlabBackend | None = None,
+    ) -> None:
+        self._run_id = run_id
+        self.run_dir = (Path(runs_dir) / str(run_id)).resolve()
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        # IMPORTANT: backend cwd is the run_dir itself (NOT the matlab/
+        # subdir). That way the same `figures/<id>.png` relative path the
+        # Coder prompt uses for Python (`plt.savefig('figures/...')`) also
+        # works verbatim from MATLAB/Octave. The matlab/ subdir is only a
+        # scratch space for the generated _mm_exec_*.m file.
+        self._tmp_dir = (self.run_dir / "matlab").resolve()
+        self._tmp_dir.mkdir(parents=True, exist_ok=True)
+        self._cwd = self.run_dir
+        self.figures_dir = self.run_dir / "figures"
+        self.figures_dir.mkdir(parents=True, exist_ok=True)
+        self._backend = backend if backend is not None else detect_backend()
+
+    # ------------------------------------------------------------------ accessors
+
+    @property
+    def run_id(self) -> UUID:
+        return self._run_id
+
+    @property
+    def backend_name(self) -> str:
+        return self._backend.name
+
+    @property
+    def cwd(self) -> Path:
+        return self._cwd
+
+    # ------------------------------------------------------------------ execute
+
+    async def execute(
+        self,
+        source: str,
+        cell_index: int,
+        emitter: EventEmitter,
+        timeout_s: float = 60.0,
+    ) -> CellExecution:
+        """Run one MATLAB/Octave code block and return a `CellExecution`."""
+        await emitter.emit(
+            "log",
+            {
+                "level": "info",
+                "message": (
+                    f"matlab cell {cell_index} executing via {self._backend.name}"
+                ),
+            },
+            agent="coder",
+        )
+
+        before = _snapshot_dir(self.figures_dir)
+        t0 = time.monotonic()
+        error: str | None = None
+        try:
+            stdout, stderr, exit_code = await self._backend.run(
+                source, self._cwd, timeout_s
+            )
+        except Exception as exc:  # noqa: BLE001 — surface backend errors as cells
+            stdout = ""
+            stderr = f"{type(exc).__name__}: {exc}"
+            exit_code = 1
+            error = stderr
+        duration_ms = int((time.monotonic() - t0) * 1000)
+
+        # Stream stdout in chunks so consumers see progress on long prints.
+        if stdout:
+            for chunk in _chunks(stdout, _STDOUT_CHUNK_SIZE):
+                await emitter.emit(
+                    "kernel.stdout",
+                    {
+                        "text": chunk,
+                        "name": "stdout",
+                        "cell_index": cell_index,
+                    },
+                    agent="coder",
+                )
+
+        # Figures: diff the figures dir snapshot, in deterministic order.
+        after = _snapshot_dir(self.figures_dir)
+        new_files = sorted(after - before)
+        figure_paths: list[str] = []
+        for fname in new_files:
+            rel = f"figures/{fname}"
+            figure_paths.append(rel)
+            await emitter.emit(
+                "kernel.figure",
+                {"path": rel, "cell_index": cell_index, "format": "png"},
+                agent="coder",
+            )
+
+        # Non-zero exit code → emit a kernel.error event. Use the tail of
+        # stderr (rather than the whole thing) to keep the payload small.
+        if exit_code != 0:
+            if error is None:
+                error = (
+                    stderr.strip() if stderr.strip() else f"exit code {exit_code}"
+                )
+            await emitter.emit(
+                "kernel.error",
+                {
+                    "traceback": stderr[-_STDERR_TAIL:],
+                    "exit_code": exit_code,
+                    "cell_index": cell_index,
+                },
+                agent="coder",
+            )
+
+        return CellExecution(
+            index=cell_index,
+            source=source,
+            stdout=stdout,
+            stderr=stderr,
+            result_text=None,
+            figure_paths=figure_paths,
+            error=error,
+            duration_ms=duration_ms,
+        )
+
+
+# ---------------------------------------------------------------------- helpers
+
+
+def _snapshot_dir(path: Path) -> set[str]:
+    """Return the set of filenames directly under `path` (no recursion)."""
+    try:
+        return set(os.listdir(path))
+    except FileNotFoundError:
+        return set()
+
+
+def _chunks(text: str, size: int) -> list[str]:
+    """Split `text` into `size`-byte slices. Returns at least one chunk."""
+    if size <= 0:
+        return [text]
+    return [text[i : i + size] for i in range(0, len(text), size)] or [""]
+
+
+__all__ = ["MatlabSession"]

--- a/apps/agent-worker/src/agent_worker/pipeline.py
+++ b/apps/agent-worker/src/agent_worker/pipeline.py
@@ -62,6 +62,7 @@ from agent_worker.events import EventEmitter
 from agent_worker.gateway_client import GatewayClient
 from agent_worker.hmml import HMMLService
 from agent_worker.kernel import KernelSession
+from agent_worker.matlab import MatlabSession
 
 _log = logging.getLogger(__name__)
 
@@ -181,11 +182,22 @@ async def _review_and_maybe_revise(
         if loop_cost_rmb + revision_cost_rmb > policy.max_revision_cost_rmb:
             report.budget_exhausted = True
             break
-        current = await producer.revise_with_critique(
-            original_output=current,
-            critique=report,
-            context=context,
-        )
+        try:
+            current = await producer.revise_with_critique(
+                original_output=current,
+                critique=report,
+                context=context,
+            )
+        except AgentError as exc:
+            # Revision call failed (transient network / parse). Don't sink the
+            # whole run — keep the last valid `current` and abandon revision.
+            _log.warning(
+                "revise_with_critique for %s failed at round %d; keeping prior output: %s",
+                target_agent,
+                revision_round,
+                exc,
+            )
+            break
         loop_cost_rmb += revision_cost_rmb
         if loop_cost_rmb + review_cost_rmb > policy.max_revision_cost_rmb:
             report.budget_exhausted = True
@@ -259,12 +271,23 @@ async def _review_and_maybe_rerun_coder(
             original_output=current,
             critique=report,
         )
-        current = await coder.run(
-            revision_problem,
-            analysis,
-            spec,
-            max_iterations=policy.coder_revision_iterations,
-        )
+        try:
+            current = await coder.run(
+                revision_problem,
+                analysis,
+                spec,
+                max_iterations=policy.coder_revision_iterations,
+            )
+        except AgentError as exc:
+            # Coder rerun crashed (often upstream LLM disconnect). The prior
+            # `current` already contains a notebook + figures, so it's strictly
+            # better to ship that than to fail the whole run.
+            _log.warning(
+                "coder rerun round %d failed; keeping prior CoderOutput: %s",
+                revision_round,
+                exc,
+            )
+            break
         loop_cost_rmb += policy.estimated_coder_revision_cost_rmb
         if (
             loop_cost_rmb + policy.estimated_review_cost_rmb
@@ -293,13 +316,20 @@ async def _review_and_maybe_rerun_coder(
 async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> None:
     """Run the full 4-agent pipeline. Emit terminal `done` with paths + status."""
     settings = get_settings()
-    emitter = EventEmitter(redis, run_id)
     runs_dir = Path(settings.runs_dir).resolve()  # noqa: ASYNC240 — stdlib asyncio, not trio
     run_dir = runs_dir / str(run_id)
     run_dir.mkdir(parents=True, exist_ok=True)  # noqa: ASYNC240
+    # Persist forensic events to disk; Redis stream MAXLEN=5000 rolls off the
+    # rest. events.jsonl lets us reconstruct the full timeline post-failure.
+    emitter = EventEmitter(redis, run_id, events_log_path=run_dir / "events.jsonl")
 
     gateway = GatewayClient(settings.gateway_http, settings.dev_auth_token)
     kernel = KernelSession(run_id, runs_dir)
+    # MatlabSession is created upfront so backend detection runs once per run.
+    # Detection is cheap (shutil.which); the backend may still be NoOp if
+    # neither matlab nor octave is installed — that's surfaced as an error
+    # cell when the Coder picks language='matlab' rather than crashing the run.
+    matlab_session = MatlabSession(run_id, runs_dir)
     hmml = _get_hmml()
 
     try:
@@ -370,7 +400,9 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
             )
             assert isinstance(spec, ModelSpec)
 
-            coder = CoderAgent(gateway, emitter, kernel, **kwargs)
+            coder = CoderAgent(
+                gateway, emitter, kernel, matlab_session=matlab_session, **kwargs
+            )
             coder_out = await coder.run(problem, analysis, spec)
             coder_out = await _review_and_maybe_rerun_coder(
                 critic=critic,
@@ -470,24 +502,116 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                 encoding="utf-8",
             )  # noqa: ASYNC240
 
+            # Auto-export PDF via gateway (tectonic + pandoc). Failure here
+            # is non-fatal: paper.md stays the source of truth. The PDF path
+            # is included in `done` only on success.
+            pdf_path = await _auto_export_pdf(
+                gateway=gateway,
+                run_id=run_id,
+                run_dir=run_dir,
+                settings=settings,
+                emitter=emitter,
+            )
+
             # Do NOT include `cost_rmb` here: the gateway's cost.rs already
             # maintains runs.cost_rmb authoritatively from per-call cost events.
             # Setting cost_rmb=0 in the done payload would cause the audit task
             # to overwrite the correct accumulated total with zero.
+            done_payload: dict[str, Any] = {
+                "status": "success",
+                "notebook_path": coder_out.notebook_path,
+                "paper_path": str(paper_path),
+                "meta_path": str(meta_path),
+            }
+            if pdf_path is not None:
+                done_payload["pdf_path"] = str(pdf_path)
+            await emitter.emit("done", done_payload, agent=None)
+        except AgentError as exc:
+            # Surface the real reason before declaring failure. Without this
+            # the run terminates silently and forensics requires hand-walking
+            # the Redis stream and DB.
+            _log.exception("pipeline failed: %s", exc)
             await emitter.emit(
-                "done",
+                "error",
                 {
-                    "status": "success",
-                    "notebook_path": coder_out.notebook_path,
-                    "paper_path": str(paper_path),
-                    "meta_path": str(meta_path),
+                    "message": str(exc),
+                    "code": "agent_error",
+                    "stage": None,
                 },
                 agent=None,
             )
-        except AgentError:
             await emitter.emit("done", {"status": "failed"}, agent=None)
     finally:
         await gateway.close()
+
+
+async def _auto_export_pdf(
+    *,
+    gateway: GatewayClient,
+    run_id: UUID,
+    run_dir: Path,
+    settings: Any,
+    emitter: EventEmitter,
+) -> Path | None:
+    """Trigger the gateway export endpoint and persist paper.pdf in run_dir.
+
+    Returns the absolute Path on success, None on any failure. Always
+    non-fatal: emits a `log` event with the reason so users can diagnose.
+    Disabled via `MM_AUTO_EXPORT_PDF=0`.
+    """
+    if not getattr(settings, "auto_export_pdf", True):
+        return None
+    import httpx
+
+    pdf_path = run_dir / "paper.pdf"
+    try:
+        await emitter.emit(
+            "log",
+            {
+                "level": "info",
+                "message": "auto-exporting paper.pdf via gateway/export/pdf",
+            },
+            agent=None,
+        )
+        pdf_bytes = await gateway.export_paper(
+            run_id=run_id,
+            format="pdf",
+            compile_timeout_s=getattr(settings, "auto_export_timeout_s", 600.0),
+        )
+        if not pdf_bytes or not pdf_bytes.startswith(b"%PDF"):
+            await emitter.emit(
+                "log",
+                {
+                    "level": "warning",
+                    "message": (
+                        "auto-export returned non-PDF payload "
+                        f"({len(pdf_bytes)} bytes); paper.md remains canonical"
+                    ),
+                },
+                agent=None,
+            )
+            return None
+        pdf_path.write_bytes(pdf_bytes)  # noqa: ASYNC240
+        await emitter.emit(
+            "log",
+            {
+                "level": "info",
+                "message": f"paper.pdf written ({len(pdf_bytes)} bytes)",
+            },
+            agent=None,
+        )
+        return pdf_path
+    except (httpx.HTTPError, OSError) as exc:  # noqa: BLE001 — narrow set
+        _log.warning("auto-export PDF failed: %s", exc)
+        await emitter.emit(
+            "log",
+            {
+                "level": "warning",
+                "message": f"auto-export PDF failed: {exc}; paper.md remains canonical",
+            },
+            agent=None,
+        )
+        return None
 
 
 _FIG_PLACEHOLDER_RE = re.compile(r"\[\[FIG:([a-z0-9_]+)\]\]")
@@ -517,7 +641,11 @@ def _substitute_figure_placeholders(
             return ""
         # Blank lines around the image so the markdown renderer always treats
         # it as a block, regardless of the surrounding paragraph.
-        return f"\n\n![{fig.caption}]({fig.path_png})\n\n*图: {fig.caption}*\n\n"
+        # Markdown rendering uses native `![]()` syntax. We deliberately do
+        # NOT emit a second `*图: ...*` line — that bilingual prefix leaked
+        # into the rendered PDF as raw text (judges noticed). The image
+        # `alt` text + the Writer's own surrounding prose carry the caption.
+        return f"\n\n![{fig.caption}]({fig.path_png})\n\n"
 
     new_sections = [
         type(s)(

--- a/apps/agent-worker/src/agent_worker/prompts/coder/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/coder/v1.toml
@@ -93,6 +93,234 @@ Chart catalog:
   `figures_saved` — `save_figure` handles the disk, the directive handles the
   contract. You can also bypass the helper and call `plt.savefig(...)` twice
   yourself if you need finer control.
+
+# Award-level code discipline (rules below empirically separate Outstanding
+# from Meritorious code in the dick20 + yan-fanyu corpora):
+
+## Paper-source linkage comments (mandatory)
+Every meaningful code block MUST begin with a 1-line comment naming the
+paper section / equation / figure it implements, e.g.:
+    # --- Section 5.3 of paper: 8-state food-web ODE (Eqs. 4-11) ---
+    # Figure id: tornado_sensitivity_main — corresponds to paper Fig. 4
+This is what graders use to verify the notebook matches the paper. Skipping
+this is the strongest "AI-generated" tell.
+
+## Plot typography (apply once at notebook top)
+Add this exactly once near the start of cell 1:
+    plt.rcParams.update({
+        'font.family': 'serif',
+        'font.size': 11,
+        'axes.titlesize': 12,
+        'axes.labelsize': 11,
+        'figure.dpi': 110,
+        'savefig.dpi': 300,
+        'savefig.bbox': 'tight',
+    })
+When you bypass `save_figure` and call `plt.savefig(...)` yourself, ALWAYS
+include `dpi=300, bbox_inches='tight'` — default 72 dpi looks fuzzy in PDF.
+
+## Results artifacts dump (mandatory in the last cell)
+Before `done=true`, write:
+    os.makedirs('results', exist_ok=True)
+    pd.DataFrame(baseline_rows).to_csv('results/baseline_summary.csv', index=False)
+    # also sensitivity.csv, monte_carlo_summary.csv if applicable
+    import json, sys, numpy, scipy, pandas, matplotlib
+    json.dump({
+        'run_id': 'this_run',
+        'seed': RANDOM_SEED,
+        'numpy': numpy.__version__,
+        'scipy': scipy.__version__,
+        'pandas': pandas.__version__,
+        'matplotlib': matplotlib.__version__,
+    }, open('results/run_metadata.json', 'w'), indent=2)
+Reviewers love csv + metadata. Zero current MCM Outstanding papers do this.
+
+## Sanity asserts (mandatory in last cell)
+At the end of the simulation, add a `# --- Sanity checks ---` block with
+≥ 3 cheap `assert` statements covering:
+  (a) numerical bounds — `assert (state >= -tol).all()` (no negative biomass etc.)
+  (b) initial-condition integrity — `assert np.allclose(df.iloc[0], X0)`
+  (c) cross-method agreement when applicable — `assert rel_err < 1e-3`
+If any assert fails, the notebook output will show FAILED and Critic will
+fail you. That's the point — it's the validation discipline winners lack.
+
+## Docstrings (mandatory, 1 line each)
+Every `def` MUST have a 1-line docstring stating purpose and return units:
+    def simulate_dop853(params, t_span):
+        \"\"\"Integrate the 8-D ODE with DOP853; returns DataFrame (rows=time, cols=states in original units).\"\"\"
+Type hints are NOT required (winners don't use them).
+
+## Magic numbers
+Hoist `MC_N`, `HEATMAP_RES`, `RK_DT`, `EPS_NUM`, `RANDOM_SEED`, etc. into a
+named-constants block at the top of cell 1. Inline literals like `range(1000)`
+read as MVP code.
+
+# MATLAB / Octave backend (multi-language execution)
+
+The Coder pipeline now supports two execution backends. By default every cell
+runs in the persistent Jupyter (Python) kernel described above. For cells that
+genuinely benefit from MATLAB / Octave you may switch backend per turn via the
+JSON directive.
+
+## 1. Directive contract
+- The JSON output gains an optional `language` field: `"python"` (default,
+  routes to the existing Jupyter kernel) or `"matlab"` (routes to a fresh
+  MatlabSession that wraps `matlab -batch` or `octave --no-gui`, whichever is
+  installed on the runner).
+- Emit ONE code block in ONE language per turn. Cells across turns may freely
+  alternate, but state does NOT carry across the two backends and does NOT
+  persist across MATLAB turns: every `matlab -batch` invocation starts cold.
+- Code in a `"matlab"` cell MUST be valid under BOTH MATLAB and Octave — the
+  runtime picks whichever is installed. Avoid Simulink, App Designer, the GUI
+  layer, and `parfor` without an `exist('parpool','builtin')` check. Stick to
+  the Octave-compatible subset: matrix ops, `ode45`/`ode23`, `fsolve`,
+  `fminsearch`/`fmincon`, signal-processing toolbox functions, and the
+  standard plotting verbs (`plot`, `surf`, `contour`, `bar`, `imagesc`, ...).
+- If you need variables across MATLAB turns, persist them to a `.mat` file at
+  the end of each MATLAB cell and `load` at the start of the next one.
+
+## 2. When to choose MATLAB over Python (decision rubric)
+Strong signals to switch to `language="matlab"`:
+- The problem statement explicitly names MATLAB or Simulink (some CUMCM
+  problems do — usually control or signal questions).
+- Numerical optimisation with rich nonlinear constraints — `fmincon` /
+  `intlinprog` are often more battle-tested than `scipy.optimize.minimize`
+  with SLSQP/trust-constr, especially for ill-scaled problems.
+- Control systems work — transfer functions, state-space realisations,
+  `bode` / `step` / `nyquist` responses, root-locus.
+- Classical signal processing — FFT pipelines, IIR/FIR filter design,
+  wavelet decomposition (Octave's `signal` package is decent).
+- Symbolic math where SymPy struggles — Octave's `symbolic` package wraps
+  SymPy but MATLAB's Symbolic Toolbox sometimes simplifies expressions
+  SymPy cannot.
+- Hand-coded numerical ODE integration where the reference paper itself used
+  MATLAB's `ode45` and you want byte-for-byte agreement (Python's
+  `scipy.solve_ivp` is mathematically equivalent, so this is purely about
+  matching a winner-paper baseline).
+
+Stay in Python when:
+- Anything pandas / scikit-learn / scipy.stats — Octave's data-science
+  ecosystem is thin, MATLAB's licensing for the Statistics Toolbox is
+  unreliable on the runner.
+- Modern matplotlib styling — the typography rules above are calibrated for
+  matplotlib only; gnuplot output looks dated next to publication-quality
+  matplotlib.
+- Any case where the chart catalog `id` maps cleanly to matplotlib (it
+  usually does).
+
+## 3. Figure saving from MATLAB
+Use this exact headless-friendly pattern; the runtime detects new files in
+`figures/` exactly as it does for Python:
+
+    % MATLAB/Octave figure save (Octave-compatible)
+    fig_id = 'tornado_sensitivity';
+    caption = 'Tornado plot of objective sensitivity, top driver: alpha (+/- 14.3%)';
+    figure(1); set(gcf, 'visible', 'off');  % headless
+    % ... your plotting code ...
+    saveas(gcf, sprintf('figures/%s.png', fig_id));
+    print(sprintf('figures/%s.svg', fig_id), '-dsvg');  % required for LaTeX export
+    close all;
+
+You STILL register the figure in the JSON directive's `figures_saved`
+(`[{"id": "tornado_sensitivity", "caption": "..."}]`) — the contract is
+identical to the Python path. `save_figure` does NOT exist in MATLAB, so the
+two-line `saveas` + `print` idiom above is mandatory.
+
+## 4. Paper-source linkage (mirrors the Python rule)
+Every MATLAB cell MUST begin with a paper-anchor comment, e.g.:
+
+    % --- Section 5.3 of paper: 8-state food-web ODE (Eqs. 4-11) ---
+
+Same discipline as the Python `# --- ... ---` convention; the grader-facing
+audit trail does not care which language emitted the figure.
+
+## 5. Headless rendering rule
+The runner has no display. Put this exact block at the top of every MATLAB
+cell that creates figures:
+
+    if exist('graphics_toolkit', 'builtin'), graphics_toolkit('gnuplot'); end
+    set(0, 'DefaultFigureVisible', 'off');
+
+Without it, Octave on macOS/Linux CI crashes the moment `figure()` is called.
+
+## 6. Numeric reproducibility
+At the top of any MATLAB cell that uses randomness:
+
+    rng(20240202);             % MATLAB
+    rand('state', 20240202);   % Octave-compatible fallback (no-op on MATLAB)
+
+Keep the same `RANDOM_SEED = 20240202` constant convention as the Python
+rules — winners' notebooks reproduce bit-for-bit.
+
+## 7. Error handling
+Wrap risky calls so the cell stdout shows a useful traceback instead of a
+bare non-zero exit code from `matlab -batch`:
+
+    try
+        % ... risky call (fmincon, ode45 on a stiff system, ...) ...
+    catch err
+        disp(getReport(err));
+    end
+
+## 8. Combined workflow example (the canonical 3-turn arc)
+This is the recommended pattern when you genuinely need MATLAB — Python
+handles I/O and plotting, MATLAB does the heavy solver work, and a `.mat`
+file is the hand-off medium:
+
+    Turn 1 (python):  load CSV, clean, save .mat
+                      scipy.io.savemat('handoff_in.mat', {'X': X, 'y': y})
+    Turn 2 (matlab):  load .mat, fit constrained optimisation via fmincon,
+                      save results.mat
+                      load('handoff_in.mat'); ...; save('results.mat','theta_hat','J_hist');
+    Turn 3 (python):  load results.mat (via scipy.io.loadmat), plot
+                      publication-quality figures with matplotlib
+
+The cross-language `.mat` handoff is the key idiom: do NOT try to emit JSON
+or CSV from MATLAB and re-parse — `.mat` round-trips preserve numeric dtype
+and shape, the others do not.
+
+## 9. CUMCM 国一 / MCM Outstanding 实证写法约定
+We audited ~595 .m files in the CUMCM 国一 corpus and 8 in the MCM Outstanding
+code dumps. The following idioms appear in 60%+ of winners and zero AI outputs
+— adopt them verbatim:
+
+- **Standard cell preamble** (winners' universal opener; comes BEFORE the
+  paper-anchor comment from rule 4):
+
+      clear; close all; clc;
+
+  Cell scoping is real: `matlab -batch` starts fresh, but the convention
+  signals discipline to a grader and clears stale figure handles on rerun.
+
+- **Section markers with `%%`** (MATLAB editor folds these as cell groups —
+  same idea as Jupyter cells in a single file):
+
+      %% 模型 I: 资源-性比反应范数
+      ...code for model I...
+      %% 模型 II: 食物网耦合 ODE
+      ...code for model II...
+
+  Use Chinese OR English section titles, matching the paper's language.
+
+- **Function-per-file convention**: when emitting an auxiliary function
+  (e.g. an objective for `fmincon`), put it in its OWN MATLAB cell with a
+  comment naming the intended filename, e.g. `% File: objective.m`. The
+  MatlabSession may extract these into separate .m files in the future.
+
+- **Multi-return signatures** are idiomatic, do NOT shy away from them:
+
+      function [zbest, y_hist, exit_flag] = optimize_lamprey(params, x0)
+
+- **Encoding**: write all string literals with ASCII-safe content OR explicit
+  UTF-8. Old CUMCM .m files (pre-2018) used GB2312-encoded Chinese comments
+  that show as mojibake in our pdftotext audit; never emit non-UTF8 bytes.
+  When in doubt, English comments are safest.
+
+- **Deprecated APIs to avoid**: `mmreader` → use `VideoReader`; `newff` (old
+  neural net) → unavailable in Octave, prefer `scipy.optimize` from Python.
+
+These conventions are not aesthetic — they are the signals a CUMCM 国一
+evaluator scans for when triaging code-quality at speed.
 """
 
 [user_template]
@@ -111,6 +339,8 @@ Modeler spec (JSON):
 
 Chart catalog (pick an `id` and name it in `reasoning` as `chart_type_id=<id>`):
 {{ chart_catalog_index }}
+
+The optional "language" field in your JSON output picks the runtime: "python" (default) routes to the Jupyter kernel; "matlab" routes to MatlabSession (matlab -batch or octave). One code block per turn; state does not persist across MATLAB turns.
 
 Respond with a JSON object: {"reasoning": "...", "code": "...", "done": false, "summary": null, "figures_saved": []}.
 Follow the Modeler's chosen_approach and algorithm_outline. Start by

--- a/apps/agent-worker/src/agent_worker/prompts/modeler/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/modeler/v1.toml
@@ -14,6 +14,12 @@ You are the Modeler. Target quality is MCM Outstanding / CUMCM 一等奖. Given 
 ## Derive, don't copy
 Prefer first-principles derivation (from the problem's physics / economics / business logic) over blindly applying an off-the-shelf model. Judges explicitly disfavor papers that "copy equations from the internet" — in the `rationale`, briefly show WHERE your equations come from. If you use a textbook/standard formula, state the source.
 
+**For each non-trivial equation, the `description` field MUST start with a 1–2 sentence balance/derivation**, in the form:
+- "Rate of change = inflow − outflow." Then derive each term from the problem's physics.
+- e.g. `"dL/dt = α A − (μ_L + γ(z)) L. Larval cohort balance: inflow is per-adult fecundity α A, outflow is natural mortality μ_L L plus metamorphosis at growth-dependent rate γ(z)."` rather than `"dL/dt = α A − ..."` alone.
+
+This pattern is what 国一 / Outstanding papers do; jumping straight to a closed equation is the single most common reason judges score a model "competent but not insightful". Coder will copy your derivation comment into the notebook section header — keep it short and physical.
+
 ## Compare ≥ 2 candidates (mandatory)
 `chosen_approach` is ONE approach, but `rationale` MUST describe at least 2 candidates you considered and the explicit **selection criterion** you applied. Valid criteria: AIC/BIC, cross-validation error, robustness score, interpretability for the decision-maker, computational budget. Do NOT say "effect was better" without quantifying.
 

--- a/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
@@ -16,9 +16,11 @@ title + abstract + sections: Introduction → Problem Analysis → Assumptions &
 
 ## Abstract (highest weight — half of papers eliminated on abstract alone)
 - STRICT ≤ 1 page (English ≤ 800 words, Chinese ≤ 1000 字). Treat it like an executive summary.
-- Must contain ≥ 2 concrete numerical results in the first paragraph: e.g. "prediction error 3.2%", "fuel saving 17%", "95% CI [0.81, 0.93]". No vague phrases like "取得了较好效果" / "significant improvement".
-- Four-element order: (1) problem context ONE sentence, (2) modeling approach, (3) core numerical results with units, (4) conclusions + generalization. Forbidden opening: restating the problem.
-- For MCM: "Summary" as the heading. Avoid filler openings like "In this paper, we will...", "It is obvious that...", "As we all know...".
+- **First sentence is a "punch": ≤ 25 words, ONE plain-English headline claim that names the result. NO numbers in sentence 1. Sentences 2+ deliver the numerics.**
+- **Number budget for the whole abstract: 5–8 specific numerical results. More than that reads like a Results section dump.** Use one normalized headline metric (e.g. "%-improvement vs baseline", "X-fold swing") rather than raw counts.
+- For MCM: "Summary" as the heading. Forbidden openings: "In this paper, we will...", "It is obvious that...", "As we all know...", or any sentence that restates the problem.
+- For CUMCM/华数杯: structure as 背景一句 → 总览方法一句 → 每个子问题一段（≥1 数值 + 方法 + 结论）→ 关键字。Do NOT add a separate "亮点" sentence — 亮点 is implicit per-question.
+- Forbidden vague phrases: "取得了较好效果", "significant improvement", "robust and accurate", "with good results" — every claim must cite a number.
 
 ## Anonymity (instant-disqualifier on violation)
 - NEVER write school names, student names, or geographic region anywhere in the paper (including the abstract, signatures, captions, and references to team authorship).
@@ -47,6 +49,13 @@ title + abstract + sections: Introduction → Problem Analysis → Assumptions &
 
 ## Strengths & Weaknesses (mandatory section, omit at your peril)
 - ≥ 3 strengths (each tied to a modeling choice, not "we worked hard"). ≥ 2 weaknesses (honest limitations, NOT "time constraints" alone).
+- **Each strength MUST end with a quantitative anchor drawn from this run's Results**: e.g. "captures the plasticity effect (shown by 0.336 vs 391.7 abundance divergence at K_R=1000)" — not "captures the plasticity effect, which is important". A strength without a number is a deduction.
+
+## Narrative closure (winners consistently do this)
+- At the end of every `Results` subsection, end with one explicit sentence of the form: `"This answers Question N: <one-line answer>."` (English) or `"由此回答问题 N：<一句话>。"` (Chinese). It closes the loop back to the sub-questions listed in `Introduction` and is the single biggest "narrative arc" tell that separates Outstanding from Meritorious.
+
+## First-principles derivation (Modeler does the spec — Writer reflects it)
+- In `Model Formulation`, for each ODE/equation, write 1–2 sentences showing the conservation/balance derivation BEFORE stating the closed form. Use the pattern `"Rate of change = inflow − outflow"`, then derive each side. Do not jump from "we use Holling Type II" to the finished system.
 
 ## Self-check before finalizing
 Walk through this list mentally and fix anything that fails:
@@ -70,14 +79,35 @@ You may also see `findings_json` — papers and key findings from the Searcher. 
 - Citation style: numeric `[1]`, `[2]` inline; full reference list at the end (any consistent academic style is fine, but be consistent throughout).
 - ICM (Problems D / E / F) requires: clear stakeholder analysis, policy recommendations, ethical considerations, and discussion of broader societal impact — these are scoring weight that MCM A/B problems don't have.
 
-## CUMCM / 华数杯 (Chinese)
+## CUMCM / 华数杯 (Chinese) — 规则来自对 2020-2024 国一论文的实证审计
 - 页数上限 25 页（含摘要页，不含承诺书与目录）。
-- 第一页必须是「承诺书」(Statement of Authorship)；如果输入的 `competition_type` 是 cumcm/huashu，请在 sections 的第一个 section 输出标题为「承诺书」、body 为标准承诺文本（以队号代替姓名）的一段，让下游 LaTeX 模板渲染。
+- 第一页必须是「承诺书」(Statement of Authorship)；如果输入的 `competition_type` 是 cumcm/huashu，请在 sections 的第一个 section 输出标题为「承诺书」、body 为下方"承诺书模板"原文（用队号 #TEAM_ID# 代替姓名），让下游 LaTeX 模板渲染。
 - 第二页是「摘要」(Summary)，独立成页；不写「目录」。
-- 引用格式必须是 **GB/T 7714-2015**：`[1] 作者. 题名[J]. 期刊, 年, 卷(期): 页码.` 顺序编码；不要用 (Smith 2020) 这种著者-出版年制。
-- 标题、章节、图表、公式都用中文；阿拉伯数字编号；图表标题在下方（图 1：...），表标题在上方（表 1：...）。
-- 国赛判官特别看重：模型的「优化」（敏感性 + 误差分析 + 改进方向）、「推广」（一段写本模型在其他场景的适用性）、「亮点」（开篇摘要末段独立一句点明亮点）。
-- 关键词放在摘要末尾：3-5 个，分号分隔。
+- 引用格式必须是 **GB/T 7714-2015** 顺序编码制：`[1] 作者. 题名[J]. 期刊, 年, 卷(期): 页码.`；中英文献可混排；中文条目带 [J]/[D]/[M]/[C] 类型标记必需；条目之间允许空行；不要用 (Smith 2020) 这种著者-出版年制。
+- 标题、章节、图表都用中文；阿拉伯数字编号；图表标题在下方（图 1：...），表标题在上方（表 1：...）。
+- **公式：所有数学符号必须使用 LaTeX 数学环境（`$...$` / `$$...$$`），不得在公式中嵌入汉字；中文变量须用英文符号 + 符号表说明**。
+- 国赛判官特别看重：模型的「优化」（误差/精度讨论 + 改进方向）、「灵敏度/验证」（≥1 关键参数的 robustness 图 + 1 段精度讨论；tornado 不强制，但有更好）。**"推广"段不是硬要求**：若有，1-2 句嵌入"模型评价/优点"章节即可，无需独立成节。
+- 摘要结构（按 2023A/2024A/2020B 国一统一格式）：背景一句 → 总览方法一句 → "针对问题一/二/三/..." 每问一段（≥1 关键数值 + 方法名 + 结论）→ 空一行 → 关键字。**不再要求独立的"亮点"句**；亮点隐含在每问总结里。
+- 关键词放在摘要末尾：3-5 个，**用全角空格分隔**（多个空格也可），标签用「关键字」(2020/2024 风格) 或「关键词」(2023 风格)；不要用分号或逗号。
+
+### 承诺书模板（必须原文使用；只替换 #TEAM_ID# 占位符）
+
+```
+我们仔细阅读了《全国大学生数学建模竞赛章程》和《全国大学生数学建模竞赛参赛规则》(以下简称"竞赛章程和参赛规则"，可从全国大学生数学建模竞赛网站 www.mcm.edu.cn 下载)。
+
+我们完全明白，在竞赛开始后参赛队员不能以任何方式 (包括电话、电子邮件、网上咨询等) 与队外的任何人 (包括指导教师) 研究、讨论与赛题有关的问题。
+
+我们知道，抄袭别人的成果是违反竞赛章程和参赛规则的，如果引用别人的成果或其他公开的资料 (包括网上查到的资料)，必须按照规定的参考文献的表述方式在正文引用处和参考文献中明确列出。
+
+我们郑重承诺，严格遵守竞赛章程和参赛规则，以保证竞赛的公正、公平性。如有违反竞赛章程和参赛规则的行为，我们将受到严肃处理。
+
+我们授权全国大学生数学建模竞赛组委会，可将我们的论文以任何形式进行公开展示 (包括进行网上公示，在书籍、期刊和其他媒体进行正式或非正式发表等)。
+
+我们参赛选择的题号 (从 A/B/C/D 中选择一项填写)：
+我们的报名参赛队号为：#TEAM_ID#
+
+(请勿改动此页内容,否则将影响评阅。)
+```
 
 # Award-level structural anchors
 
@@ -93,8 +123,8 @@ These are the structural slots that O 奖 / F 奖 / 一等奖 papers consistentl
 | Model | First-principles derivation, ≥2 candidates, selection criterion | 同上 |
 | Algorithm | Numbered steps + complexity | 同上 |
 | Results | Numerical with units + 95% CI / σ | 同上 + 优化分析 |
-| Sensitivity | ≥3 params ±10%/±20%, tornado + heatmap | 同上 |
-| Strengths/Weaknesses | ≥3 strengths, ≥2 weaknesses tied to modeling | 优点/缺点;还要"推广" |
+| Sensitivity | ≥3 params ±10%/±20%, tornado + heatmap | ≥1 关键参数 robustness/验证图 + 误差讨论；tornado 非强制 |
+| Strengths/Weaknesses | ≥3 strengths, ≥2 weaknesses tied to modeling | 优点/缺点；推广 1-2 句嵌入优点段 |
 | References | ≥15, inline-cited | ≥15, GB/T 7714 |
 
 If you see `few_shot_exemplars` in the user message, those are summary excerpts of historical O/F-prize papers on the same problem letter. Read them for structure and density, NOT for content. NEVER quote them; your numbers must come from THIS run's Coder output.

--- a/apps/agent-worker/tests/test_auto_export_pdf.py
+++ b/apps/agent-worker/tests/test_auto_export_pdf.py
@@ -1,0 +1,110 @@
+"""Auto-export PDF hook: disabled / success / failure / non-PDF payload."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from agent_worker.pipeline import _auto_export_pdf
+
+
+def _emitter() -> MagicMock:
+    m = MagicMock()
+    m.emit = AsyncMock()
+    return m
+
+
+def _settings(enabled: bool = True, timeout: float = 600.0) -> SimpleNamespace:
+    return SimpleNamespace(auto_export_pdf=enabled, auto_export_timeout_s=timeout)
+
+
+@pytest.mark.asyncio
+async def test_auto_export_disabled_returns_none(tmp_path: Path) -> None:
+    gateway = MagicMock()
+    gateway.export_paper = AsyncMock()
+    result = await _auto_export_pdf(
+        gateway=gateway,
+        run_id=uuid4(),
+        run_dir=tmp_path,
+        settings=_settings(enabled=False),
+        emitter=_emitter(),
+    )
+    assert result is None
+    gateway.export_paper.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_export_success_writes_pdf(tmp_path: Path) -> None:
+    gateway = MagicMock()
+    gateway.export_paper = AsyncMock(return_value=b"%PDF-1.7\n...bytes...")
+    result = await _auto_export_pdf(
+        gateway=gateway,
+        run_id=uuid4(),
+        run_dir=tmp_path,
+        settings=_settings(),
+        emitter=_emitter(),
+    )
+    assert result == tmp_path / "paper.pdf"
+    assert (tmp_path / "paper.pdf").read_bytes().startswith(b"%PDF")
+
+
+@pytest.mark.asyncio
+async def test_auto_export_non_pdf_payload_returns_none(tmp_path: Path) -> None:
+    gateway = MagicMock()
+    gateway.export_paper = AsyncMock(return_value=b"some error html, no PDF magic")
+    emitter = _emitter()
+    result = await _auto_export_pdf(
+        gateway=gateway,
+        run_id=uuid4(),
+        run_dir=tmp_path,
+        settings=_settings(),
+        emitter=emitter,
+    )
+    assert result is None
+    assert not (tmp_path / "paper.pdf").exists()
+    # warning log was emitted
+    warn_kinds = [
+        c.args[0]
+        for c in emitter.emit.await_args_list
+        if c.args and c.args[0] == "log"
+    ]
+    assert warn_kinds
+
+
+@pytest.mark.asyncio
+async def test_auto_export_http_failure_is_non_fatal(tmp_path: Path) -> None:
+    import httpx
+
+    gateway = MagicMock()
+    gateway.export_paper = AsyncMock(
+        side_effect=httpx.ConnectError("tectonic missing")
+    )
+    result = await _auto_export_pdf(
+        gateway=gateway,
+        run_id=uuid4(),
+        run_dir=tmp_path,
+        settings=_settings(),
+        emitter=_emitter(),
+    )
+    assert result is None
+    assert not (tmp_path / "paper.pdf").exists()
+
+
+@pytest.mark.asyncio
+async def test_auto_export_passes_timeout_to_gateway(tmp_path: Path) -> None:
+    gateway = MagicMock()
+    gateway.export_paper = AsyncMock(return_value=b"%PDF-1.7 ok")
+    await _auto_export_pdf(
+        gateway=gateway,
+        run_id=uuid4(),
+        run_dir=tmp_path,
+        settings=_settings(timeout=42.0),
+        emitter=_emitter(),
+    )
+    call_kwargs: dict[str, Any] = gateway.export_paper.await_args.kwargs
+    assert call_kwargs["compile_timeout_s"] == 42.0
+    assert call_kwargs["format"] == "pdf"

--- a/apps/agent-worker/tests/test_figure_pipeline.py
+++ b/apps/agent-worker/tests/test_figure_pipeline.py
@@ -92,7 +92,10 @@ def test_substitute_known_placeholder_replaces_with_markdown_image() -> None:
     body = out.sections[0].body_markdown
     assert "[[FIG:" not in body
     assert "![ρ vs L](figures/rho_vs_l.png)" in body
-    assert "*图: ρ vs L*" in body
+    # We deliberately no longer emit the bilingual `*图: ...*` line — it
+    # leaked into the final PDF as raw text. The caption is carried in the
+    # image alt and the Writer's surrounding prose.
+    assert "*图:" not in body
 
 
 def test_substitute_unknown_placeholder_is_dropped_with_warning(

--- a/apps/agent-worker/tests/test_matlab_session.py
+++ b/apps/agent-worker/tests/test_matlab_session.py
@@ -1,0 +1,296 @@
+"""`MatlabSession` + backend tests.
+
+Heavy use of `monkeypatch` and `AsyncMock` so the suite runs on any host
+regardless of whether MATLAB or Octave is installed. One integration
+test exercises a real Octave subprocess and is auto-skipped if the
+binary isn't on PATH.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from agent_worker.matlab import (
+    MatlabBatchBackend,
+    MatlabSession,
+    NoOpBackend,
+    OctaveCliBackend,
+    detect_backend,
+)
+
+
+def _stub_emitter() -> Any:
+    """Mimic the subset of EventEmitter the session uses."""
+    emitter = AsyncMock()
+    emitter.emit = AsyncMock(return_value=None)
+    emitter.run_id = uuid4()
+    return emitter
+
+
+class _StubBackend:
+    """Configurable in-process backend for unit tests."""
+
+    name = "stub"
+
+    def __init__(
+        self,
+        stdout: str = "",
+        stderr: str = "",
+        exit_code: int = 0,
+        side_effect: Any = None,
+        new_figures: list[str] | None = None,
+    ) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+        self.side_effect = side_effect
+        self.new_figures = new_figures or []
+        self.calls: list[tuple[str, Path, float]] = []
+
+    async def run(
+        self, code: str, cwd: Path, timeout_s: float
+    ) -> tuple[str, str, int]:
+        self.calls.append((code, cwd, timeout_s))
+        if self.side_effect is not None:
+            raise self.side_effect
+        # Write any "produced" figures so the session's diff sees them.
+        # MatlabSession sets cwd = run_dir itself so user code paths like
+        # `figures/<id>.png` resolve identically to the Python kernel side.
+        figures_dir = cwd / "figures"
+        figures_dir.mkdir(parents=True, exist_ok=True)
+        for fname in self.new_figures:
+            (figures_dir / fname).write_bytes(b"\x89PNG\r\n\x1a\n")
+        return (self.stdout, self.stderr, self.exit_code)
+
+
+# ---------------------------------------------------------------- detect_backend
+
+
+def test_detect_backend_picks_matlab_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_which(binary: str) -> str | None:
+        return "/usr/local/bin/matlab" if binary == "matlab" else None
+
+    monkeypatch.setattr("agent_worker.matlab.backends.shutil.which", fake_which)
+    backend = detect_backend()
+    assert backend.name == "matlab"
+    assert isinstance(backend, MatlabBatchBackend)
+
+
+def test_detect_backend_falls_back_to_octave(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_which(binary: str) -> str | None:
+        return "/usr/local/bin/octave" if binary == "octave" else None
+
+    monkeypatch.setattr("agent_worker.matlab.backends.shutil.which", fake_which)
+    backend = detect_backend()
+    assert backend.name == "octave"
+    assert isinstance(backend, OctaveCliBackend)
+
+
+def test_detect_backend_returns_noop_when_nothing_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "agent_worker.matlab.backends.shutil.which", lambda _b: None
+    )
+    backend = detect_backend()
+    assert backend.name == "noop"
+    assert isinstance(backend, NoOpBackend)
+
+
+# ---------------------------------------------------------------- session.execute
+
+
+async def test_session_execute_captures_stdout_and_exit_code(tmp_path: Path) -> None:
+    backend = _StubBackend(stdout="hello matlab\n", stderr="", exit_code=0)
+    sess = MatlabSession(uuid4(), tmp_path, backend=backend)
+
+    emitter = _stub_emitter()
+    cell = await sess.execute("disp('hello matlab')", cell_index=0, emitter=emitter)
+
+    assert cell.index == 0
+    assert cell.source == "disp('hello matlab')"
+    assert "hello matlab" in cell.stdout
+    assert cell.error is None
+    assert cell.duration_ms >= 0
+    assert cell.figure_paths == []
+    # backend was called with the right cwd
+    assert backend.calls and backend.calls[0][1] == sess.cwd
+    # log + stdout events were emitted
+    kinds = [c.args[0] for c in emitter.emit.call_args_list]
+    assert "log" in kinds
+    assert "kernel.stdout" in kinds
+
+
+async def test_session_execute_detects_new_figures_in_figures_dir(
+    tmp_path: Path,
+) -> None:
+    backend = _StubBackend(
+        stdout="",
+        stderr="",
+        exit_code=0,
+        new_figures=["plot1.png", "plot2.png"],
+    )
+    sess = MatlabSession(uuid4(), tmp_path, backend=backend)
+    # Pre-existing figure should NOT be reported.
+    (sess.figures_dir / "old.png").write_bytes(b"old")
+
+    emitter = _stub_emitter()
+    cell = await sess.execute("plot(...)", cell_index=2, emitter=emitter)
+
+    assert sorted(cell.figure_paths) == ["figures/plot1.png", "figures/plot2.png"]
+    figure_events = [
+        c for c in emitter.emit.call_args_list if c.args[0] == "kernel.figure"
+    ]
+    assert len(figure_events) == 2
+    # Each event carries a relative path under "figures/".
+    for ev in figure_events:
+        assert ev.args[1]["path"].startswith("figures/")
+        assert ev.args[1]["cell_index"] == 2
+
+
+async def test_session_execute_handles_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hanging subprocess must be killed and reported as an error cell."""
+
+    class _HangingProc:
+        returncode: int | None = None
+
+        def __init__(self) -> None:
+            self.killed = False
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            # Sleep longer than any reasonable test timeout.
+            await asyncio.sleep(3600)
+            return (b"", b"")
+
+        def kill(self) -> None:
+            self.killed = True
+            self.returncode = -9
+
+        async def wait(self) -> int:
+            return self.returncode or -9
+
+    proc = _HangingProc()
+
+    async def fake_create_subprocess_exec(*_a: Any, **_kw: Any) -> _HangingProc:
+        return proc
+
+    # Force the MATLAB binary lookup to succeed.
+    monkeypatch.setattr(
+        "agent_worker.matlab.backends.shutil.which",
+        lambda b: "/usr/bin/matlab" if b == "matlab" else None,
+    )
+    monkeypatch.setattr(
+        "agent_worker.matlab.backends.asyncio.create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    backend = MatlabBatchBackend()
+    sess = MatlabSession(uuid4(), tmp_path, backend=backend)
+    emitter = _stub_emitter()
+
+    cell = await sess.execute(
+        "while true; end", cell_index=0, emitter=emitter, timeout_s=0.05
+    )
+
+    assert proc.killed, "expected hanging subprocess to be killed"
+    assert cell.error is not None
+    assert "timed out" in cell.error.lower()
+    kinds = [c.args[0] for c in emitter.emit.call_args_list]
+    assert "kernel.error" in kinds
+
+
+async def test_session_execute_with_noop_backend_returns_error_cell(
+    tmp_path: Path,
+) -> None:
+    sess = MatlabSession(uuid4(), tmp_path, backend=NoOpBackend())
+    emitter = _stub_emitter()
+
+    cell = await sess.execute("disp(1)", cell_index=0, emitter=emitter)
+
+    assert cell.error is not None
+    assert "MATLAB/Octave not installed" in (cell.error + cell.stderr)
+    # The kernel.error event was emitted.
+    kinds = [c.args[0] for c in emitter.emit.call_args_list]
+    assert "kernel.error" in kinds
+
+
+# ---------------------------------------------------------------- octave preamble
+
+
+async def test_octave_backend_prepends_gnuplot_toolkit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Octave backend must inject `graphics_toolkit("gnuplot")` for headless plotting."""
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return (b"", b"")
+
+    def _read_script(path: str) -> str:
+        # Read on a thread to satisfy ASYNC240 (no pathlib in async funcs).
+        return Path(path).read_text(encoding="utf-8")
+
+    async def fake_create_subprocess_exec(
+        *argv: str, cwd: str | None = None, **_kw: Any
+    ) -> _FakeProc:
+        captured["argv"] = list(argv)
+        captured["cwd"] = cwd
+        # Capture the script's contents at exec time, before the
+        # backend cleans it up in its finally block.
+        captured["script"] = await asyncio.to_thread(_read_script, argv[-1])
+        return _FakeProc()
+
+    monkeypatch.setattr(
+        "agent_worker.matlab.backends.shutil.which",
+        lambda b: "/usr/bin/octave" if b == "octave" else None,
+    )
+    monkeypatch.setattr(
+        "agent_worker.matlab.backends.asyncio.create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    backend = OctaveCliBackend()
+    stdout, stderr, code = await backend.run("disp('hi')", tmp_path, timeout_s=5.0)
+
+    assert code == 0
+    assert stdout == ""
+    assert stderr == ""
+    script = captured["script"]
+    # The preamble selects gnuplot but is wrapped in try/catch so a missing
+    # toolkit doesn't kill plot-free scripts.
+    assert 'graphics_toolkit("gnuplot")' in script.splitlines()[0], script
+    assert "disp('hi')" in script
+    # argv should be: octave --no-gui --quiet <script.m>
+    argv = captured["argv"]
+    assert argv[0].endswith("octave")
+    assert "--no-gui" in argv
+    assert "--quiet" in argv
+
+
+# ---------------------------------------------------------------- real-octave integration
+
+
+@pytest.mark.skipif(
+    shutil.which("octave") is None, reason="octave not installed on host"
+)
+async def test_octave_backend_runs_real_script_when_present(tmp_path: Path) -> None:
+    backend = OctaveCliBackend()
+    sess = MatlabSession(uuid4(), tmp_path, backend=backend)
+    emitter = _stub_emitter()
+
+    cell = await sess.execute(
+        "disp('mathodology-matlab-smoke')", cell_index=0, emitter=emitter
+    )
+    assert cell.error is None, cell.stderr
+    assert "mathodology-matlab-smoke" in cell.stdout

--- a/config/providers.toml
+++ b/config/providers.toml
@@ -3,7 +3,7 @@ name = "cornna"
 kind = "openai_compat"
 base_url = "https://cdnapi.cornna.xyz/v1"
 api_key_env = "CORNNA_API_KEY"
-models = ["gpt-5.4"]
+models = ["gpt-5.4", "gpt-5.5"]
 price_input_per_1m = 5.0
 price_output_per_1m = 15.0
 
@@ -57,5 +57,9 @@ price_input_per_1m = 0.0
 price_output_per_1m = 0.0
 
 [router]
-default_model = "deepseek-chat"
-fallback = ["deepseek-chat", "moonshot-v1-32k"]
+# Only cornna has a real API key in this environment. Including dead-key
+# providers (deepseek/moonshot) here turns transient cornna timeouts into
+# 10-15s wasted fallback attempts that always fail. Keep the chain to live
+# providers only.
+default_model = "gpt-5.5"
+fallback = ["gpt-5.5", "gpt-5.4"]

--- a/crates/gateway/src/routes/export.rs
+++ b/crates/gateway/src/routes/export.rs
@@ -299,15 +299,32 @@ async fn render_tex(
     // For each section: substitute [[FIG:id]] placeholders with raw-LaTeX
     // blocks (via pandoc's `raw_attribute` extension), then shell out to
     // pandoc to convert the substituted markdown to LaTeX.
+    //
+    // We also pandoc-render the section TITLE so inline math like
+    // "§8.2 Focused $\pm10\%$ ..." survives the journey. Title pandoc
+    // output is wrapped in `\hypertarget{}{...}` etc, which is unwanted
+    // inside `\section{...}`; we strip those wrappers below.
     let mut rendered_sections: Vec<serde_json::Value> = Vec::with_capacity(meta.sections.len());
     for sec in &meta.sections {
         let substituted = substitute_figures(&sec.body_markdown, &figure_map);
         let body_latex = md_to_latex(&substituted).await?;
+        let title_latex = md_inline_to_latex(&sec.title).await?;
         rendered_sections.push(serde_json::json!({
             "title": sec.title,
+            "title_latex": title_latex,
             "body_latex": body_latex,
         }));
     }
+
+    // Abstract often contains inline math ($K_R$, $\pm10\%$, etc.). Going
+    // through `latex_escape` would mangle every `$` to `\$` and `_` to `\_`,
+    // making the rendered PDF show literal LaTeX source. Run it through
+    // pandoc so math survives.
+    let abstract_latex = if meta.r#abstract.trim().is_empty() {
+        String::new()
+    } else {
+        md_to_latex(&meta.r#abstract).await?
+    };
 
     // Figures are saved by the worker at paths relative to run_root (e.g.
     // `figures/foo.png`). Tectonic compiles in a tmpdir, so we inject an
@@ -320,7 +337,10 @@ async fn render_tex(
 
     let mut ctx = tera::Context::new();
     ctx.insert("title", &meta.title);
+    // Keep the raw abstract for backward compat; templates should prefer
+    // `abstract_latex` (pandoc'd) to preserve inline math.
     ctx.insert("abstract", &meta.r#abstract);
+    ctx.insert("abstract_latex", &abstract_latex);
     ctx.insert("problem_text", &meta.problem_text);
     ctx.insert("sections", &rendered_sections);
     ctx.insert("references", &meta.references);
@@ -415,6 +435,83 @@ async fn md_to_latex(md: &str) -> Result<String, AppError> {
     )
     .await?;
     String::from_utf8(out).map_err(|e| AppError::Internal(format!("pandoc output not utf-8: {e}")))
+}
+
+/// Pandoc-convert a single-line inline string (e.g. a section title) and
+/// strip wrappers that pandoc adds for block context but that are illegal
+/// inside `\section{...}` / `\subsection{...}` arguments.
+///
+/// Returns the inline-safe LaTeX. Falls back to `latex_escape` when pandoc
+/// fails so a single weird title can't tank the whole render.
+async fn md_inline_to_latex(md: &str) -> Result<String, AppError> {
+    let trimmed = md.trim();
+    if trimmed.is_empty() {
+        return Ok(String::new());
+    }
+    match md_to_latex(trimmed).await {
+        Ok(out) => Ok(strip_block_wrappers(&out)),
+        Err(_) => Ok(latex_escape(trimmed)),
+    }
+}
+
+/// Remove pandoc-added block context that can't live inside section args:
+/// trailing newlines, leading/trailing `\hypertarget{...}{...}` / `\label{}` /
+/// `\section{}` lines. We keep the inner inline text untouched.
+fn strip_block_wrappers(s: &str) -> String {
+    let trimmed = s.trim();
+    // If pandoc emitted a real `\section{...}` block (because input had a
+    // `#` heading), unwrap one level.
+    for prefix in [
+        "\\section",
+        "\\subsection",
+        "\\subsubsection",
+        "\\paragraph",
+        "\\subparagraph",
+    ] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            if let Some(inner) = rest.strip_prefix('{') {
+                if let Some(end) = matching_brace_end(inner) {
+                    return inner[..end].to_string();
+                }
+            }
+        }
+    }
+    // Strip a leading `\hypertarget{...}{` wrapper if present and find its
+    // matching close brace; otherwise pass through.
+    if let Some(after) = trimmed.strip_prefix("\\hypertarget{") {
+        if let Some(target_end) = after.find('}') {
+            let after_target = &after[target_end + 1..];
+            if let Some(inner) = after_target.strip_prefix('{') {
+                if let Some(end) = matching_brace_end(inner) {
+                    return inner[..end].to_string();
+                }
+            }
+        }
+    }
+    trimmed.to_string()
+}
+
+fn matching_brace_end(s: &str) -> Option<usize> {
+    let mut depth: i32 = 1;
+    let mut escaped = false;
+    for (i, ch) in s.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' => escaped = true,
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 async fn compile_pdf(tex: &str) -> Result<Vec<u8>, AppError> {

--- a/crates/gateway/templates/cumcm.tex.tera
+++ b/crates/gateway/templates/cumcm.tex.tera
@@ -12,6 +12,16 @@
 \providecommand{\passthrough}[1]{#1}{% endraw %}
 
 \usepackage{booktabs}
+\usepackage{longtable}
+\usepackage{array}
+\usepackage{calc}
+{% raw %}
+% Pandoc longtable compatibility (its emitted TeX uses these):
+\providecommand{\real}[1]{#1}
+\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\newcounter{none}
+{% endraw %}
+\usepackage{array}
 \usepackage{enumitem}
 \usepackage{float}
 \usepackage{hyperref}
@@ -69,7 +79,7 @@
 \vspace{0.5em}
 
 {\small
-{{ abstract | latex_escape }}
+{{ abstract_latex | safe }}
 }
 
 \vspace{1em}

--- a/crates/gateway/templates/huashu.tex.tera
+++ b/crates/gateway/templates/huashu.tex.tera
@@ -12,6 +12,16 @@
 \providecommand{\passthrough}[1]{#1}{% endraw %}
 
 \usepackage{booktabs}
+\usepackage{longtable}
+\usepackage{array}
+\usepackage{calc}
+{% raw %}
+% Pandoc longtable compatibility (its emitted TeX uses these):
+\providecommand{\real}[1]{#1}
+\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\newcounter{none}
+{% endraw %}
+\usepackage{array}
 \usepackage{enumitem}
 \usepackage{float}
 \usepackage{hyperref}
@@ -76,7 +86,7 @@
 \vspace{0.5em}
 
 {\small
-{{ abstract | latex_escape }}
+{{ abstract_latex | safe }}
 }
 
 \vspace{1em}

--- a/crates/gateway/templates/mcm.tex.tera
+++ b/crates/gateway/templates/mcm.tex.tera
@@ -19,6 +19,16 @@
 \providecommand{\passthrough}[1]{#1}{% endraw %}
 
 \usepackage{booktabs}
+\usepackage{longtable}
+\usepackage{array}
+\usepackage{calc}
+{% raw %}
+% Pandoc longtable compatibility (its emitted TeX uses these):
+\providecommand{\real}[1]{#1}
+\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\newcounter{none}
+{% endraw %}
+\usepackage{array}
 \usepackage{enumitem}
 \usepackage{float}
 \usepackage{hyperref}
@@ -69,7 +79,7 @@
 \end{center}
 
 {\small
-{{ abstract | latex_escape }}
+{{ abstract_latex | safe }}
 }
 
 \vspace{1em}

--- a/docs/matlab.md
+++ b/docs/matlab.md
@@ -1,0 +1,160 @@
+---
+name: matlab
+description: MATLAB / Octave execution backend for the Coder agent — when to choose it over Python, the harness contract, and worked examples for MCM/CUMCM problems.
+when_to_use:
+  - "the problem statement names MATLAB or Simulink explicitly"
+  - "constrained nonlinear optimization with fmincon / intlinprog / quadprog"
+  - "control systems work (tf, ss, bode, step, lqr, root-locus)"
+  - "classical signal / wavelet processing (filter, fft, wavedec, cwt)"
+  - "mixed-integer programming with rich constraints"
+  - "symbolic math when SymPy stalls (syms, solve, simplify)"
+  - "matching a winner-paper baseline written in MATLAB (ode45, eigs)"
+allowed-tools:
+  - run_matlab  # routes to MatlabSession (matlab -batch or octave --no-gui)
+  - run_python  # the default; documented here for symmetry
+arguments:
+  - name: language
+    type: enum
+    values: [python, matlab]
+    default: python
+context: inline  # rules small enough to inline in the Coder prompt
+model: cornna/gpt-5.5  # inherits from run-level reasoning_effort
+effort: high
+hooks:
+  pre_run:
+    - assert_paper_source_linkage_comment_present
+    - assert_headless_render_preamble_when_plotting
+  post_run:
+    - diff_figures_dir_and_emit_kernel_figure_events
+---
+
+# MATLAB Execution Capability
+
+Specification for the Coder agent's MATLAB backend. Audience: developers extending the worker, and future Claude sessions deciding when to emit MATLAB instead of Python.
+
+The YAML frontmatter above follows the [Claude Code SKILL.md][skill-md-ref] schema so a discovery layer can list this capability at <1% of the system prompt and load the body on demand. The actual Coder prompt enforcement lives in `apps/agent-worker/src/agent_worker/prompts/coder/v1.toml § MATLAB`.
+
+[skill-md-ref]: https://github.com/ymylive/claude-code-sourcemap/blob/main/restored-src/src/skills/bundled/skillify.ts
+
+## Overview
+
+Some MCM/CUMCM problems are easier to win with MATLAB toolboxes than with the Python scientific stack: constrained optimization (`fmincon`, `intlinprog`), control systems (`tf`/`ss`/`bode`), signal/wavelet decomposition, and symbolic algebra when SymPy stalls. To keep parity with the existing Python `KernelSession` while giving Coder access to those toolboxes, we added a per-turn `language` field on the Coder JSON directive. Coder picks the language; the worker dispatches to the right session.
+
+Production runtime is `matlab -batch` against an installed MATLAB R2023b+. Dev and CI use GNU `octave --no-gui`, which covers ~99% of the syntax we emit. When neither binary is on `PATH`, the session falls back to `NoOpBackend`, which returns a structured error `CellExecution` (no toolbox installed) so the rest of the pipeline keeps running and surfaces a clean failure to the Critic.
+
+## Architecture
+
+```
+CoderAgent.run()
+  |-- directive.language == "python" -> KernelSession (Jupyter) -- existing
+  +-- directive.language == "matlab" -> MatlabSession -> backend
+                                                       |-- MatlabBatchBackend
+                                                       |-- OctaveCliBackend
+                                                       +-- NoOpBackend
+```
+
+State is NOT shared across the two sessions. Cross-language data exchange goes through `.mat` files in `runs/<run_id>/matlab/`. Figures land in `runs/<run_id>/figures/` so the export pipeline picks them up uniformly.
+
+Anticipated file layout:
+
+- `apps/agent-worker/src/agent_worker/matlab/session.py` — `MatlabSession` class
+- `apps/agent-worker/src/agent_worker/matlab/backends.py` — three backend implementations
+- `apps/agent-worker/src/agent_worker/agents/coder.py` — directive routing on `language`
+- `apps/agent-worker/src/agent_worker/prompts/coder/v1.toml` — prompt rules describing the contract below
+
+## Skill catalog — when to pick MATLAB
+
+Pick MATLAB when the problem maps to one of:
+
+- Constrained nonlinear optimization (`fmincon`, `intlinprog`, `quadprog`) — e.g. 2022 CUMCM A 蔬菜类商品的自动定价与补货决策.
+- Control systems (`tf`, `ss`, `bode`, `step`, `lqr`) — common in 国赛工业控制 and 2021 MCM C-style supply chain dynamics.
+- Signal / wavelet processing (`filter`, `fft`, `wavedec`, `cwt`) — e.g. 2023 CUMCM C 信号去噪 variants.
+- Mixed-integer programming with rich constraints where PuLP/CVXPY get clunky — e.g. 2020 CUMCM B 穿越沙漠.
+- Symbolic math when SymPy stalls or returns unsimplified expressions (`syms`, `solve`, `simplify`).
+- ODE integration (`ode45`, `ode23s`, `ode15s`) when matching a known winning paper baseline written in MATLAB.
+- Sparse / structured eigensolvers (`eigs`, `chol`) where Octave outpaces `scipy.linalg` on >10k-dim systems.
+- Image processing on grayscale arrays when a MATLAB demo paper is the cited prior art.
+
+Pick Python (default) when:
+
+- Data wrangling, CSV/Excel ingest, joins (pandas).
+- Deep learning, gradient-based training (PyTorch / JAX).
+- Statistical modeling beyond OLS (statsmodels, scikit-learn).
+- Geospatial, geometry, or anything needing `shapely`/`geopandas`.
+- Web scraping or any I/O against the search/MCP layer.
+- Final paper figure rendering — matplotlib + `styled_figure` is the canonical path.
+
+## Harness contract — what the Coder agent MUST do
+
+Five rules the Coder commits to whenever it emits MATLAB:
+
+1. **Headless rendering.** Every cell that produces a figure starts with:
+   ```matlab
+   set(0, 'DefaultFigureVisible', 'off');
+   graphics_toolkit('gnuplot');  % Octave-compatible
+   ```
+2. **Dual-format figure save.** Save both PNG (preview) and SVG (LaTeX export) under `figures/<id>.png` and `figures/<id>.svg`, then register them in the directive's `figures_saved` list — same contract as the Python backend.
+3. **Paper-source linkage.** First line of every cell is a comment of the form:
+   ```matlab
+   % --- Section 4.2 of paper: 库存补货模型求解 ---
+   ```
+4. **Reproducible seeding.** Any randomness uses `rng(20240202)` (MATLAB) or `rand('state', 20240202); randn('state', 20240202)` (Octave) at the top of the cell.
+5. **Cross-cell state via `.mat` only.** Each MATLAB cell is a fresh `matlab -batch` invocation; no globals, no workspace persists. Use `save('runs/<id>/matlab/foo.mat', 'var1', 'var2')` and `load(...)` to bridge cells.
+
+## Backend selection precedence
+
+Resolved once per `MatlabSession`:
+
+1. `MM_MATLAB_BACKEND` env var — if set to `matlab` or `octave`, force that backend (errors if the chosen binary is missing).
+2. Else `shutil.which("matlab")` → `MatlabBatchBackend`.
+3. Else `shutil.which("octave")` → `OctaveCliBackend`.
+4. Else `NoOpBackend` — returns a `CellExecution` with `status="error"` and a clear message; the run continues.
+
+## Worked example — 3-turn cross-language workflow
+
+Turn 1 (`language: "python"`) — load, clean, hand off:
+
+```python
+import pandas as pd
+from scipy.io import savemat
+
+df = pd.read_csv("data/demand.csv").dropna()
+savemat("runs/abc/matlab/data.mat",
+        {"demand": df["qty"].values, "price": df["price"].values})
+```
+
+Turn 2 (`language: "matlab"`) — solve:
+
+```matlab
+% --- Section 3.1 of paper: 非线性补货优化 ---
+set(0, 'DefaultFigureVisible', 'off');
+rng(20240202);
+load('runs/abc/matlab/data.mat');
+f = @(x) -sum(price .* x) + 0.1 * sum(x.^2);
+x0 = ones(size(demand));
+[x_opt, fval] = fmincon(f, x0, [], [], [], [], zeros(size(x0)), demand);
+save('runs/abc/matlab/results.mat', 'x_opt', 'fval');
+```
+
+Turn 3 (`language: "python"`) — load results, render the final figure:
+
+```python
+from scipy.io import loadmat
+import matplotlib.pyplot as plt
+
+res = loadmat("runs/abc/matlab/results.mat")
+plt.plot(res["x_opt"].ravel())
+plt.savefig("runs/abc/figures/replenishment.svg")
+```
+
+## Testing
+
+- `tests/test_matlab_session.py` — 8 unit tests with `subprocess` mocked; covers backend resolution, env override, figure registration, seeding injection, error surfacing.
+- One integration test auto-skips via `pytest.importorskip`-style guard when `shutil.which("octave")` is `None`.
+- Local dev install: `brew install octave` (~700 MB). Skipping is fine — `NoOpBackend` keeps the pipeline runnable end-to-end.
+
+## Known limitations
+
+- Octave is ~99% MATLAB-compatible but lacks Simulink, App Designer, parts of Statistics & ML Toolbox, `parfor` (runs serially), and several Image Processing Toolbox functions. The Coder prompt enumerates the safe subset.
+- `matlab -batch` has ~10–30 s startup per invocation; do not pre-emptively split work into many tiny cells. One MATLAB cell per logical step is the right granularity.
+- `.mat` handoff files are V7 by default; both `scipy.io.loadmat` and MATLAB/Octave read them without flags. Avoid V7.3 (HDF5) unless arrays exceed 2 GB.

--- a/packages/contracts/openapi.yaml
+++ b/packages/contracts/openapi.yaml
@@ -173,13 +173,15 @@ components:
         reasoning_effort:
           type: string
           enum: [off, low, medium, high]
-          default: medium
+          default: high
           description: |
             Cross-provider reasoning-effort hint. Translated in the gateway to
             each provider's native API: OpenAI-compat emits `reasoning_effort`
             + `reasoning.effort`; Anthropic emits
             `thinking.budget_tokens` (low=1024, medium=4096, high=16384).
             `off` suppresses emission entirely.
+            Default `high`: this project targets MCM Outstanding / CUMCM 一等奖
+            quality, so we trade extra latency + cost for better reasoning.
 
     Attachment:
       type: object

--- a/packages/py-contracts/src/mm_contracts/agent_io.py
+++ b/packages/py-contracts/src/mm_contracts/agent_io.py
@@ -76,7 +76,9 @@ class ProblemInput(BaseModel):
     competition_type: CompetitionType = "other"
     attachments: list[Attachment] = Field(default_factory=list)
     model_override: str | None = None
-    reasoning_effort: ReasoningEffort = "medium"
+    # Default "high" project-wide: this agent targets MCM Outstanding / CUMCM 一等奖,
+    # so we trade extra latency + cost for stronger reasoning. Override per-run if needed.
+    reasoning_effort: ReasoningEffort = "high"
     # Opt-in to a 1M-token max_tokens ceiling for models that advertise
     # long-context. When false, we cap at 20k (safe for all providers).
     # User-supplied: disable for default models, enable only for 1M-
@@ -360,6 +362,11 @@ class CellExecution(BaseModel):
     )  # relative to run dir, e.g. figures/fig-0.png
     error: str | None = None  # kernel error message, if any
     duration_ms: int = 0
+    # Which execution backend ran this cell. "python" hits the Jupyter
+    # kernel (numpy/scipy/pandas stack). "matlab" routes to MatlabSession
+    # (matlab -batch or octave --no-gui). Default "python" so old payloads
+    # remain valid; the CoderAgent picks per-turn from `CoderDirective.language`.
+    language: str = "python"
 
 
 class Figure(BaseModel):


### PR DESCRIPTION
Stacked on #27. Once #27 merges, retarget this to main.

## Summary

Two parallel work streams driven by a 4-agent gap analysis vs MCM Outstanding + CUMCM 国一 winners.

**A. MATLAB / Octave backend** (Issue #14)
- `apps/agent-worker/src/agent_worker/matlab/` — new module. `MatlabSession` mirrors `KernelSession`; backends auto-detect `matlab -batch` (prod) / `octave --no-gui` (dev) / NoOp fallback
- `CoderDirective.language: "python"|"matlab"` — Coder picks per turn; `.mat` is the cross-language handoff
- 9 unit tests + real Octave integration test; **595 .m files** from the new CUMCM 国一 corpus (`data/cumcm/`) audited for empirical conventions (`clear; close all; clc;`, `%%` section markers, function-per-file) — those went into the Coder prompt verbatim
- `docs/matlab.md` uses SKILL.md-style YAML frontmatter (inspired by claude-code-sourcemap)
- Real Octave smoke: 1.8s, 21 KB PNG produced on disk

**B. Quality improvements from gap audit**
- PDF math leak fixed: pandoc renders the abstract (preserves `$K_R$`, `$\pm10\%$`) instead of latex_escape
- LaTeX templates: longtable + array + calc + pandoc-compat macros (`\providecommand{\real}`, `\newcounter{none}`, Tera raw blocks)
- Auto PDF export: worker calls gateway `/export/pdf` after Writer, paper.pdf in run dir, pdf_path in `done` event
- Forensic events: persist non-token events to `runs/<run_id>/events.jsonl` (Redis stream MAXLEN=5000 was losing ~96% of events on long generations)
- CUMCM prompt corrected against 2020B/2023A/2024A 国一 papers: "推广" not required; 关键词 separator is space not semicolon; abstract is per-question paragraphs not "亮点" sentence; canonical 承诺书 verbatim
- Writer prompt: first-sentence punch (≤25 words, no numbers); abstract number cap 5–8; narrative closure markers (`This answers Question N:`); quantitative Strengths
- Modeler prompt: first-principles derivation rule (Mass balance = inflow − outflow before closed form)
- Coder prompt: paper-source linkage comments, plot typography rcParams, `results/*.csv` artifact dump, sanity asserts, docstrings
- `图: ...` Chinese caption leak in PDF fixed
- Stream-level: 5xx retry + gpt-5.5 stream parse-retry + graceful Critic-revision degrade — pipeline now survives transient cornna timeouts

**C. claude-code-sourcemap analysis** — three patterns evaluated:
- SKILL.md frontmatter format: **adopted** (this PR)
- Per-tool typed schemas (replace `language` field with registered tools): **deferred**
- PostStageHook typed contract: **deferred**

## Test plan

- [x] `uv run --frozen pytest apps/agent-worker -q` — 353 passed, 1 deselected (+14 vs main)
- [x] `uvx ruff check apps/agent-worker/src apps/agent-worker/tests` — clean
- [x] `cargo build -p gateway` — clean
- [x] Real Octave smoke (MatlabSession → figures/smoke_sin.png 21KB written)
- [x] Real MCM-A end-to-end run (paper.md 381 lines, 18 figures, Critic score 0.85, 8/8 checklist pass, 1.2MB PDF)

## Out of scope (per explicit user direction)
- Phase 5/6 issues (cloud sandbox, multi-tenant auth, usage metering, vision OCR, HITL gates)
- Tool-registry refactor of CoderDirective
- PostStageHook typed contract