### PR TITLE
feat: round 4 — wire reminders + shared Compactor (stacked on #29)

### DIFF
--- a/apps/agent-worker/src/agent_worker/agents/coder.py
+++ b/apps/agent-worker/src/agent_worker/agents/coder.py
@@ -109,6 +109,7 @@ class CoderAgent:
         analysis: AnalyzerOutput,
         spec: ModelSpec,
         max_iterations: int = MAX_ITERATIONS,
+        upstream_reminders: str = "",
     ) -> CoderOutput:
         """Execute the agent loop end-to-end; always emits stage lifecycle events."""
         t0 = time.monotonic()
@@ -141,6 +142,7 @@ class CoderAgent:
                     # Snippets are NOT injected — token budget would blow up
                     # past ~15k otherwise. LLM references catalog entries by id.
                     chart_catalog_index=render_index_markdown(),
+                    upstream_reminders=upstream_reminders,
                 ),
             },
         ]

--- a/apps/agent-worker/src/agent_worker/agents/modeler.py
+++ b/apps/agent-worker/src/agent_worker/agents/modeler.py
@@ -79,7 +79,10 @@ class ModelerAgent(BaseAgent):
         )
 
     async def run_for(
-        self, problem: ProblemInput, analysis: AnalyzerOutput
+        self,
+        problem: ProblemInput,
+        analysis: AnalyzerOutput,
+        upstream_reminders: str = "",
     ) -> ModelSpec:
         """Render the template from problem+analysis (+HMML context) and call the LLM."""
         retrieved: list[tuple[MethodNode, float]] = []
@@ -125,6 +128,7 @@ class ModelerAgent(BaseAgent):
             ),
             retrieved_methods=retrieved_ctx,
             few_shot_exemplars=few_shot_block,
+            upstream_reminders=upstream_reminders,
         )
         assert isinstance(output, ModelSpec)
         return output

--- a/apps/agent-worker/src/agent_worker/agents/searcher.py
+++ b/apps/agent-worker/src/agent_worker/agents/searcher.py
@@ -43,6 +43,7 @@ from mm_contracts import (
 from pydantic import ValidationError
 
 from agent_worker.agents.base import AgentError, AgentParseError
+from agent_worker.compactor import CompactionPolicy, PaperCompactor
 from agent_worker.config import get_settings
 from agent_worker.events import EventEmitter
 from agent_worker.gateway_client import GatewayClient
@@ -118,35 +119,18 @@ _log = logging.getLogger(__name__)
 
 
 # --- PDF enrichment / compaction tuning -------------------------------------
+# Kept as module-level constants so external callers / tests can import them.
+# The actual prompts + circuit-breaker + threshold logic now live in the
+# shared `agent_worker.compactor.PaperCompactor` subclass — these values feed
+# its `CompactionPolicy`.
 COMPACT_THRESHOLD_CHARS = 24_000
 COMPACT_TARGET_CHARS = 24_000
 COMPACT_MIN_OUTPUT_CHARS = 1_000
 
-_COMPACT_SYSTEM_PROMPT = """You compress an academic paper into a high-density summary for downstream LLM citation. Preserve verbatim:
-- Mathematical formulas (LaTeX or plain)
-- Parameter definitions and units
-- Methodology steps in order
-- Experimental setup (sample size, data source, conditions)
-- Numerical results with confidence intervals or error bars
-- Key claims that Writer might cite
-
-Drop entirely:
-- Boilerplate (acknowledgments, ethics, conflicts of interest)
-- Related-work prose (the Writer has SearchFindings.papers for that)
-- Narrative filler ("In this paper we propose...")
-- Reference list
-- Repeated information
-
-Preserve the source language. If the input is Chinese, output Chinese.
-If English, output English. Do not translate.
-
-Output: dense markdown, ≤24000 characters. Keep section headings
-(## Methods, ## Results, etc.) so Writer can grep for them.
-Respond with the compacted markdown only."""
-
 # Sentinel for _stream_and_collect's default. Passing response_format=None
-# explicitly disables the JSON-object constraint (used by _compact_one); the
-# default preserves backward compat for _ask_llm / _refine_queries.
+# explicitly disables the JSON-object constraint (used by the compaction
+# caller below); the default preserves backward compat for _ask_llm /
+# _refine_queries.
 _DEFAULT_JSON_RESPONSE_FORMAT: dict[str, Any] = {"type": "json_object"}
 
 
@@ -175,7 +159,10 @@ class SearcherAgent:
         self._runs_dir: Path | None = runs_dir
 
     async def run_for(
-        self, problem: ProblemInput, analysis: AnalyzerOutput
+        self,
+        problem: ProblemInput,
+        analysis: AnalyzerOutput,
+        upstream_reminders: str = "",
     ) -> SearchFindings:
         """Build queries → arXiv + configured web source(s) → LLM synthesize."""
         t0 = time.monotonic()
@@ -568,7 +555,9 @@ class SearcherAgent:
             )
             findings = SearchFindings(queries=queries)
         else:
-            findings = await self._synthesize(problem, analysis, queries, unique)
+            findings = await self._synthesize(
+                problem, analysis, queries, unique, upstream_reminders
+            )
 
         # Phase 3.5/3.6: enrich top papers with full text + compact oversized files.
         # Skip when runs_dir wasn't injected (test fixtures) or there are no
@@ -830,6 +819,34 @@ class SearcherAgent:
             )
             return raw_queries
 
+    def _build_paper_compactor(self) -> PaperCompactor:
+        """Construct a PaperCompactor wired to this agent's gateway.
+
+        The caller closure routes the compactor's LLM call through the same
+        streaming gateway as the rest of Searcher (with `response_format=None`
+        so the model returns markdown, not JSON).
+        """
+        model = self._model_override or self.prompt.model_preference[0]
+
+        async def _caller(*, system: str, user: str, model: str) -> str:
+            messages: list[dict[str, Any]] = [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ]
+            return await self._stream_and_collect(
+                model, messages, response_format=None
+            )
+
+        return PaperCompactor(
+            _caller,
+            model=model,
+            policy=CompactionPolicy(
+                threshold_chars=COMPACT_THRESHOLD_CHARS,
+                target_chars=COMPACT_TARGET_CHARS,
+                min_output_chars=COMPACT_MIN_OUTPUT_CHARS,
+            ),
+        )
+
     async def _compact_oversized_papers(
         self, runs_papers_dir: Path, paths: list[str]
     ) -> list[str]:
@@ -839,7 +856,12 @@ class SearcherAgent:
         the Writer side has its own char-budget soft truncation as a safety
         net. Returns the same paths argument unchanged (compaction never drops
         a paper; it either improves the file or leaves it alone).
+
+        The actual threshold + LLM + circuit-breaker logic lives in
+        `PaperCompactor`; this method handles only the filesystem orchestration
+        and per-file emitter logging.
         """
+        compactor = self._build_paper_compactor()
         run_dir = runs_papers_dir.parent
         for rel_path in paths:
             abs_path = run_dir / rel_path
@@ -857,61 +879,36 @@ class SearcherAgent:
                 continue
             if len(raw) <= COMPACT_THRESHOLD_CHARS:
                 continue
-            compacted = await self._compact_one(raw)
-            if not compacted or len(compacted) < COMPACT_MIN_OUTPUT_CHARS:
+            result = await compactor.compact(raw)
+            if not result.was_compacted:
+                # PaperCompactor returns the original text on every non-success
+                # path (LLM error, too-short output, no compression, breaker
+                # tripped). Surface the reason so failures are debuggable.
                 await self.emitter.emit(
                     "log",
                     {
                         "level": "warning",
                         "message": (
                             f"compact: keeping raw for {rel_path} "
-                            f"(compaction unusable)"
+                            f"(compaction unusable: {result.failure_reason})"
                         ),
                     },
                     agent=self.AGENT_NAME,
                 )
                 continue
-            abs_path.write_text(compacted, encoding="utf-8")
+            abs_path.write_text(result.compacted, encoding="utf-8")
             await self.emitter.emit(
                 "log",
                 {
                     "level": "info",
                     "message": (
-                        f"compact: {rel_path} {len(raw)} → {len(compacted)} chars"
+                        f"compact: {rel_path} {result.original_chars} → "
+                        f"{result.compacted_chars} chars"
                     ),
                 },
                 agent=self.AGENT_NAME,
             )
         return paths
-
-    async def _compact_one(self, raw_text: str) -> str | None:
-        """Run one LLM call to compress raw paper text. None on failure."""
-        model = self._model_override or self.prompt.model_preference[0]
-        user_text = (
-            "Compact this paper text into ≤24000 characters of dense markdown, "
-            "preserving the source language verbatim.\n\nRaw paper text:\n\n"
-            + raw_text
-        )
-        messages: list[dict[str, Any]] = [
-            {"role": "system", "content": _COMPACT_SYSTEM_PROMPT},
-            {"role": "user", "content": user_text},
-        ]
-        try:
-            text = await self._stream_and_collect(
-                model, messages, response_format=None
-            )
-        except Exception as e:  # noqa: BLE001
-            await self.emitter.emit(
-                "log",
-                {
-                    "level": "warning",
-                    "message": f"compact: LLM call failed: {e}",
-                },
-                agent=self.AGENT_NAME,
-            )
-            return None
-        text = text.strip() if isinstance(text, str) else ""
-        return text or None
 
     async def _synthesize(
         self,
@@ -919,6 +916,7 @@ class SearcherAgent:
         analysis: AnalyzerOutput,
         queries: list[str],
         papers: list[Paper],
+        upstream_reminders: str = "",
     ) -> SearchFindings:
         """One LLM call to triage + summarize the retrieved papers."""
         model = self._model_override or self.prompt.model_preference[0]
@@ -949,6 +947,7 @@ class SearcherAgent:
                         papers_payload, ensure_ascii=False, indent=2
                     ),
                     queries_json=json.dumps(queries, ensure_ascii=False),
+                    upstream_reminders=upstream_reminders,
                 ),
             },
         ]

--- a/apps/agent-worker/src/agent_worker/agents/writer.py
+++ b/apps/agent-worker/src/agent_worker/agents/writer.py
@@ -102,6 +102,7 @@ class WriterAgent(BaseAgent):
         spec: ModelSpec,
         coder_output: CoderOutput,
         findings: SearchFindings | None = None,
+        upstream_reminders: str = "",
     ) -> PaperDraft:
         """Render the Writer template from all upstream artifacts and call the LLM."""
         # Fallback so existing callers / tests that don't pass findings still work.
@@ -159,6 +160,7 @@ class WriterAgent(BaseAgent):
             ),
             paper_fulltexts=fulltexts_block,
             few_shot_exemplars=few_shot_block,
+            upstream_reminders=upstream_reminders,
         )
         assert isinstance(output, PaperDraft)
         return output

--- a/apps/agent-worker/src/agent_worker/compactor.py
+++ b/apps/agent-worker/src/agent_worker/compactor.py
@@ -1,0 +1,236 @@
+"""Shared text-compaction utility, modeled on claude-code-sourcemap's compact
+subsystem.
+
+The pattern:
+- Threshold-triggered: only invoke the LLM when input exceeds a budget.
+- LLM-summarized: domain-tunable prompts compress while preserving signal.
+- Circuit-breaker: 3 consecutive failures → stop calling the LLM until a
+  later success resets the counter. (Same `MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES`
+  pattern as sourcemap's `autoCompact.ts:62`.)
+- No-tools preamble: tool-trained models like to call tools mid-summary;
+  the system prompt rejects that explicitly.
+
+Subclass `Compactor` (override `SYSTEM_PROMPT` and `build_user_prompt`) to
+customize per domain — see `PaperCompactor` for the Searcher's academic-paper
+flavor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+# Borrowed verbatim-in-spirit from sourcemap's NO_TOOLS_PREAMBLE: tool-trained
+# models occasionally try to call tools mid-summary, which on a single-turn
+# completion path means no text output at all. Stating consequences upfront
+# prevents that wasted turn. Concatenated onto every subclass SYSTEM_PROMPT.
+NO_TOOLS_PREAMBLE: str = (
+    "CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.\n"
+    "- You already have all the context you need in the user message.\n"
+    "- Tool calls will be REJECTED and waste your only turn.\n"
+    "- Your entire response must be plain text.\n\n"
+)
+
+
+@dataclass
+class CompactionPolicy:
+    """Knobs governing when to fire and how much to keep."""
+
+    threshold_chars: int = 24_000
+    target_chars: int = 24_000           # aim summary at this size
+    min_output_chars: int = 800          # if shorter -> treat as failed
+    max_consecutive_failures: int = 3    # circuit breaker
+    keep_recent_chars: int = 2_000       # tail kept verbatim (reserved for
+                                         #  message-style compaction; unused
+                                         #  by the text-only path today)
+
+
+@dataclass
+class CompactionResult:
+    """Outcome of a single `Compactor.compact` call.
+
+    `was_compacted` is true iff the LLM was invoked AND produced a usable
+    summary. On every other path (below threshold, breaker tripped, LLM error,
+    output too short, no actual compression) `compacted` equals the original
+    text and `failure_reason` explains why.
+    """
+
+    compacted: str
+    was_compacted: bool
+    original_chars: int
+    compacted_chars: int
+    failure_reason: str | None = None
+
+
+class CompactorCaller(Protocol):
+    """Async fn the Compactor uses to call the LLM. Returns the assistant text."""
+
+    async def __call__(self, *, system: str, user: str, model: str) -> str: ...
+
+
+class Compactor:
+    """Threshold-triggered, LLM-summarized text compactor with a circuit breaker.
+
+    Subclassable: override `SYSTEM_PROMPT` / `build_user_prompt` for domain-
+    specific compaction (e.g. `PaperCompactor` for academic PDFs).
+    """
+
+    SYSTEM_PROMPT: str = (
+        "You are a precise summarizer. Compress the user-provided text while "
+        "preserving all numbers, equations, named entities, and citations. "
+        "Do NOT call tools. Return plain text only."
+    )
+
+    def __init__(
+        self,
+        caller: CompactorCaller,
+        *,
+        model: str = "gpt-5.5",
+        policy: CompactionPolicy | None = None,
+    ) -> None:
+        self._caller = caller
+        self._model = model
+        self._policy = policy or CompactionPolicy()
+        self._consecutive_failures = 0
+
+    @property
+    def consecutive_failures(self) -> int:
+        """Current breaker count. Exposed for diagnostics and tests."""
+        return self._consecutive_failures
+
+    @property
+    def policy(self) -> CompactionPolicy:
+        return self._policy
+
+    def should_compact(self, text: str) -> bool:
+        """Two conditions: input exceeds threshold AND breaker not tripped."""
+        return (
+            len(text) > self._policy.threshold_chars
+            and self._consecutive_failures < self._policy.max_consecutive_failures
+        )
+
+    def build_user_prompt(self, text: str) -> str:
+        """Override to customize the compaction prompt."""
+        return (
+            f"Compress the following to at most ~{self._policy.target_chars} "
+            f"characters. Preserve all specific numbers and equations.\n\n{text}"
+        )
+
+    def _full_system_prompt(self) -> str:
+        """SYSTEM_PROMPT with the NO_TOOLS_PREAMBLE prepended."""
+        return NO_TOOLS_PREAMBLE + self.SYSTEM_PROMPT
+
+    async def compact(self, text: str) -> CompactionResult:
+        original = len(text)
+        if not self.should_compact(text):
+            reason = (
+                "below_threshold"
+                if original <= self._policy.threshold_chars
+                else "circuit_breaker_tripped"
+            )
+            return CompactionResult(
+                compacted=text,
+                was_compacted=False,
+                original_chars=original,
+                compacted_chars=original,
+                failure_reason=reason,
+            )
+        try:
+            user_prompt = self.build_user_prompt(text)
+            summary = await self._caller(
+                system=self._full_system_prompt(),
+                user=user_prompt,
+                model=self._model,
+            )
+        except Exception as exc:  # noqa: BLE001 — any caller error is a failure
+            self._consecutive_failures += 1
+            return CompactionResult(
+                compacted=text,
+                was_compacted=False,
+                original_chars=original,
+                compacted_chars=original,
+                failure_reason=f"llm_error: {type(exc).__name__}: {exc}",
+            )
+        # Normalize None / non-string returns to empty so the length checks
+        # treat them as "too short". Callers SHOULD return str, but the
+        # gateway path historically tolerated odd shapes.
+        if not isinstance(summary, str):
+            summary = ""
+        summary = summary.strip()
+        if len(summary) < self._policy.min_output_chars:
+            self._consecutive_failures += 1
+            return CompactionResult(
+                compacted=text,
+                was_compacted=False,
+                original_chars=original,
+                compacted_chars=original,
+                failure_reason="output_too_short",
+            )
+        if len(summary) >= original:
+            # LLM returned same-or-larger; not compressing — keep original.
+            self._consecutive_failures += 1
+            return CompactionResult(
+                compacted=text,
+                was_compacted=False,
+                original_chars=original,
+                compacted_chars=original,
+                failure_reason="no_compression_achieved",
+            )
+        # Success — reset breaker.
+        self._consecutive_failures = 0
+        return CompactionResult(
+            compacted=summary,
+            was_compacted=True,
+            original_chars=original,
+            compacted_chars=len(summary),
+        )
+
+
+class PaperCompactor(Compactor):
+    """Domain-specific subclass for academic paper text (Searcher's use case).
+
+    Preserves the exact behavioral envelope of the inline implementation that
+    used to live in `searcher.py`: same 24k threshold, same prompt intent
+    (preserve numbers / methods / DOIs; drop boilerplate / refs), same
+    source-language preservation rule.
+    """
+
+    SYSTEM_PROMPT = (
+        "You compress an academic paper into a high-density summary for "
+        "downstream LLM citation. Preserve verbatim:\n"
+        "- Mathematical formulas (LaTeX or plain)\n"
+        "- Parameter definitions and units\n"
+        "- Methodology steps in order\n"
+        "- Experimental setup (sample size, data source, conditions)\n"
+        "- Numerical results with confidence intervals or error bars\n"
+        "- Key claims that Writer might cite\n\n"
+        "Drop entirely:\n"
+        "- Boilerplate (acknowledgments, ethics, conflicts of interest)\n"
+        "- Related-work prose (the Writer has SearchFindings.papers for that)\n"
+        "- Narrative filler (\"In this paper we propose...\")\n"
+        "- Reference list (keep DOIs only)\n"
+        "- Repeated information\n\n"
+        "Preserve the source language. If the input is Chinese, output Chinese.\n"
+        "If English, output English. Do not translate.\n\n"
+        "Output: dense markdown, capped at the target character budget. Keep "
+        "section headings (## Methods, ## Results, etc.) so Writer can grep "
+        "for them. Respond with the compacted markdown only."
+    )
+
+    def build_user_prompt(self, text: str) -> str:
+        return (
+            f"Compact this paper text into ~{self._policy.target_chars} "
+            f"characters of dense markdown, preserving the source language "
+            f"verbatim and keeping all numerical results, methods detail, "
+            f"and DOIs.\n\nRaw paper text:\n\n{text}"
+        )
+
+
+__all__ = [
+    "NO_TOOLS_PREAMBLE",
+    "CompactionPolicy",
+    "CompactionResult",
+    "Compactor",
+    "CompactorCaller",
+    "PaperCompactor",
+]

--- a/apps/agent-worker/src/agent_worker/pipeline.py
+++ b/apps/agent-worker/src/agent_worker/pipeline.py
@@ -165,7 +165,17 @@ async def _review_and_maybe_revise(
     policy: CriticPolicy = DEFAULT_CRITIC_POLICY,
     estimated_review_cost_rmb: float | None = None,
     estimated_revision_cost_rmb: float | None = None,
+    reminders_out: dict[str, str] | None = None,
 ) -> BaseModel:
+    """Critic-driven review with up to `max_revision_rounds` retries.
+
+    When `reminders_out` is provided, the FINAL accepted verdict's
+    `additional_context` (computed by `critique_to_hook_result`) is
+    written into it under the *next* stage's name. Downstream agents
+    then render this string as a `<system_reminder>` block in their
+    user prompt — that's how Critic minor-finding feedback flows
+    forward without a full revision round.
+    """
     review_cost_rmb = (
         policy.estimated_review_cost_rmb
         if estimated_review_cost_rmb is None
@@ -243,7 +253,11 @@ async def _review_and_maybe_revise(
     hook_result = critique_to_hook_result(report)
     agg = aggregate([hook_result])
     reminder = agg.merged_reminder()
+    next_stage = _next_stage_after(target_agent)
     if reminder:
+        if reminders_out is not None and next_stage is not None:
+            reminders_out[next_stage] = reminder
+
         import contextlib
 
         # Critic exposes `emitter` on all current builds; suppress just in
@@ -255,7 +269,7 @@ async def _review_and_maybe_revise(
                 {
                     "level": "info",
                     "message": "post-stage reminder available for downstream",
-                    "for_stage": _next_stage_after(target_agent),
+                    "for_stage": next_stage,
                     "reminder_chars": len(reminder),
                     "reminder": reminder,
                 },
@@ -273,6 +287,7 @@ async def _review_and_maybe_rerun_coder(
     spec: ModelSpec,
     coder_out: CoderOutput,
     policy: CriticPolicy = DEFAULT_CRITIC_POLICY,
+    reminders_out: dict[str, str] | None = None,
 ) -> CoderOutput:
     criteria = [
         "Executed cells support the model specification.",
@@ -352,6 +367,15 @@ async def _review_and_maybe_rerun_coder(
 
     if _critique_should_fail_run(report):
         raise AgentError(f"Critic rejected coder after revision: {report.summary}")
+
+    # Same post-stage hook lifecycle as _review_and_maybe_revise — surface
+    # a `<system_reminder>` for the next stage (writer) when the final
+    # verdict has minor findings worth carrying forward.
+    hook_result = critique_to_hook_result(report)
+    agg = aggregate([hook_result])
+    reminder = agg.merged_reminder()
+    if reminder and reminders_out is not None:
+        reminders_out["writer"] = reminder
     return current
 
 
@@ -385,6 +409,13 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                 "model_override": problem.model_override,
             }
 
+            # Shared dict for post-stage hook reminders. Keys are stage
+            # names ("searcher", "modeler", "coder", "writer"). Each entry
+            # is a `<system_reminder>` XML block produced by
+            # `critique_to_hook_result()` after the upstream Critic verdict.
+            # Downstream agents render it into their user_template.
+            upstream_reminders: dict[str, str] = {}
+
             analyzer = AnalyzerAgent(gateway, emitter, **kwargs)
             critic = CriticAgent(gateway, emitter, **kwargs)
             analysis = await analyzer.run_for_problem(problem)
@@ -403,11 +434,16 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                     "Lists concrete data requirements.",
                     "Proposes at least one usable modeling approach.",
                 ],
+                reminders_out=upstream_reminders,
             )
             assert isinstance(analysis, AnalyzerOutput)
 
             searcher = SearcherAgent(gateway, emitter, runs_dir=runs_dir, **kwargs)
-            findings = await searcher.run_for(problem, analysis)
+            findings = await searcher.run_for(
+                problem,
+                analysis,
+                upstream_reminders=upstream_reminders.get("searcher", ""),
+            )
             findings = await _review_and_maybe_revise(
                 critic=critic,
                 producer=searcher,
@@ -419,11 +455,16 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                     "analysis": analysis.model_dump(mode="json"),
                 },
                 criteria=_searcher_review_criteria(),
+                reminders_out=upstream_reminders,
             )
             assert isinstance(findings, SearchFindings)
 
             modeler = ModelerAgent(gateway, emitter, hmml=hmml, **kwargs)
-            spec = await modeler.run_for(problem, analysis)
+            spec = await modeler.run_for(
+                problem,
+                analysis,
+                upstream_reminders=upstream_reminders.get("modeler", ""),
+            )
             spec = await _review_and_maybe_revise(
                 critic=critic,
                 producer=modeler,
@@ -439,13 +480,19 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                     "Algorithm outline is executable by Coder.",
                     "Validation strategy is concrete.",
                 ],
+                reminders_out=upstream_reminders,
             )
             assert isinstance(spec, ModelSpec)
 
             coder = CoderAgent(
                 gateway, emitter, kernel, matlab_session=matlab_session, **kwargs
             )
-            coder_out = await coder.run(problem, analysis, spec)
+            coder_out = await coder.run(
+                problem,
+                analysis,
+                spec,
+                upstream_reminders=upstream_reminders.get("coder", ""),
+            )
             coder_out = await _review_and_maybe_rerun_coder(
                 critic=critic,
                 coder=coder,
@@ -453,11 +500,17 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                 analysis=analysis,
                 spec=spec,
                 coder_out=coder_out,
+                reminders_out=upstream_reminders,
             )
 
             writer = WriterAgent(gateway, emitter, run_dir=run_dir, **kwargs)
             paper = await writer.run_for(
-                problem, analysis, spec, coder_out, findings
+                problem,
+                analysis,
+                spec,
+                coder_out,
+                findings,
+                upstream_reminders=upstream_reminders.get("writer", ""),
             )
 
             # Deterministic evidence mining: surface concrete facts about the
@@ -500,6 +553,7 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                 producer=writer,
                 target_agent="writer",
                 output=paper,
+                reminders_out=upstream_reminders,  # final stage; for post-mortem
                 context={
                     "problem_text": problem.problem_text,
                     "competition_type": problem.competition_type,

--- a/apps/agent-worker/src/agent_worker/prompts/coder/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/coder/v1.toml
@@ -325,6 +325,8 @@ evaluator scans for when triaging code-quality at speed.
 
 [user_template]
 text = """
+{{ upstream_reminders }}
+
 You are solving this problem. Read the Analyzer's scoped plan and the
 Modeler's concrete spec, then implement the approach step by step.
 

--- a/apps/agent-worker/src/agent_worker/prompts/modeler/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/modeler/v1.toml
@@ -56,6 +56,8 @@ Respond with a single JSON object matching ModelSpec. Use ensure_ascii=False for
 
 [user_template]
 text = """
+{{ upstream_reminders }}
+
 Problem type: {{ competition_type }}
 
 Problem statement:

--- a/apps/agent-worker/src/agent_worker/prompts/searcher/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/searcher/v1.toml
@@ -52,6 +52,8 @@ Return a JSON object matching SearchFindings. No prose, no markdown fences.
 
 [user_template]
 text = """
+{{ upstream_reminders }}
+
 Problem type: {{ competition_type }}
 Problem: {{ problem_text }}
 

--- a/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
@@ -132,6 +132,8 @@ If you see `few_shot_exemplars` in the user message, those are summary excerpts 
 
 [user_template]
 text = """
+{{ upstream_reminders }}
+
 Problem type: {{ competition_type }}
 
 Problem statement:

--- a/apps/agent-worker/tests/test_compactor.py
+++ b/apps/agent-worker/tests/test_compactor.py
@@ -1,0 +1,252 @@
+"""Tests for the shared text-compaction utility.
+
+Pytest runs in ``asyncio_mode = "auto"`` (see ``pyproject.toml``), so plain
+``async def test_*`` functions are picked up without explicit markers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from agent_worker.compactor import (
+    NO_TOOLS_PREAMBLE,
+    CompactionPolicy,
+    Compactor,
+    PaperCompactor,
+)
+
+
+@dataclass
+class _StubCaller:
+    """Records each call and returns either a queued string or raises."""
+
+    # Either a list of strings (one consumed per call) or a single exception
+    # raised on every call. `responses` rotates; once exhausted the last
+    # response is sticky.
+    responses: list[str] = field(default_factory=list)
+    raise_exc: Exception | None = None
+    calls: list[dict[str, str]] = field(default_factory=list)
+
+    async def __call__(self, *, system: str, user: str, model: str) -> str:
+        self.calls.append({"system": system, "user": user, "model": model})
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        if not self.responses:
+            return ""
+        if len(self.responses) == 1:
+            return self.responses[0]
+        return self.responses.pop(0)
+
+
+def _policy(**overrides: object) -> CompactionPolicy:
+    """Default test policy: small thresholds so we don't have to fabricate 24k."""
+    base = {
+        "threshold_chars": 100,
+        "target_chars": 80,
+        "min_output_chars": 20,
+        "max_consecutive_failures": 3,
+    }
+    base.update(overrides)  # type: ignore[arg-type]
+    return CompactionPolicy(**base)  # type: ignore[arg-type]
+
+
+async def test_under_threshold_skips_compaction() -> None:
+    caller = _StubCaller(responses=["UNUSED"])
+    c = Compactor(caller, policy=_policy(threshold_chars=1_000))
+    result = await c.compact("short text")
+    assert result.was_compacted is False
+    assert result.compacted == "short text"
+    assert result.original_chars == len("short text")
+    assert result.compacted_chars == len("short text")
+    assert result.failure_reason == "below_threshold"
+    assert caller.calls == []  # LLM was NOT invoked
+
+
+async def test_above_threshold_calls_llm_and_returns_summary() -> None:
+    summary = "x" * 40  # well above min_output_chars(20), below original size
+    caller = _StubCaller(responses=[summary])
+    c = Compactor(caller, model="gpt-test", policy=_policy())
+    long_input = "y" * 500
+    result = await c.compact(long_input)
+    assert result.was_compacted is True
+    assert result.compacted == summary
+    assert result.original_chars == 500
+    assert result.compacted_chars == 40
+    assert result.failure_reason is None
+    assert len(caller.calls) == 1
+    call = caller.calls[0]
+    assert call["model"] == "gpt-test"
+    # The system prompt must include the no-tools preamble (sourcemap parity).
+    assert NO_TOOLS_PREAMBLE in call["system"]
+    # The original text must appear in the user prompt.
+    assert long_input in call["user"]
+
+
+async def test_llm_failure_increments_breaker_and_falls_through_to_original() -> None:
+    caller = _StubCaller(raise_exc=RuntimeError("provider 502"))
+    c = Compactor(caller, policy=_policy())
+    long_input = "y" * 500
+    result = await c.compact(long_input)
+    assert result.was_compacted is False
+    assert result.compacted == long_input
+    assert result.failure_reason is not None
+    assert "llm_error" in result.failure_reason
+    assert "RuntimeError" in result.failure_reason
+    assert "provider 502" in result.failure_reason
+    assert c.consecutive_failures == 1
+
+
+async def test_three_consecutive_failures_trip_circuit_breaker() -> None:
+    caller = _StubCaller(raise_exc=RuntimeError("nope"))
+    c = Compactor(caller, policy=_policy())
+    long_input = "z" * 500
+    # Three failures bring the breaker to its threshold.
+    for _ in range(3):
+        r = await c.compact(long_input)
+        assert r.was_compacted is False
+    assert c.consecutive_failures == 3
+    assert len(caller.calls) == 3
+    # Fourth call must skip the LLM entirely (breaker tripped).
+    r4 = await c.compact(long_input)
+    assert r4.was_compacted is False
+    assert r4.failure_reason == "circuit_breaker_tripped"
+    assert len(caller.calls) == 3  # no new invocation
+
+
+async def test_circuit_breaker_resets_on_success() -> None:
+    # Two failures, then a success → breaker resets.
+    summary = "ok" * 30  # 60 chars; above min(20), below 500
+    caller = _StubCaller(responses=["short", "short", summary])
+    # Use a policy where "short" (5 chars) is too short to count as success.
+    c = Compactor(caller, policy=_policy(min_output_chars=20))
+    long_input = "a" * 500
+    r1 = await c.compact(long_input)
+    r2 = await c.compact(long_input)
+    assert r1.was_compacted is False and r2.was_compacted is False
+    assert c.consecutive_failures == 2
+    r3 = await c.compact(long_input)
+    assert r3.was_compacted is True
+    assert r3.compacted == summary
+    assert c.consecutive_failures == 0
+
+
+async def test_output_too_short_counts_as_failure() -> None:
+    caller = _StubCaller(responses=["tiny"])  # 4 chars, below min(20)
+    c = Compactor(caller, policy=_policy())
+    result = await c.compact("y" * 500)
+    assert result.was_compacted is False
+    assert result.failure_reason == "output_too_short"
+    assert c.consecutive_failures == 1
+
+
+async def test_output_not_smaller_than_input_counts_as_failure() -> None:
+    # Summary is the SAME size as the input — no compression achieved.
+    long_input = "y" * 500
+    same_size = "z" * 500
+    caller = _StubCaller(responses=[same_size])
+    c = Compactor(caller, policy=_policy())
+    result = await c.compact(long_input)
+    assert result.was_compacted is False
+    assert result.failure_reason == "no_compression_achieved"
+    assert result.compacted == long_input  # original kept
+    assert c.consecutive_failures == 1
+
+
+async def test_paper_compactor_uses_specialized_system_prompt() -> None:
+    summary = "## Methods\n" + ("dense " * 30)  # ~190 chars
+    caller = _StubCaller(responses=[summary])
+    c = PaperCompactor(caller, policy=_policy())
+    long_input = "raw paper " * 100  # 1000 chars
+    result = await c.compact(long_input)
+    assert result.was_compacted is True
+    system = caller.calls[0]["system"]
+    # No-tools preamble is always there.
+    assert NO_TOOLS_PREAMBLE in system
+    # Domain-specific markers from PaperCompactor.SYSTEM_PROMPT.
+    assert "academic paper" in system
+    assert "DOIs only" in system
+    assert "Preserve the source language" in system
+
+
+async def test_build_user_prompt_subclass_override() -> None:
+    class _SubCompactor(Compactor):
+        SYSTEM_PROMPT = "Tiny system."
+
+        def build_user_prompt(self, text: str) -> str:
+            return f"CUSTOM PREFIX :: {text}"
+
+    summary = "compressed enough"  # 17 chars - below min(20) → too short
+    caller = _StubCaller(responses=["x" * 40])  # OK shape
+    c = _SubCompactor(caller, policy=_policy())
+    await c.compact("y" * 500)
+    user = caller.calls[0]["user"]
+    assert user.startswith("CUSTOM PREFIX :: ")
+    assert "y" * 500 in user
+    # Sanity: the variable `summary` is unused on the green path; keep it
+    # bound so a future ruff run with F841 doesn't trip. Reference it:
+    assert isinstance(summary, str)
+
+
+async def test_failure_reason_is_populated_correctly() -> None:
+    # 1) below_threshold
+    caller = _StubCaller(responses=["unused"])
+    c = Compactor(caller, policy=_policy(threshold_chars=1_000))
+    r = await c.compact("tiny")
+    assert r.failure_reason == "below_threshold"
+
+    # 2) llm_error: <ExcType>: <msg>
+    caller_err = _StubCaller(raise_exc=ValueError("boom"))
+    c_err = Compactor(caller_err, policy=_policy())
+    r_err = await c_err.compact("z" * 500)
+    assert r_err.failure_reason is not None
+    assert r_err.failure_reason.startswith("llm_error: ValueError: boom")
+
+    # 3) output_too_short
+    caller_short = _StubCaller(responses=["t"])
+    c_short = Compactor(caller_short, policy=_policy())
+    r_short = await c_short.compact("z" * 500)
+    assert r_short.failure_reason == "output_too_short"
+
+    # 4) no_compression_achieved
+    caller_same = _StubCaller(responses=["z" * 600])
+    c_same = Compactor(caller_same, policy=_policy())
+    r_same = await c_same.compact("y" * 500)
+    assert r_same.failure_reason == "no_compression_achieved"
+
+    # 5) circuit_breaker_tripped
+    caller_break = _StubCaller(raise_exc=RuntimeError("x"))
+    c_break = Compactor(caller_break, policy=_policy())
+    for _ in range(3):
+        await c_break.compact("z" * 500)
+    r_break = await c_break.compact("z" * 500)
+    assert r_break.failure_reason == "circuit_breaker_tripped"
+
+    # 6) success → failure_reason is None
+    caller_ok = _StubCaller(responses=["x" * 40])
+    c_ok = Compactor(caller_ok, policy=_policy())
+    r_ok = await c_ok.compact("z" * 500)
+    assert r_ok.was_compacted is True
+    assert r_ok.failure_reason is None
+
+
+async def test_summary_is_stripped_before_length_checks() -> None:
+    """LLM output with surrounding whitespace must be stripped first.
+
+    Mirrors the existing `_compact_one` behavior in `searcher.py` that called
+    `.strip()` on the LLM's text before returning it.
+    """
+    summary_padded = "   " + ("x" * 40) + "\n\n"
+    caller = _StubCaller(responses=[summary_padded])
+    c = Compactor(caller, policy=_policy())
+    result = await c.compact("y" * 500)
+    assert result.was_compacted is True
+    assert result.compacted == "x" * 40  # stripped
+    assert result.compacted_chars == 40
+
+
+async def test_paper_compactor_default_policy_matches_searcher_threshold() -> None:
+    """The default policy must keep the Searcher's 24k threshold envelope."""
+    c = PaperCompactor(_StubCaller())
+    assert c.policy.threshold_chars == 24_000
+    assert c.policy.target_chars == 24_000
+    assert c.policy.max_consecutive_failures == 3


### PR DESCRIPTION
Stacked on #29. Lands the two deferred items from that PR.

## A. Post-stage reminder propagation

Completes the hook lifecycle started in #29 (which only emitted log events for `additional_context`). Now the reminder actually flows downstream:

- `pipeline.py`: shared `upstream_reminders: dict[stage, str]` filled by `_review_and_maybe_revise` and `_review_and_maybe_rerun_coder` after each Critic verdict; `critique_to_hook_result()` produces a concise `<system_reminder>` XML block; pipeline passes it to the NEXT stage's `run_for(..., upstream_reminders=...)`.
- 4 agent `run_for` signatures gain `upstream_reminders: str = ""` (searcher, modeler, coder, writer). Backward-compatible default.
- 4 prompt `user_template`s render `{{ upstream_reminders }}` at the top. Empty reminders → empty string, no behavior change.

## B. Shared `Compactor` utility (sourcemap `services/compact/` pattern)

- `apps/agent-worker/src/agent_worker/compactor.py`
  - `CompactionPolicy` knobs (threshold / target / min-output / keep-recent)
  - `Compactor` + `PaperCompactor` subclass with `NO_TOOLS_PREAMBLE` trick
  - 3-strike `max_consecutive_failures` circuit breaker (sourcemap `autoCompact.ts:62-91`)
  - Failure-reason taxonomy: `below_threshold` / `circuit_breaker_tripped` / `llm_error` / `output_too_short` / `no_compression_achieved`
- Searcher refactor: `_compact_one` + `_compact_oversized_papers` body now delegate to `PaperCompactor`. Same threshold (24k chars), same I/O contract, same system-prompt content. Module-level constants kept for backward-compat.
- 12 new unit tests covering threshold gating, circuit-breaker dynamics, LLM error fall-through, output validation, subclass customization.

## Test plan

- [x] `uv run --frozen pytest apps/agent-worker -q` → **401 passed** (+12 vs #29)
- [x] `uvx ruff check apps/agent-worker/src apps/agent-worker/tests` → clean
- [x] Searcher compaction tests still pass unchanged (`test_searcher_compaction.py` 6/6)
- [x] All existing tests pass; no regressions

## Sourcemap references
- `types/hooks.ts:50-166` — `HookResult` / `additional_context` shape (already imported in #29)
- `services/compact/autoCompact.ts:62-91` — 3-strike circuit breaker constant
- `services/compact/prompt.ts:19-26` — `NO_TOOLS_PREAMBLE` trick

## Deferred to round 5
- Tool-registry refactor of `CoderDirective` (replace `language: str` with registered `run_python` / `run_matlab` tools, each with its own pydantic schema + validator) — the biggest remaining sourcemap pattern (`Tool.ts:362 + buildTool`)
- Generalize `Compactor.compact_messages` for chat-style compaction (only matters if Critic revision histories blow up; not happening today)