### PR TITLE
feat: NL paper fine-tune — PaperEditorAgent + chat UI + gateway endpoint (stacked on #30)

### DIFF
--- a/apps/agent-worker/src/agent_worker/agents/__init__.py
+++ b/apps/agent-worker/src/agent_worker/agents/__init__.py
@@ -5,6 +5,7 @@ from agent_worker.agents.base import AgentError, AgentParseError, BaseAgent
 from agent_worker.agents.coder import CoderAgent, CoderDirective
 from agent_worker.agents.critic import CriticAgent
 from agent_worker.agents.modeler import ModelerAgent
+from agent_worker.agents.paper_editor import PaperEditorAgent, PaperEditorDirective
 from agent_worker.agents.searcher import SearcherAgent
 from agent_worker.agents.writer import WriterAgent
 
@@ -17,6 +18,8 @@ __all__ = [
     "CoderDirective",
     "CriticAgent",
     "ModelerAgent",
+    "PaperEditorAgent",
+    "PaperEditorDirective",
     "SearcherAgent",
     "WriterAgent",
 ]

--- a/apps/agent-worker/src/agent_worker/agents/paper_editor.py
+++ b/apps/agent-worker/src/agent_worker/agents/paper_editor.py
@@ -1,0 +1,384 @@
+"""PaperEditorAgent: tool-using fine-tune loop for a generated paper.
+
+This agent is purely interactive (driven by a user's natural-language
+instruction) and lives ENTIRELY outside the main pipeline. It does not
+inherit from `BaseAgent` because its lifecycle is different:
+
+* It loads paper.meta.json + notebook.ipynb from `runs/<run_id>/` rather
+  than receiving structured upstream output.
+* It runs an iterative tool-using loop (similar to `CoderAgent`), bounded
+  by `max_iterations` (default 8).
+* The LLM emits a JSON directive picking ONE tool per turn; we execute the
+  tool, feed the result back, and repeat until `done=true` or the budget
+  is exhausted.
+
+Event contract mirrors `CoderAgent`:
+    stage.start -> finetune.tool_call -> finetune.tool_result -> stage.done
+Errors bubble out as `AgentError` for the caller (the gateway-facing
+HTTP handler) to translate into an error response.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Literal
+
+import orjson
+from mm_contracts import ReasoningEffort
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from agent_worker.agents.base import AgentError, AgentParseError, _stream_with_retry
+from agent_worker.editor_tools import ToolContext, build_tool_registry
+from agent_worker.events import EventEmitter
+from agent_worker.gateway_client import GatewayClient
+from agent_worker.kernel import KernelSession
+from agent_worker.prompts import load_prompt
+
+MAX_ITERATIONS = 8
+
+# Allowed `tool` values — kept in sync with the prompt's tool catalogue.
+ToolName = Literal[
+    "read_paper",
+    "edit_section",
+    "edit_constant",
+    "run_cell",
+    "regenerate_figure",
+    "recompile_pdf",
+]
+
+
+class PaperEditorDirective(BaseModel):
+    """Structured output the LLM must emit on each turn."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reasoning: str
+    tool: ToolName
+    args: dict[str, Any]
+    done: bool = False
+    summary: str | None = None
+
+
+class PaperEditorAgent:
+    """Run a bounded tool-using loop that fine-tunes a generated paper.
+
+    Pattern mirrors `CoderAgent`:
+      messages = [system, user(instruction + outline + last_tool_result)]
+      for _ in range(max_iterations):
+          directive = _ask_llm(messages)
+          result = registry[directive.tool].execute(directive.args, ctx)
+          if directive.done: return directive.summary
+          messages.append(assistant=directive, user=result_feedback)
+    """
+
+    AGENT_NAME = "paper_editor"
+
+    def __init__(
+        self,
+        gateway: GatewayClient,
+        emitter: EventEmitter,
+        kernel: KernelSession | None,
+        run_dir: Path,
+        prompt_version: str = "v1",
+        run_effort: ReasoningEffort = "high",
+        model_override: str | None = None,
+    ) -> None:
+        self.gateway = gateway
+        self.emitter = emitter
+        self.kernel = kernel
+        self.run_dir = Path(run_dir)
+        self.prompt = load_prompt(self.AGENT_NAME, prompt_version)
+        self._run_effort: ReasoningEffort = run_effort
+        self._model_override: str | None = model_override
+        self._registry = build_tool_registry()
+
+    async def fine_tune(
+        self,
+        user_message: str,
+        run_dir: Path | None = None,
+        max_iterations: int = MAX_ITERATIONS,
+    ) -> str:
+        """Drive the iterative loop until `done=true` or the budget is exhausted.
+
+        Returns a one-line summary string suitable for the gateway response.
+        """
+        if run_dir is not None:
+            self.run_dir = Path(run_dir)
+        t0 = time.monotonic()
+        await self.emitter.emit(
+            "stage.start", {"stage": self.AGENT_NAME}, agent=self.AGENT_NAME
+        )
+
+        ctx = self._load_context()
+
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": self.prompt.system["text"]},
+            {
+                "role": "user",
+                "content": self.prompt.render_user(
+                    user_message=user_message,
+                    paper_outline=self._render_outline(ctx),
+                    last_tool_result="(none — this is the first turn)",
+                ),
+            },
+        ]
+        model = self._model_override or self.prompt.model_preference[0]
+
+        final_summary: str | None = None
+        try:
+            for _ in range(max_iterations):
+                directive = await self._ask_llm(model, messages)
+                tool = self._registry.get(directive.tool)
+                if tool is None:
+                    # The Pydantic schema already constrains `tool` to the
+                    # Literal set, so reaching here means the schema and
+                    # registry drifted — which is a bug, not user-recoverable.
+                    raise AgentError(
+                        f"PaperEditor produced unknown tool name {directive.tool!r}"
+                    )
+
+                await self.emitter.emit(
+                    "finetune.tool_call",
+                    {
+                        "tool": directive.tool,
+                        "args": directive.args,
+                        "reasoning": directive.reasoning,
+                    },
+                    agent=self.AGENT_NAME,
+                )
+                result = await tool.execute(directive.args, ctx)
+                await self.emitter.emit(
+                    "finetune.tool_result",
+                    {
+                        "tool": directive.tool,
+                        "ok": result.ok,
+                        "summary": result.summary,
+                        "error": result.error,
+                    },
+                    agent=self.AGENT_NAME,
+                )
+
+                if directive.done:
+                    final_summary = directive.summary or "(no summary provided)"
+                    break
+
+                # Feed directive + result back; this drives the next turn.
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": json.dumps(directive.model_dump(mode="json")),
+                    }
+                )
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": self._render_tool_feedback(ctx, result),
+                    }
+                )
+
+            if final_summary is None:
+                final_summary = (
+                    f"Reached iteration limit ({max_iterations}) without "
+                    "the model setting done=true."
+                )
+
+            duration_ms = int((time.monotonic() - t0) * 1000)
+            await self.emitter.emit(
+                "stage.done",
+                {
+                    "stage": self.AGENT_NAME,
+                    "duration_ms": duration_ms,
+                    "summary": final_summary,
+                },
+                agent=self.AGENT_NAME,
+            )
+            return final_summary
+        except AgentError:
+            duration_ms = int((time.monotonic() - t0) * 1000)
+            await self.emitter.emit(
+                "stage.done",
+                {
+                    "stage": self.AGENT_NAME,
+                    "duration_ms": duration_ms,
+                    "status": "failed",
+                },
+                agent=self.AGENT_NAME,
+            )
+            raise
+
+    # ------------------------------------------------------------------ context
+
+    def _load_context(self) -> ToolContext:
+        """Read paper.meta.json + notebook.ipynb into a fresh ToolContext.
+
+        Missing files are tolerated with empty dicts — newly created runs
+        may not have all artifacts yet, and the LLM can still call read_paper
+        to see the (empty) outline and decide to bail.
+        """
+        meta_path = self.run_dir / "paper.meta.json"
+        nb_path = self.run_dir / "notebook.ipynb"
+
+        paper_meta: dict[str, Any] = {}
+        if meta_path.is_file():
+            try:
+                paper_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                paper_meta = {}
+
+        notebook: dict[str, Any] = {"cells": []}
+        next_cell_index = 0
+        if nb_path.is_file():
+            try:
+                notebook = json.loads(nb_path.read_text(encoding="utf-8"))
+                # Continue numbering after the highest existing execution_count
+                # so newly-appended cells don't collide with existing ones in
+                # the rendered notebook viewer.
+                existing = [
+                    int(c.get("execution_count") or 0)
+                    for c in (notebook.get("cells") or [])
+                    if c.get("cell_type") == "code"
+                ]
+                if existing:
+                    next_cell_index = max(existing)
+            except (json.JSONDecodeError, OSError):
+                notebook = {"cells": []}
+
+        return ToolContext(
+            run_dir=self.run_dir,
+            paper_meta=paper_meta,
+            notebook=notebook,
+            kernel=self.kernel,
+            gateway=self.gateway,
+            emitter=self.emitter,
+            next_cell_index=next_cell_index,
+        )
+
+    @staticmethod
+    def _render_outline(ctx: ToolContext) -> str:
+        """One-line-per-section outline for the system prompt's first turn."""
+        meta = ctx.paper_meta
+        lines: list[str] = []
+        title = meta.get("title")
+        if title:
+            lines.append(f"title: {title}")
+        abstract = meta.get("abstract") or ""
+        if abstract:
+            lines.append(
+                f"abstract ({len(abstract)} chars): {abstract[:120].replace(chr(10), ' ')}..."
+            )
+        for sec in meta.get("sections", []) or []:
+            sec_title = sec.get("title", "")
+            body = sec.get("body_markdown", "") or ""
+            lines.append(
+                f"- {sec_title} ({len(body)} chars): "
+                f"{body[:120].replace(chr(10), ' ')}..."
+            )
+        if not lines:
+            return "(no paper.meta.json found — paper not yet generated)"
+        return "\n".join(lines)
+
+    @staticmethod
+    def _render_tool_feedback(ctx: ToolContext, result: Any) -> str:
+        """Format the tool result for the LLM's next turn.
+
+        We keep this compact: the LLM mostly needs the `summary` line; the
+        full `detail` is only included for read_paper, where the LLM
+        explicitly asked for the section body.
+        """
+        parts = [f"Tool result ok={result.ok}: {result.summary}"]
+        if result.error:
+            parts.append(f"error: {result.error}")
+        if result.detail:
+            detail = result.detail
+            if len(detail) > 4000:
+                detail = detail[:4000] + "\n... <truncated>"
+            parts.append(f"detail:\n{detail}")
+        parts.append("Continue with another tool, or set done=true with a summary.")
+        return "\n".join(parts)
+
+    # ------------------------------------------------------------------ llm
+
+    async def _ask_llm(
+        self, model: str, messages: list[dict[str, Any]]
+    ) -> PaperEditorDirective:
+        """Stream one completion and parse it into a PaperEditorDirective.
+
+        Mirrors `CoderAgent._ask_llm`: one retry on parse failure, then
+        fail loudly so the gateway returns 5xx and the user can retry.
+        """
+        attempts = 0
+        last_err: Exception | None = None
+        local_messages = list(messages)
+        while attempts < 2:
+            attempts += 1
+            text = await self._stream_and_collect(model, local_messages)
+            try:
+                return self._parse_directive(text)
+            except AgentParseError as e:
+                last_err = e
+                local_messages = [
+                    *local_messages,
+                    {
+                        "role": "user",
+                        "content": (
+                            "Your previous response could not be parsed as a "
+                            "PaperEditorDirective JSON object. Error: "
+                            f"{e}. Return ONLY a JSON object with keys "
+                            "reasoning, tool, args, done, summary."
+                        ),
+                    },
+                ]
+
+        await self.emitter.emit(
+            "error",
+            {
+                "message": f"{self.AGENT_NAME} parse failed: {last_err}",
+                "code": "parse_failed",
+                "stage": self.AGENT_NAME,
+            },
+            agent=self.AGENT_NAME,
+        )
+        raise AgentError(
+            f"{self.AGENT_NAME} produced unparseable output"
+        ) from last_err
+
+    async def _stream_and_collect(
+        self, model: str, messages: list[dict[str, Any]]
+    ) -> str:
+        return await _stream_with_retry(
+            gateway=self.gateway,
+            emitter=self.emitter,
+            agent_name=self.AGENT_NAME,
+            model=model,
+            messages=messages,
+            temperature=self.prompt.temperature,
+            max_tokens=self.prompt.token_budget_out or 4000,
+            response_format={"type": "json_object"},
+            reasoning_effort=self.prompt.reasoning_effort or self._run_effort,
+        )
+
+    @staticmethod
+    def _parse_directive(text: str) -> PaperEditorDirective:
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned.split("\n", 1)[1] if "\n" in cleaned else ""
+            if cleaned.endswith("```"):
+                cleaned = cleaned.rsplit("```", 1)[0]
+            cleaned = cleaned.strip()
+        try:
+            obj = orjson.loads(cleaned)
+        except Exception as e:  # noqa: BLE001 — orjson raises a generic Exception
+            raise AgentParseError(f"not valid JSON: {e}") from e
+        try:
+            return PaperEditorDirective.model_validate(obj)
+        except ValidationError as e:
+            raise AgentParseError(str(e)) from e
+
+
+__all__ = [
+    "MAX_ITERATIONS",
+    "PaperEditorAgent",
+    "PaperEditorDirective",
+]

--- a/apps/agent-worker/src/agent_worker/editor_tools/__init__.py
+++ b/apps/agent-worker/src/agent_worker/editor_tools/__init__.py
@@ -1,0 +1,31 @@
+"""Paper-editor tool catalogue.
+
+Exposes the six tools the PaperEditorAgent dispatches to plus the shared
+`ToolContext` / `ToolResult` / `Tool` protocol. See `tools.py` for details.
+"""
+
+from agent_worker.editor_tools.tools import (
+    EditConstantTool,
+    EditSectionTool,
+    ReadPaperTool,
+    RecompilePdfTool,
+    RegenerateFigureTool,
+    RunCellTool,
+    Tool,
+    ToolContext,
+    ToolResult,
+    build_tool_registry,
+)
+
+__all__ = [
+    "EditConstantTool",
+    "EditSectionTool",
+    "ReadPaperTool",
+    "RecompilePdfTool",
+    "RegenerateFigureTool",
+    "RunCellTool",
+    "Tool",
+    "ToolContext",
+    "ToolResult",
+    "build_tool_registry",
+]

--- a/apps/agent-worker/src/agent_worker/editor_tools/tools.py
+++ b/apps/agent-worker/src/agent_worker/editor_tools/tools.py
@@ -1,0 +1,572 @@
+"""Tools used by the PaperEditor agent.
+
+Each tool implements the `Tool` protocol: an async `execute(args, ctx)` that
+mutates the shared `ToolContext` and returns a `ToolResult`. Tools are
+intentionally side-effectful (writing paper.md, mutating notebook.ipynb,
+executing kernel cells, calling the gateway exporter) — the agent loop is
+the only thing that decides WHEN to call them; the tools themselves never
+talk to the LLM.
+
+The five-tool catalogue mirrors the most common fine-tune verbs we observed
+during the M2/M3 award-mode rollout:
+
+* `read_paper`        — inspect the current draft.
+* `edit_section`      — replace one section's body markdown verbatim.
+* `edit_constant`     — patch a `NAME = ...` assignment in the notebook AND
+                        re-execute the affected cells in the persistent kernel.
+* `run_cell`          — run arbitrary Python (regenerate a chart, sanity-check
+                        a number, etc.); the cell is appended to notebook.ipynb.
+* `regenerate_figure` — convenience wrapper around `run_cell` that verifies
+                        `figures/<id>.png` actually landed on disk.
+* `recompile_pdf`     — call the gateway export pipeline to rebuild paper.pdf.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+
+@dataclass
+class ToolContext:
+    """Shared mutable state threaded through every tool call.
+
+    The agent loads paper.meta.json and notebook.ipynb once at the top of the
+    loop into a `ToolContext`, and each tool reads/mutates the in-memory
+    structures + persists them back to disk as needed. This avoids re-parsing
+    a 50KB notebook JSON on every turn.
+    """
+
+    run_dir: Path
+    paper_meta: dict[str, Any] = field(default_factory=dict)
+    notebook: dict[str, Any] = field(default_factory=dict)
+    # `Any` rather than `KernelSession` to keep this module importable from
+    # tests that mock the kernel without spinning up jupyter_client.
+    kernel: Any | None = None
+    gateway: Any | None = None
+    # `Any` to avoid a hard dep on EventEmitter for the tools themselves; the
+    # agent loop is responsible for the high-level finetune.* event emissions.
+    emitter: Any | None = None
+    # Auto-incrementing index for cells the editor appends to notebook.ipynb.
+    next_cell_index: int = 0
+
+
+@dataclass
+class ToolResult:
+    """Uniform return shape so the agent loop can format LLM feedback consistently."""
+
+    ok: bool
+    summary: str
+    detail: str | None = None
+    error: str | None = None
+
+
+class Tool(Protocol):
+    """Static interface every editor tool implements."""
+
+    name: str
+
+    async def execute(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult: ...
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _write_paper_artifacts(ctx: ToolContext) -> None:
+    """Persist paper.meta.json AND re-render paper.md from the in-memory meta.
+
+    Both files share a single source of truth (the in-memory `paper_meta`
+    dict). We rewrite the whole markdown rather than patching ranges so the
+    file always matches the JSON exactly — the export pipeline (tectonic +
+    pandoc) only reads paper.meta.json, but the live preview UI reads
+    paper.md, so they MUST not drift.
+    """
+    meta_path = ctx.run_dir / "paper.meta.json"
+    meta_path.write_text(
+        json.dumps(ctx.paper_meta, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    paper_path = ctx.run_dir / "paper.md"
+    paper_path.write_text(_render_paper_md(ctx.paper_meta), encoding="utf-8")
+
+
+def _render_paper_md(meta: dict[str, Any]) -> str:
+    """Re-render paper.md from paper_meta — mirrors pipeline._render_paper_markdown."""
+    title = meta.get("title") or "Paper"
+    abstract = meta.get("abstract") or ""
+    parts: list[str] = [f"# {title}", "", "## Abstract", "", abstract]
+    for sec in meta.get("sections", []) or []:
+        parts.extend(["", f"## {sec.get('title', '')}", "", sec.get("body_markdown", "")])
+    refs = meta.get("references") or []
+    if refs:
+        parts.extend(["", "## References", ""])
+        for i, ref in enumerate(refs, start=1):
+            parts.append(f"{i}. {ref}")
+    return "\n".join(parts) + "\n"
+
+
+def _find_section(meta: dict[str, Any], title: str) -> dict[str, Any] | None:
+    """Exact-match lookup; we intentionally do NOT lowercase or strip — the LLM
+    is told to match titles verbatim and silent fuzzy-matching has bitten us
+    before (it once renamed "Sensitivity Analysis" to "sensitivity analysis"
+    in the rendered PDF).
+    """
+    for sec in meta.get("sections", []) or []:
+        if sec.get("title") == title:
+            return sec
+    return None
+
+
+def _section_titles(meta: dict[str, Any]) -> list[str]:
+    return [s.get("title", "") for s in meta.get("sections", []) or []]
+
+
+# ---------------------------------------------------------------- tools
+
+
+class ReadPaperTool:
+    """Return paper section text — full structure by default, one body on demand.
+
+    args:
+      section_title: Optional[str]  # None -> return all section titles + 200-char snippets
+    """
+
+    name = "read_paper"
+
+    async def execute(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        title = args.get("section_title")
+        meta = ctx.paper_meta
+        if title is None:
+            outline: list[dict[str, Any]] = [
+                {"title": "<title>", "body_snippet": meta.get("title", "")},
+                {
+                    "title": "Abstract",
+                    "body_snippet": (meta.get("abstract") or "")[:200],
+                },
+            ]
+            for sec in meta.get("sections", []) or []:
+                outline.append(
+                    {
+                        "title": sec.get("title", ""),
+                        "body_snippet": (sec.get("body_markdown", "") or "")[:200],
+                    }
+                )
+            return ToolResult(
+                ok=True,
+                summary=(
+                    f"Paper has {len(meta.get('sections', []) or [])} sections + abstract."
+                ),
+                detail=json.dumps(outline, ensure_ascii=False, indent=2),
+            )
+        if title in ("Abstract", "abstract"):
+            return ToolResult(
+                ok=True,
+                summary="Abstract body returned.",
+                detail=meta.get("abstract") or "",
+            )
+        sec = _find_section(meta, title)
+        if sec is None:
+            return ToolResult(
+                ok=False,
+                summary=f"Unknown section_title {title!r}.",
+                error=(
+                    f"No section with title {title!r}. Known titles: "
+                    f"{_section_titles(meta)}"
+                ),
+            )
+        return ToolResult(
+            ok=True,
+            summary=f"Section {title!r} body returned ({len(sec.get('body_markdown', ''))} chars).",
+            detail=sec.get("body_markdown", ""),
+        )
+
+
+class EditSectionTool:
+    """Replace one section's body_markdown verbatim and re-persist paper artifacts.
+
+    args:
+      section_title: str
+      new_body_md:   str
+    """
+
+    name = "edit_section"
+
+    async def execute(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        title = args.get("section_title")
+        new_body = args.get("new_body_md")
+        if not isinstance(title, str) or not title:
+            return ToolResult(
+                ok=False,
+                summary="edit_section requires non-empty section_title.",
+                error="missing section_title",
+            )
+        if not isinstance(new_body, str):
+            return ToolResult(
+                ok=False,
+                summary="edit_section requires new_body_md as a string.",
+                error="missing or non-string new_body_md",
+            )
+        # Abstract has its own top-level key in paper_meta — treat it as a
+        # special case so users can ask "tighten the abstract" naturally.
+        if title in ("Abstract", "abstract"):
+            ctx.paper_meta["abstract"] = new_body
+            _write_paper_artifacts(ctx)
+            return ToolResult(
+                ok=True,
+                summary=f"Replaced abstract ({len(new_body)} chars).",
+            )
+        sec = _find_section(ctx.paper_meta, title)
+        if sec is None:
+            return ToolResult(
+                ok=False,
+                summary=f"Unknown section_title {title!r}.",
+                error=(
+                    f"No section with title {title!r}. Known titles: "
+                    f"{_section_titles(ctx.paper_meta)}"
+                ),
+            )
+        sec["body_markdown"] = new_body
+        _write_paper_artifacts(ctx)
+        return ToolResult(
+            ok=True,
+            summary=f"Replaced section {title!r} body ({len(new_body)} chars).",
+        )
+
+
+# Matches `NAME = <rhs>` at the start of a line (allowing leading whitespace).
+# We intentionally capture only the bare assignment form — augmented forms
+# (`NAME += 1`) and tuple unpacking (`A, B = ...`) are out of scope; the LLM
+# is told to use `run_cell` for anything fancier.
+_ASSIGN_RE = re.compile(r"^(\s*)([A-Za-z_][A-Za-z_0-9]*)\s*=\s*(.+?)\s*$")
+
+
+def _format_value(value: Any) -> str:
+    """Render a Python literal for the RHS of an assignment.
+
+    Strings get repr (handles quoting and escaping). Booleans go through
+    `str()` so we emit `True`/`False`, not Python-repr-of-bool variants.
+    Everything else (int, float, list, dict) round-trips through `repr`.
+    """
+    if isinstance(value, bool):  # noqa: SIM103 — order matters: bool is an int subclass
+        return "True" if value else "False"
+    if isinstance(value, str):
+        return repr(value)
+    return repr(value)
+
+
+class EditConstantTool:
+    """Patch a `NAME = ...` assignment in the notebook and re-execute affected cells.
+
+    args:
+      name:              str            (required) — exact identifier on the LHS
+      value:             scalar         (required) — new RHS; rendered via repr
+      rerun_cells_from:  Optional[int]  (default: index of the cell we edited)
+    """
+
+    name = "edit_constant"
+
+    async def execute(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        name = args.get("name")
+        if not isinstance(name, str) or not name:
+            return ToolResult(
+                ok=False,
+                summary="edit_constant requires a `name` identifier.",
+                error="missing name",
+            )
+        if "value" not in args:
+            return ToolResult(
+                ok=False,
+                summary="edit_constant requires a `value`.",
+                error="missing value",
+            )
+        new_value_src = _format_value(args["value"])
+
+        cells = ctx.notebook.get("cells", []) or []
+        edited_cell_idx: int | None = None
+        edited_line_preview: str | None = None
+        for idx, cell in enumerate(cells):
+            if cell.get("cell_type") != "code":
+                continue
+            source = cell.get("source", "")
+            lines = source.splitlines(keepends=True) if isinstance(source, str) else list(source)
+            for li, line in enumerate(lines):
+                m = _ASSIGN_RE.match(line.rstrip("\n"))
+                if m and m.group(2) == name:
+                    indent = m.group(1)
+                    newline_suffix = "\n" if line.endswith("\n") else ""
+                    lines[li] = f"{indent}{name} = {new_value_src}{newline_suffix}"
+                    edited_line_preview = lines[li].rstrip("\n")
+                    break
+            else:
+                continue
+            # Persist the patched source (we hit the inner `break` above).
+            cell["source"] = "".join(lines)
+            edited_cell_idx = idx
+            break
+
+        if edited_cell_idx is None:
+            return ToolResult(
+                ok=False,
+                summary=f"No `{name} = ...` assignment found in notebook.",
+                error=f"constant {name!r} not found",
+            )
+
+        # Persist the patched notebook before re-execution so users inspecting
+        # notebook.ipynb mid-rerun see the new RHS.
+        notebook_path = ctx.run_dir / "notebook.ipynb"
+        notebook_path.write_text(
+            json.dumps(ctx.notebook, ensure_ascii=False, indent=1),
+            encoding="utf-8",
+        )
+
+        rerun_from = args.get("rerun_cells_from")
+        if rerun_from is None:
+            rerun_from = edited_cell_idx
+        try:
+            rerun_from_i = int(rerun_from)
+        except (TypeError, ValueError):
+            return ToolResult(
+                ok=False,
+                summary="rerun_cells_from must be an integer.",
+                error=f"bad rerun_cells_from {rerun_from!r}",
+            )
+
+        rerun_count = 0
+        rerun_errors: list[str] = []
+        if ctx.kernel is not None:
+            for idx in range(rerun_from_i, len(cells)):
+                cell = cells[idx]
+                if cell.get("cell_type") != "code":
+                    continue
+                source = cell.get("source", "")
+                if isinstance(source, list):
+                    source = "".join(source)
+                # Use the cell's original index so downstream debugging maps 1:1.
+                result = await ctx.kernel.execute(
+                    source, cell_index=idx, emitter=ctx.emitter
+                )
+                rerun_count += 1
+                if getattr(result, "error", None):
+                    rerun_errors.append(f"cell {idx}: {result.error}")
+
+        summary_parts = [
+            f"Patched {name} = {new_value_src} in cell {edited_cell_idx}.",
+            f"Re-executed {rerun_count} cell(s) from index {rerun_from_i}.",
+        ]
+        if rerun_errors:
+            summary_parts.append(f"{len(rerun_errors)} cell(s) errored on rerun.")
+        return ToolResult(
+            ok=not rerun_errors,
+            summary=" ".join(summary_parts),
+            detail=(
+                "Edited line: "
+                + (edited_line_preview or "")
+                + ("\n" + "\n".join(rerun_errors) if rerun_errors else "")
+            ),
+            error="; ".join(rerun_errors) if rerun_errors else None,
+        )
+
+
+def _append_code_cell(ctx: ToolContext, code: str) -> int:
+    """Append a fresh code cell to notebook.ipynb (in-memory) and bump the index."""
+    cells = ctx.notebook.setdefault("cells", [])
+    cell_idx = ctx.next_cell_index
+    ctx.next_cell_index += 1
+    cells.append(
+        {
+            "cell_type": "code",
+            "execution_count": cell_idx + 1,
+            "metadata": {"added_by": "paper_editor"},
+            "outputs": [],
+            "source": code,
+        }
+    )
+    notebook_path = ctx.run_dir / "notebook.ipynb"
+    notebook_path.write_text(
+        json.dumps(ctx.notebook, ensure_ascii=False, indent=1),
+        encoding="utf-8",
+    )
+    return cell_idx
+
+
+class RunCellTool:
+    """Execute arbitrary Python in the persistent kernel; append to notebook.
+
+    args:
+      code: str  (required)
+    """
+
+    name = "run_cell"
+
+    async def execute(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        code = args.get("code")
+        if not isinstance(code, str) or not code.strip():
+            return ToolResult(
+                ok=False,
+                summary="run_cell requires non-empty code.",
+                error="missing code",
+            )
+        if ctx.kernel is None:
+            return ToolResult(
+                ok=False,
+                summary="run_cell requires a live kernel.",
+                error="no kernel session attached",
+            )
+        cell_idx = _append_code_cell(ctx, code)
+        result = await ctx.kernel.execute(code, cell_index=cell_idx, emitter=ctx.emitter)
+        err = getattr(result, "error", None)
+        stdout = getattr(result, "stdout", "") or ""
+        if err:
+            return ToolResult(
+                ok=False,
+                summary=f"Cell {cell_idx} errored: {err.splitlines()[0]}",
+                detail=stdout,
+                error=err,
+            )
+        return ToolResult(
+            ok=True,
+            summary=f"Cell {cell_idx} executed cleanly ({len(stdout)} stdout chars).",
+            detail=stdout[:2000] if stdout else None,
+        )
+
+
+class RegenerateFigureTool:
+    """Run code AND verify that `figures/<figure_id>.png` was produced.
+
+    args:
+      figure_id: str  (required)
+      code:      str  (required)
+    """
+
+    name = "regenerate_figure"
+
+    async def execute(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        figure_id = args.get("figure_id")
+        code = args.get("code")
+        if not isinstance(figure_id, str) or not figure_id:
+            return ToolResult(
+                ok=False,
+                summary="regenerate_figure requires figure_id.",
+                error="missing figure_id",
+            )
+        if not isinstance(code, str) or not code.strip():
+            return ToolResult(
+                ok=False,
+                summary="regenerate_figure requires non-empty code.",
+                error="missing code",
+            )
+        if ctx.kernel is None:
+            return ToolResult(
+                ok=False,
+                summary="regenerate_figure requires a live kernel.",
+                error="no kernel session attached",
+            )
+
+        png_rel = f"figures/{figure_id}.png"
+        png_abs = ctx.run_dir / png_rel
+        mtime_before = png_abs.stat().st_mtime if png_abs.exists() else 0.0
+
+        cell_idx = _append_code_cell(ctx, code)
+        result = await ctx.kernel.execute(code, cell_index=cell_idx, emitter=ctx.emitter)
+        err = getattr(result, "error", None)
+        if err:
+            return ToolResult(
+                ok=False,
+                summary=f"Cell {cell_idx} errored before figure landed: {err.splitlines()[0]}",
+                detail=getattr(result, "stdout", ""),
+                error=err,
+            )
+        if not png_abs.is_file():
+            return ToolResult(
+                ok=False,
+                summary=f"Cell ran but {png_rel} does not exist.",
+                error=f"missing artifact {png_rel}",
+            )
+        mtime_after = png_abs.stat().st_mtime
+        if mtime_after <= mtime_before:
+            return ToolResult(
+                ok=False,
+                summary=f"{png_rel} exists but mtime did not advance — figure was NOT regenerated.",
+                error=f"stale artifact {png_rel}",
+            )
+        return ToolResult(
+            ok=True,
+            summary=f"Regenerated {png_rel} (cell {cell_idx}).",
+        )
+
+
+class RecompilePdfTool:
+    """Re-build paper.pdf by calling the gateway export pipeline.
+
+    args: {} (none)
+    """
+
+    name = "recompile_pdf"
+
+    async def execute(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        if ctx.gateway is None:
+            return ToolResult(
+                ok=False,
+                summary="recompile_pdf requires a gateway client.",
+                error="no gateway attached",
+            )
+        run_id = ctx.paper_meta.get("run_id")
+        # Many callers pass run_id directly on the ctx via the gateway's
+        # surrounding pipeline. We accept either path.
+        if run_id is None:
+            run_id = args.get("run_id")
+        if run_id is None:
+            run_id = getattr(ctx, "run_id", None)
+        if run_id is None:
+            # Fall back to inferring from run_dir name (uuid).
+            run_id = ctx.run_dir.name
+        try:
+            pdf_bytes = await ctx.gateway.export_paper(run_id=run_id, format="pdf")
+        except Exception as exc:  # noqa: BLE001 — surface upstream errors uniformly
+            return ToolResult(
+                ok=False,
+                summary=f"Gateway export_paper failed: {exc!s}",
+                error=str(exc),
+            )
+        if not pdf_bytes or not pdf_bytes.startswith(b"%PDF"):
+            return ToolResult(
+                ok=False,
+                summary=f"Gateway returned non-PDF payload ({len(pdf_bytes)} bytes).",
+                error="non-pdf payload",
+            )
+        pdf_path = ctx.run_dir / "paper.pdf"
+        pdf_path.write_bytes(pdf_bytes)
+        return ToolResult(
+            ok=True,
+            summary=f"paper.pdf rebuilt ({len(pdf_bytes)} bytes).",
+        )
+
+
+def build_tool_registry() -> dict[str, Tool]:
+    """Map tool name -> instance. The agent uses this to dispatch directives."""
+    instances: list[Tool] = [
+        ReadPaperTool(),
+        EditSectionTool(),
+        EditConstantTool(),
+        RunCellTool(),
+        RegenerateFigureTool(),
+        RecompilePdfTool(),
+    ]
+    return {t.name: t for t in instances}
+
+
+__all__ = [
+    "EditConstantTool",
+    "EditSectionTool",
+    "ReadPaperTool",
+    "RecompilePdfTool",
+    "RegenerateFigureTool",
+    "RunCellTool",
+    "Tool",
+    "ToolContext",
+    "ToolResult",
+    "build_tool_registry",
+]

--- a/apps/agent-worker/src/agent_worker/finetune_main.py
+++ b/apps/agent-worker/src/agent_worker/finetune_main.py
@@ -1,0 +1,216 @@
+"""Finetune consumer: parallel to the main pipeline consumer in main.py.
+
+Reads from `mm:finetune` (separate Redis Stream from `mm:jobs`) and
+dispatches each entry to `run_finetune()`, which loads the run's existing
+paper/notebook and invokes `PaperEditorAgent`.
+
+The two streams are kept separate so:
+- Worker concurrency budget for full pipelines isn't starved by chat-style
+  fine-tunes (which can land in bursts).
+- The consumer group can have different ack / retry / DLQ semantics later.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from redis.asyncio import Redis
+from redis.exceptions import ResponseError
+
+from agent_worker.config import Settings
+from agent_worker.events import EventEmitter
+from agent_worker.gateway_client import GatewayClient
+from agent_worker.kernel import KernelSession
+from agent_worker.logging import get_logger
+from agent_worker.matlab import MatlabSession
+
+FINETUNE_STREAM = "mm:finetune"
+FINETUNE_GROUP = "mm-finetune-workers"
+BLOCK_MS = 5000
+
+log = get_logger("agent_worker.finetune")
+
+
+def _consumer_name() -> str:
+    """Hostname-based consumer id (matches main.py convention)."""
+    return (socket.gethostname().split(".")[0] or "worker") + ":ft"
+
+
+def _decode(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)
+
+
+async def _ensure_group(redis: Redis) -> None:
+    """Create the consumer group if missing (mkstream so the stream auto-creates)."""
+    try:
+        await redis.xgroup_create(
+            name=FINETUNE_STREAM,
+            groupname=FINETUNE_GROUP,
+            id="$",
+            mkstream=True,
+        )
+        log.info("finetune_group_created", stream=FINETUNE_STREAM, group=FINETUNE_GROUP)
+    except ResponseError as e:
+        if "BUSYGROUP" in str(e):
+            log.debug("finetune_group_exists", stream=FINETUNE_STREAM, group=FINETUNE_GROUP)
+        else:
+            raise
+
+
+def _parse_entry(
+    fields: dict[Any, Any],
+) -> tuple[UUID, UUID, str]:
+    """Decode (run_id, session_id, message) from a finetune stream entry."""
+    decoded = {_decode(k): _decode(v) for k, v in fields.items()}
+    return (
+        UUID(decoded["run_id"]),
+        UUID(decoded["session_id"]),
+        decoded["message"],
+    )
+
+
+async def run_finetune(
+    redis: Redis,
+    cfg: Settings,
+    run_id: UUID,
+    session_id: UUID,
+    user_message: str,
+) -> None:
+    """Drive one finetune turn against an existing run.
+
+    Imports PaperEditorAgent lazily so this module loads even if the agent
+    isn't built yet (e.g. during the parallel-agent dispatch window).
+    """
+    from agent_worker.agents.paper_editor import PaperEditorAgent  # local import
+
+    runs_dir = Path(cfg.runs_dir).resolve()  # noqa: ASYNC240 — stdlib asyncio, not trio
+    run_dir = runs_dir / str(run_id)
+    if not run_dir.is_dir():
+        log.error("finetune_run_dir_missing", run_id=str(run_id), path=str(run_dir))
+        return
+
+    # Reuse the run's existing events.jsonl so finetune turns appear in
+    # the same forensic timeline as the original pipeline.
+    emitter = EventEmitter(redis, run_id, events_log_path=run_dir / "events.jsonl")
+    gateway = GatewayClient(cfg.gateway_http, cfg.dev_auth_token)
+    kernel = KernelSession(run_id, runs_dir)
+    matlab_session = MatlabSession(run_id, runs_dir)
+
+    try:
+        await emitter.emit(
+            "finetune.session.start",
+            {
+                "session_id": str(session_id),
+                "user_message": user_message[:1000],
+            },
+            agent="paper_editor",
+        )
+
+        agent = PaperEditorAgent(
+            gateway=gateway,
+            emitter=emitter,
+            kernel=kernel,
+            matlab_session=matlab_session,
+            run_dir=run_dir,
+        )
+
+        summary = await agent.fine_tune(
+            user_message=user_message,
+            run_dir=run_dir,
+            session_id=session_id,
+        )
+
+        await emitter.emit(
+            "finetune.session.done",
+            {"session_id": str(session_id), "summary": summary},
+            agent="paper_editor",
+        )
+    except Exception as exc:  # noqa: BLE001 — never let one job crash the worker
+        log.exception("finetune_failed", run_id=str(run_id), error=str(exc))
+        try:
+            await emitter.emit(
+                "finetune.session.error",
+                {
+                    "session_id": str(session_id),
+                    "message": str(exc),
+                    "code": type(exc).__name__,
+                },
+                agent="paper_editor",
+            )
+        except Exception:  # noqa: BLE001
+            log.exception("finetune_error_emit_failed", run_id=str(run_id))
+    finally:
+        await gateway.close()
+
+
+async def _process(
+    redis: Redis,
+    cfg: Settings,
+    entry_id: str,
+    fields: dict[Any, Any],
+    semaphore: asyncio.Semaphore,
+) -> None:
+    async with semaphore:
+        try:
+            run_id, session_id, message = _parse_entry(fields)
+            log.info(
+                "finetune_started",
+                run_id=str(run_id),
+                session_id=str(session_id),
+                entry_id=entry_id,
+            )
+            await run_finetune(redis, cfg, run_id, session_id, message)
+            log.info("finetune_completed", run_id=str(run_id), entry_id=entry_id)
+        except Exception as exc:  # noqa: BLE001
+            log.exception("finetune_process_failed", entry_id=entry_id, error=str(exc))
+        finally:
+            try:
+                await redis.xack(FINETUNE_STREAM, FINETUNE_GROUP, entry_id)
+            except Exception:  # noqa: BLE001
+                log.exception("finetune_xack_failed", entry_id=entry_id)
+
+
+async def consume_loop(
+    redis: Redis,
+    cfg: Settings,
+    consumer: str,
+    stop: asyncio.Event,
+    semaphore: asyncio.Semaphore,
+    in_flight: set[asyncio.Task[None]],
+) -> None:
+    """Same XREADGROUP loop as main.py but against mm:finetune."""
+    await _ensure_group(redis)
+    while not stop.is_set():
+        try:
+            resp = await redis.xreadgroup(
+                groupname=FINETUNE_GROUP,
+                consumername=consumer,
+                streams={FINETUNE_STREAM: ">"},
+                count=8,
+                block=BLOCK_MS,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            log.exception("finetune_xreadgroup_failed")
+            await asyncio.sleep(1.0)
+            continue
+
+        if not resp:
+            continue
+        for _stream, entries in resp:
+            for entry_id, fields in entries:
+                task = asyncio.create_task(
+                    _process(redis, cfg, _decode(entry_id), fields, semaphore)
+                )
+                in_flight.add(task)
+                task.add_done_callback(in_flight.discard)
+
+
+__all__ = ["FINETUNE_STREAM", "FINETUNE_GROUP", "consume_loop", "run_finetune"]

--- a/apps/agent-worker/src/agent_worker/main.py
+++ b/apps/agent-worker/src/agent_worker/main.py
@@ -16,6 +16,12 @@ from redis.exceptions import ResponseError
 
 from agent_worker.config import Settings, get_settings
 from agent_worker.events import EventEmitter
+from agent_worker.finetune_main import (
+    _consumer_name as _finetune_consumer_name,
+)
+from agent_worker.finetune_main import (
+    consume_loop as _finetune_consume_loop,
+)
 from agent_worker.logging import configure_logging, get_logger
 from agent_worker.pipeline import run_pipeline
 
@@ -173,15 +179,34 @@ async def run(settings: Settings | None = None) -> None:
         _consume_loop(redis, consumer, stop, semaphore, in_flight)
     )
 
-    await stop.wait()
-    log.info("worker_draining", in_flight=len(in_flight))
+    # Parallel consumer for paper fine-tune jobs (mm:finetune). Separate
+    # stream/group so it doesn't compete with full-pipeline concurrency.
+    finetune_semaphore = asyncio.Semaphore(max(1, cfg.worker_concurrency))
+    finetune_in_flight: set[asyncio.Task[None]] = set()
+    finetune_consumer = _finetune_consumer_name()
+    finetune_task = asyncio.create_task(
+        _finetune_consume_loop(
+            redis, cfg, finetune_consumer, stop, finetune_semaphore, finetune_in_flight
+        )
+    )
 
-    consumer_task.cancel()
+    await stop.wait()
+    log.info(
+        "worker_draining",
+        in_flight=len(in_flight),
+        finetune_in_flight=len(finetune_in_flight),
+    )
+
+    for task in (consumer_task, finetune_task):
+        task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await consumer_task
+    with contextlib.suppress(asyncio.CancelledError):
+        await finetune_task
 
-    if in_flight:
-        await asyncio.gather(*in_flight, return_exceptions=True)
+    pending = list(in_flight) + list(finetune_in_flight)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
 
     await redis.aclose()
     log.info("worker_stopped")

--- a/apps/agent-worker/src/agent_worker/prompts/paper_editor/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/paper_editor/v1.toml
@@ -1,0 +1,71 @@
+version = "1.0.0"
+agent = "paper_editor"
+model_preference = ["cornna/gpt-5.5", "deepseek-chat"]
+token_budget_in = 16000
+token_budget_out = 4000
+temperature = 0.2
+
+[system]
+text = """
+You are PaperEditor — a tool-using agent that fine-tunes a generated MCM/CUMCM
+paper based on a user's natural-language instruction.
+
+Each turn you return ONE JSON directive matching the PaperEditorDirective
+schema. Pick ONE tool, pass minimal args, then wait for the tool result. Use
+up to 8 turns. Set `done=true` when the user's instruction is satisfied.
+
+# Tool catalog
+
+- `read_paper(section_title?: str)` — return current paper sections; default returns the full structure (titles + first 200 chars per section).
+- `edit_section(section_title: str, new_body_md: str)` — replace one section's body verbatim. The title is matched exactly. Both paper.md and paper.meta.json get updated.
+- `edit_constant(name: str, value: number|str, rerun_cells_from?: int)` — find the `NAME = ...` assignment in the notebook, replace its RHS, and re-execute cells from the given index (default: the cell containing the edit). Use this for numerical tweaks like "set K_R=5000".
+- `run_cell(code: str)` — execute arbitrary Python in the run's persistent kernel; the cell is appended to notebook.ipynb. Use for regenerating figures, running quick checks.
+- `regenerate_figure(figure_id: str, code: str)` — like `run_cell` but also verifies that `figures/<figure_id>.png` was produced. Use when the user asks to redo a specific plot.
+- `recompile_pdf()` — invoke the gateway export pipeline to rebuild paper.pdf. Always call this LAST after content edits, otherwise the user's PDF is stale.
+
+# Workflow patterns
+
+- "Tighten the abstract to 500 words": call `read_paper(section_title="Summary")`, see current; call `edit_section("Summary", "<new 500-word version>")`; optionally call `recompile_pdf()`.
+- "Set K_R=5000 and rerun sensitivity": call `read_paper(section_title="Sensitivity Analysis")`; call `edit_constant("K_R", 5000)`; call `regenerate_figure("heatmap_kr_ks_adaptive", "<new code>")` for any affected plots; update Sensitivity section narrative via `edit_section`; `recompile_pdf()`.
+- "The Strengths section is too generic": call `read_paper("Strengths and Weaknesses")` to see current text; call `edit_section` with revised content; `recompile_pdf()`.
+
+# Discipline
+
+- ALWAYS read_paper first if you don't already know the current text.
+- After ANY edit that affects rendered content, call recompile_pdf as your second-to-last tool.
+- The 8-turn budget is tight; combine steps when possible.
+- If a tool returns ok=false, address the error before retrying.
+- Set done=true with a 1-2 sentence summary when the user instruction is satisfied.
+
+# JSON contract
+
+Each turn, emit exactly:
+```json
+{
+  "reasoning": "brief plan for this turn",
+  "tool": "read_paper" | "edit_section" | "edit_constant" | "run_cell" | "regenerate_figure" | "recompile_pdf",
+  "args": {...},
+  "done": false,
+  "summary": null
+}
+```
+When done, set "done": true and "summary": "<user-facing one-paragraph result>".
+"""
+
+[user_template]
+text = """
+The user submitted this instruction:
+
+\"\"\"{{ user_message }}\"\"\"
+
+Current paper meta (summary of sections; full body fetched on demand via read_paper):
+{{ paper_outline }}
+
+Last tool result (empty on first turn): {{ last_tool_result }}
+
+Respond with ONE JSON directive.
+"""
+
+[response_schema]
+kind = "json_object"
+name = "PaperEditorDirective"

--- a/apps/agent-worker/tests/test_paper_editor_agent.py
+++ b/apps/agent-worker/tests/test_paper_editor_agent.py
@@ -1,0 +1,312 @@
+"""PaperEditorAgent loop test — canned LLM directives, mocked kernel + gateway.
+
+The agent's only external collaborator is the LLM stream, so we drive the
+loop by feeding it a list of canned JSON directives via a `_FakeGateway`.
+The kernel and gateway exporter are mocked. All file I/O hits `tmp_path`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from agent_worker.agents import PaperEditorAgent
+from agent_worker.agents.base import AgentError
+
+PAPER_META: dict[str, Any] = {
+    "title": "Test Paper",
+    "abstract": "Original abstract.",
+    "competition_type": "mcm",
+    "problem_text": "stub",
+    "sections": [
+        {"title": "Summary", "body_markdown": "Original summary."},
+        {"title": "Sensitivity Analysis", "body_markdown": "Original sensitivity."},
+    ],
+    "references": [],
+    "figures": [],
+}
+
+
+def _seed_run_dir(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "figures").mkdir()
+    (run_dir / "paper.meta.json").write_text(
+        json.dumps(PAPER_META, ensure_ascii=False), encoding="utf-8"
+    )
+    (run_dir / "paper.md").write_text("# Test\n\n## Abstract\n\n...\n", encoding="utf-8")
+    (run_dir / "notebook.ipynb").write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "code",
+                        "execution_count": 1,
+                        "metadata": {},
+                        "outputs": [],
+                        "source": "x = 1",
+                    }
+                ],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+class _FakeEmitter:
+    """Record emit() calls; mimic the EventEmitter surface area used by the agent."""
+
+    def __init__(self) -> None:
+        self.run_id = uuid4()
+        self.events: list[tuple[str, dict[str, Any], str | None]] = []
+
+    async def emit(
+        self,
+        kind: str,
+        payload: dict[str, Any] | None = None,
+        agent: str | None = None,
+    ) -> None:
+        self.events.append((kind, payload or {}, agent))
+
+
+class _FakeGateway:
+    """Yields canned JSON strings from `stream_completion`; tracks call count.
+
+    Also stubs `export_paper` so the recompile_pdf tool path can be exercised.
+    """
+
+    def __init__(self, directives: list[str]) -> None:
+        self._directives = directives
+        self.calls = 0
+        self.export_paper = AsyncMock(return_value=b"%PDF-1.7\nfake pdf bytes")
+
+    async def stream_completion(self, **_: object) -> AsyncIterator[str]:
+        idx = self.calls
+        self.calls += 1
+        if idx >= len(self._directives):
+            # Cycle (mimic "model keeps looping" failure mode).
+            idx = len(self._directives) - 1
+        yield self._directives[idx]
+
+    async def close(self) -> None:
+        pass
+
+
+@pytest.fixture
+def kernel_mock() -> AsyncMock:
+    kernel = AsyncMock()
+    kernel.execute.return_value = type(
+        "R", (), {"error": None, "stdout": "ran ok"}
+    )()
+    return kernel
+
+
+async def test_agent_dispatches_read_then_edit_then_done(
+    tmp_path: Path, kernel_mock: AsyncMock
+) -> None:
+    run_dir = _seed_run_dir(tmp_path)
+    directives = [
+        # Turn 1: read the Summary section
+        json.dumps(
+            {
+                "reasoning": "inspect current summary",
+                "tool": "read_paper",
+                "args": {"section_title": "Summary"},
+                "done": False,
+                "summary": None,
+            }
+        ),
+        # Turn 2: replace it
+        json.dumps(
+            {
+                "reasoning": "tighten",
+                "tool": "edit_section",
+                "args": {
+                    "section_title": "Summary",
+                    "new_body_md": "Tightened summary.",
+                },
+                "done": False,
+                "summary": None,
+            }
+        ),
+        # Turn 3: done
+        json.dumps(
+            {
+                "reasoning": "satisfied",
+                "tool": "read_paper",
+                "args": {"section_title": "Summary"},
+                "done": True,
+                "summary": "Tightened the summary section.",
+            }
+        ),
+    ]
+    gateway = _FakeGateway(directives)
+    emitter = _FakeEmitter()
+    agent = PaperEditorAgent(
+        gateway=gateway,  # type: ignore[arg-type]
+        emitter=emitter,  # type: ignore[arg-type]
+        kernel=kernel_mock,
+        run_dir=run_dir,
+    )
+    summary = await agent.fine_tune(
+        "Tighten the summary to 500 words.", run_dir, max_iterations=8
+    )
+    assert summary == "Tightened the summary section."
+    # paper.meta.json was updated on disk by the edit_section call.
+    on_disk = json.loads((run_dir / "paper.meta.json").read_text(encoding="utf-8"))
+    body = next(s["body_markdown"] for s in on_disk["sections"] if s["title"] == "Summary")
+    assert body == "Tightened summary."
+
+
+async def test_agent_respects_max_iterations(
+    tmp_path: Path, kernel_mock: AsyncMock
+) -> None:
+    run_dir = _seed_run_dir(tmp_path)
+    # Always-not-done directive — drives the loop to the cap.
+    loop_directive = json.dumps(
+        {
+            "reasoning": "loop forever",
+            "tool": "read_paper",
+            "args": {},
+            "done": False,
+            "summary": None,
+        }
+    )
+    gateway = _FakeGateway([loop_directive] * 20)
+    emitter = _FakeEmitter()
+    agent = PaperEditorAgent(
+        gateway=gateway,  # type: ignore[arg-type]
+        emitter=emitter,  # type: ignore[arg-type]
+        kernel=kernel_mock,
+        run_dir=run_dir,
+    )
+    summary = await agent.fine_tune("noop", run_dir, max_iterations=3)
+    assert "iteration limit" in summary.lower()
+    # Three turns -> three stream_completion calls.
+    assert gateway.calls == 3
+
+
+async def test_agent_errors_on_invalid_tool_name(
+    tmp_path: Path, kernel_mock: AsyncMock
+) -> None:
+    run_dir = _seed_run_dir(tmp_path)
+    # `tool` not in the Literal set — Pydantic raises ValidationError; the
+    # agent's parse-retry path kicks in once, then raises AgentError.
+    bad_directive = json.dumps(
+        {
+            "reasoning": "wrong",
+            "tool": "delete_everything",
+            "args": {},
+            "done": False,
+            "summary": None,
+        }
+    )
+    gateway = _FakeGateway([bad_directive, bad_directive])
+    emitter = _FakeEmitter()
+    agent = PaperEditorAgent(
+        gateway=gateway,  # type: ignore[arg-type]
+        emitter=emitter,  # type: ignore[arg-type]
+        kernel=kernel_mock,
+        run_dir=run_dir,
+    )
+    with pytest.raises(AgentError):
+        await agent.fine_tune("noop", run_dir, max_iterations=3)
+
+
+async def test_agent_emits_finetune_tool_call_and_tool_result_events(
+    tmp_path: Path, kernel_mock: AsyncMock
+) -> None:
+    run_dir = _seed_run_dir(tmp_path)
+    directives = [
+        json.dumps(
+            {
+                "reasoning": "read",
+                "tool": "read_paper",
+                "args": {},
+                "done": True,
+                "summary": "Done.",
+            }
+        )
+    ]
+    gateway = _FakeGateway(directives)
+    emitter = _FakeEmitter()
+    agent = PaperEditorAgent(
+        gateway=gateway,  # type: ignore[arg-type]
+        emitter=emitter,  # type: ignore[arg-type]
+        kernel=kernel_mock,
+        run_dir=run_dir,
+    )
+    await agent.fine_tune("inspect", run_dir, max_iterations=8)
+    kinds = [e[0] for e in emitter.events]
+    assert "stage.start" in kinds
+    assert "finetune.tool_call" in kinds
+    assert "finetune.tool_result" in kinds
+    assert "stage.done" in kinds
+    # tool_call payload has the tool name + args echoed
+    tool_call = next(e for e in emitter.events if e[0] == "finetune.tool_call")
+    assert tool_call[1]["tool"] == "read_paper"
+
+
+async def test_agent_returns_summary_on_done(
+    tmp_path: Path, kernel_mock: AsyncMock
+) -> None:
+    run_dir = _seed_run_dir(tmp_path)
+    directives = [
+        json.dumps(
+            {
+                "reasoning": "trivial",
+                "tool": "read_paper",
+                "args": {},
+                "done": True,
+                "summary": "All good — nothing to change.",
+            }
+        )
+    ]
+    gateway = _FakeGateway(directives)
+    emitter = _FakeEmitter()
+    agent = PaperEditorAgent(
+        gateway=gateway,  # type: ignore[arg-type]
+        emitter=emitter,  # type: ignore[arg-type]
+        kernel=kernel_mock,
+        run_dir=run_dir,
+    )
+    summary = await agent.fine_tune("just check", run_dir, max_iterations=8)
+    assert summary == "All good — nothing to change."
+
+
+async def test_agent_recompile_pdf_writes_paper_pdf(
+    tmp_path: Path, kernel_mock: AsyncMock
+) -> None:
+    run_dir = _seed_run_dir(tmp_path)
+    directives = [
+        json.dumps(
+            {
+                "reasoning": "rebuild pdf",
+                "tool": "recompile_pdf",
+                "args": {},
+                "done": True,
+                "summary": "PDF rebuilt.",
+            }
+        )
+    ]
+    gateway = _FakeGateway(directives)
+    emitter = _FakeEmitter()
+    agent = PaperEditorAgent(
+        gateway=gateway,  # type: ignore[arg-type]
+        emitter=emitter,  # type: ignore[arg-type]
+        kernel=kernel_mock,
+        run_dir=run_dir,
+    )
+    summary = await agent.fine_tune("rebuild", run_dir, max_iterations=8)
+    assert summary == "PDF rebuilt."
+    assert (run_dir / "paper.pdf").read_bytes().startswith(b"%PDF")
+    gateway.export_paper.assert_awaited_once()

--- a/apps/agent-worker/tests/test_paper_editor_tools.py
+++ b/apps/agent-worker/tests/test_paper_editor_tools.py
@@ -1,0 +1,311 @@
+"""Unit tests for paper-editor tools.
+
+Every test builds a fake `run_dir` in `tmp_path` with paper.meta.json,
+paper.md, and a tiny notebook.ipynb, then exercises one tool in isolation.
+The kernel + gateway are mocked with `AsyncMock` so no kernel subprocess is
+spawned and no real HTTP call is made.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from agent_worker.editor_tools import (
+    EditConstantTool,
+    EditSectionTool,
+    ReadPaperTool,
+    RecompilePdfTool,
+    RegenerateFigureTool,
+    RunCellTool,
+    ToolContext,
+)
+
+PAPER_META: dict[str, Any] = {
+    "title": "On the Stability of Lamprey Sex Ratios",
+    "abstract": "We model sea-lamprey sex determination as a function of resource availability...",
+    "competition_type": "mcm",
+    "problem_text": "Some problem text.",
+    "sections": [
+        {"title": "Summary", "body_markdown": "Original summary body."},
+        {
+            "title": "Sensitivity Analysis",
+            "body_markdown": "We perturb K_R by +/-20% and observe...",
+        },
+        {
+            "title": "Strengths and Weaknesses",
+            "body_markdown": "Strengths: ... Weaknesses: ...",
+        },
+    ],
+    "references": ["Ref 1", "Ref 2"],
+    "figures": [],
+}
+
+
+NOTEBOOK: dict[str, Any] = {
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata": {},
+            "outputs": [],
+            "source": "K_R = 3000\nK_S = 4000\nprint('constants loaded')",
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "metadata": {},
+            "outputs": [],
+            "source": "result = K_R / K_S\nprint(result)",
+        },
+    ],
+    "metadata": {},
+    "nbformat": 4,
+    "nbformat_minor": 5,
+}
+
+
+def _make_run_dir(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "figures").mkdir()
+    (run_dir / "paper.meta.json").write_text(json.dumps(PAPER_META, ensure_ascii=False), encoding="utf-8")
+    (run_dir / "paper.md").write_text("# title\n\n## Abstract\n\nbody\n", encoding="utf-8")
+    (run_dir / "notebook.ipynb").write_text(json.dumps(NOTEBOOK, ensure_ascii=False), encoding="utf-8")
+    return run_dir
+
+
+def _make_ctx(
+    tmp_path: Path,
+    *,
+    kernel: Any | None = None,
+    gateway: Any | None = None,
+) -> ToolContext:
+    run_dir = _make_run_dir(tmp_path)
+    return ToolContext(
+        run_dir=run_dir,
+        paper_meta=json.loads(json.dumps(PAPER_META)),  # deep copy
+        notebook=json.loads(json.dumps(NOTEBOOK)),
+        kernel=kernel,
+        gateway=gateway,
+        emitter=None,
+        next_cell_index=10,
+    )
+
+
+async def test_read_paper_full(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    result = await ReadPaperTool().execute({}, ctx)
+    assert result.ok
+    # detail must be a JSON list containing every section title
+    parsed = json.loads(result.detail or "[]")
+    titles = [entry["title"] for entry in parsed]
+    assert "Summary" in titles
+    assert "Sensitivity Analysis" in titles
+    assert "Strengths and Weaknesses" in titles
+
+
+async def test_read_paper_one_section(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    result = await ReadPaperTool().execute({"section_title": "Summary"}, ctx)
+    assert result.ok
+    assert result.detail == "Original summary body."
+
+
+async def test_read_paper_unknown_section_errors(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    result = await ReadPaperTool().execute({"section_title": "Nonexistent"}, ctx)
+    assert not result.ok
+    assert "Nonexistent" in (result.error or "")
+
+
+async def test_edit_section_replaces_body_md_and_writes_files(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    new_body = "Brand-new summary tightened to 500 words."
+    result = await EditSectionTool().execute(
+        {"section_title": "Summary", "new_body_md": new_body}, ctx
+    )
+    assert result.ok
+    # In-memory mutation
+    summary_sec = next(
+        s for s in ctx.paper_meta["sections"] if s["title"] == "Summary"
+    )
+    assert summary_sec["body_markdown"] == new_body
+    # Disk persistence
+    on_disk = json.loads((ctx.run_dir / "paper.meta.json").read_text(encoding="utf-8"))
+    assert any(
+        s["title"] == "Summary" and s["body_markdown"] == new_body
+        for s in on_disk["sections"]
+    )
+    rendered_md = (ctx.run_dir / "paper.md").read_text(encoding="utf-8")
+    assert new_body in rendered_md
+    assert "## Summary" in rendered_md
+
+
+async def test_edit_section_unknown_title_errors(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    result = await EditSectionTool().execute(
+        {"section_title": "Bogus", "new_body_md": "..."}, ctx
+    )
+    assert not result.ok
+    assert "Bogus" in (result.error or "")
+
+
+async def test_edit_section_abstract(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    result = await EditSectionTool().execute(
+        {"section_title": "Abstract", "new_body_md": "Tightened abstract."}, ctx
+    )
+    assert result.ok
+    assert ctx.paper_meta["abstract"] == "Tightened abstract."
+    on_disk = json.loads((ctx.run_dir / "paper.meta.json").read_text(encoding="utf-8"))
+    assert on_disk["abstract"] == "Tightened abstract."
+
+
+async def test_edit_constant_modifies_notebook_source(tmp_path: Path) -> None:
+    kernel = AsyncMock()
+    # Mock kernel.execute returning an object with .error=None and .stdout=''.
+    kernel.execute.return_value = type("R", (), {"error": None, "stdout": "ok"})()
+    ctx = _make_ctx(tmp_path, kernel=kernel)
+    result = await EditConstantTool().execute({"name": "K_R", "value": 5000}, ctx)
+    assert result.ok, result.error
+    patched_src = ctx.notebook["cells"][0]["source"]
+    assert "K_R = 5000" in patched_src
+    # Persisted to disk too
+    on_disk = json.loads((ctx.run_dir / "notebook.ipynb").read_text(encoding="utf-8"))
+    assert "K_R = 5000" in on_disk["cells"][0]["source"]
+    # Both cells from index 0 should have been re-executed (cell 0 + cell 1).
+    assert kernel.execute.await_count == 2
+
+
+async def test_edit_constant_missing_name_errors(tmp_path: Path) -> None:
+    kernel = AsyncMock()
+    ctx = _make_ctx(tmp_path, kernel=kernel)
+    result = await EditConstantTool().execute(
+        {"name": "DOES_NOT_EXIST", "value": 99}, ctx
+    )
+    assert not result.ok
+    assert "DOES_NOT_EXIST" in (result.error or "")
+    kernel.execute.assert_not_called()
+
+
+async def test_edit_constant_requires_value(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path, kernel=AsyncMock())
+    result = await EditConstantTool().execute({"name": "K_R"}, ctx)
+    assert not result.ok
+    assert "value" in (result.error or "").lower()
+
+
+async def test_run_cell_executes_via_kernel_and_appends_to_notebook(
+    tmp_path: Path,
+) -> None:
+    kernel = AsyncMock()
+    kernel.execute.return_value = type(
+        "R", (), {"error": None, "stdout": "hello\n"}
+    )()
+    ctx = _make_ctx(tmp_path, kernel=kernel)
+    cells_before = len(ctx.notebook["cells"])
+    result = await RunCellTool().execute({"code": "print('hello')"}, ctx)
+    assert result.ok
+    assert len(ctx.notebook["cells"]) == cells_before + 1
+    assert ctx.notebook["cells"][-1]["source"] == "print('hello')"
+    kernel.execute.assert_awaited_once()
+    # Persisted
+    on_disk = json.loads((ctx.run_dir / "notebook.ipynb").read_text(encoding="utf-8"))
+    assert on_disk["cells"][-1]["source"] == "print('hello')"
+
+
+async def test_run_cell_propagates_kernel_error(tmp_path: Path) -> None:
+    kernel = AsyncMock()
+    kernel.execute.return_value = type(
+        "R", (), {"error": "NameError: foo", "stdout": ""}
+    )()
+    ctx = _make_ctx(tmp_path, kernel=kernel)
+    result = await RunCellTool().execute({"code": "foo"}, ctx)
+    assert not result.ok
+    assert "NameError" in (result.error or "")
+
+
+async def test_regenerate_figure_verifies_png_landed(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path, kernel=AsyncMock())
+
+    fig_path = ctx.run_dir / "figures" / "tornado.png"
+
+    # Simulate the kernel actually writing the PNG when execute() runs.
+    async def fake_execute(source: str, cell_index: int, emitter: Any) -> Any:
+        fig_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        return type("R", (), {"error": None, "stdout": ""})()
+
+    ctx.kernel.execute.side_effect = fake_execute  # type: ignore[union-attr]
+
+    result = await RegenerateFigureTool().execute(
+        {"figure_id": "tornado", "code": "plt.savefig('figures/tornado.png')"},
+        ctx,
+    )
+    assert result.ok, result.error
+    assert fig_path.is_file()
+
+
+async def test_regenerate_figure_errors_when_png_missing(tmp_path: Path) -> None:
+    kernel = AsyncMock()
+    kernel.execute.return_value = type("R", (), {"error": None, "stdout": ""})()
+    ctx = _make_ctx(tmp_path, kernel=kernel)
+    result = await RegenerateFigureTool().execute(
+        {"figure_id": "doesnotexist", "code": "x = 1"}, ctx
+    )
+    assert not result.ok
+    assert "doesnotexist" in (result.error or "")
+
+
+async def test_recompile_pdf_calls_gateway_export_paper(tmp_path: Path) -> None:
+    gateway = AsyncMock()
+    gateway.export_paper.return_value = b"%PDF-1.7\n...rest of pdf bytes..."
+    ctx = _make_ctx(tmp_path, gateway=gateway)
+    result = await RecompilePdfTool().execute({}, ctx)
+    assert result.ok, result.error
+    gateway.export_paper.assert_awaited_once()
+    pdf_on_disk = (ctx.run_dir / "paper.pdf").read_bytes()
+    assert pdf_on_disk.startswith(b"%PDF")
+
+
+async def test_recompile_pdf_handles_gateway_500(tmp_path: Path) -> None:
+    import httpx
+
+    gateway = AsyncMock()
+    gateway.export_paper.side_effect = httpx.HTTPError("upstream 500")
+    ctx = _make_ctx(tmp_path, gateway=gateway)
+    result = await RecompilePdfTool().execute({}, ctx)
+    assert not result.ok
+    assert "upstream 500" in (result.error or "")
+    assert not (ctx.run_dir / "paper.pdf").is_file()
+
+
+async def test_recompile_pdf_rejects_non_pdf_payload(tmp_path: Path) -> None:
+    gateway = AsyncMock()
+    gateway.export_paper.return_value = b"<html>oops</html>"
+    ctx = _make_ctx(tmp_path, gateway=gateway)
+    result = await RecompilePdfTool().execute({}, ctx)
+    assert not result.ok
+    assert (result.error or "").startswith("non-pdf")
+
+
+@pytest.fixture
+def ctx_with_kernel(tmp_path: Path) -> ToolContext:
+    """Convenience fixture for tests that need a generic ctx + mocked kernel."""
+    kernel = AsyncMock()
+    kernel.execute.return_value = type("R", (), {"error": None, "stdout": ""})()
+    return _make_ctx(tmp_path, kernel=kernel)
+
+
+async def test_edit_constant_with_string_value(ctx_with_kernel: ToolContext) -> None:
+    # Verify string values get repr'd (preserving the quotes in the source).
+    ctx_with_kernel.notebook["cells"][0]["source"] = "MODE = 'baseline'\nprint(MODE)"
+    result = await EditConstantTool().execute(
+        {"name": "MODE", "value": "adaptive"}, ctx_with_kernel
+    )
+    assert result.ok
+    patched_src = ctx_with_kernel.notebook["cells"][0]["source"]
+    assert "MODE = 'adaptive'" in patched_src

--- a/apps/web/src/components/FinetuneChat.vue
+++ b/apps/web/src/components/FinetuneChat.vue
@@ -1,0 +1,707 @@
+<script setup lang="ts">
+// FinetuneChat — natural-language editing panel rendered below the paper.
+//
+// The store does all the bookkeeping; this file is presentation only:
+//   - render the message history with collapsible reasoning blocks
+//   - render tool calls as monospace cards with args + result/error
+//   - stream new tokens into the live assistant bubble
+//   - submit on Enter (Shift+Enter = newline)
+//
+// Marked is configured exactly like PaperDraft (gfm, no breaks). We skip
+// KaTeX inside chat — overkill for ad-hoc messages, and the assistant rarely
+// emits raw $...$ in chat replies (it edits sections instead).
+import { computed, nextTick, ref, watch } from "vue";
+import { Marked } from "marked";
+import { useFinetuneStore } from "@/stores/finetune";
+import type { Message, ToolCall } from "@/stores/finetune";
+import T from "./T.vue";
+
+const props = defineProps<{ runId: string }>();
+const emit = defineEmits<{
+  // Fired when the assistant signals `finetune.done` AND at least one
+  // edit-style tool succeeded — the Workbench re-fetches paper.md on this.
+  (e: "paper-updated"): void;
+}>();
+
+const store = useFinetuneStore();
+
+// --- markdown rendering ---------------------------------------------------
+// Plain GFM with no walker — chat doesn't need figure URL rewriting.
+const md = new Marked({ gfm: true, breaks: false });
+
+function renderMd(text: string): string {
+  if (!text) return "";
+  return md.parse(text, { async: false }) as string;
+}
+
+// --- input handling -------------------------------------------------------
+const input = ref<string>("");
+const taRef = ref<HTMLTextAreaElement | null>(null);
+
+// Auto-grow textarea: clamp between 1 and 6 line-heights to keep the panel
+// stable on long drafts. The line-height matches the .ft-input rule below.
+function autosize(): void {
+  const el = taRef.value;
+  if (!el) return;
+  el.style.height = "auto";
+  // 22px per line × max 6 lines + 20px padding budget. Hard ceiling avoids
+  // the textarea eating the entire viewport if the user pastes a wall.
+  const max = 22 * 6 + 20;
+  el.style.height = `${Math.min(el.scrollHeight, max)}px`;
+}
+
+watch(input, () => {
+  void nextTick(autosize);
+});
+
+function onKeydown(ev: KeyboardEvent): void {
+  // Enter submits; Shift+Enter inserts a newline (standard chat UX).
+  if (ev.key === "Enter" && !ev.shiftKey && !ev.isComposing) {
+    ev.preventDefault();
+    void submit();
+  }
+}
+
+async function submit(): Promise<void> {
+  const text = input.value.trim();
+  if (!text) return;
+  if (store.isRunning) return;
+  input.value = "";
+  await nextTick(autosize);
+  await store.send(props.runId, text);
+}
+
+// --- paper-updated hook ---------------------------------------------------
+// Bumps each time the store finishes a turn that included a successful
+// edit. We forward to the Workbench so it re-fetches paper.md.
+const lastEmittedToken = ref<number>(0);
+watch(
+  () => store.paperUpdatedAt,
+  (now) => {
+    if (now === 0 || now === lastEmittedToken.value) return;
+    if (!store.didEdit) return;
+    lastEmittedToken.value = now;
+    emit("paper-updated");
+  },
+);
+
+// --- auto-scroll ----------------------------------------------------------
+const historyEl = ref<HTMLDivElement | null>(null);
+const pinned = ref(true);
+
+function onHistoryScroll(): void {
+  const el = historyEl.value;
+  if (!el) return;
+  pinned.value = el.scrollHeight - el.scrollTop - el.clientHeight < 12;
+}
+
+// Watch a coarse trigger so we don't run nextTick on every token character.
+const liveSize = computed<number>(() => {
+  let n = store.messages.length;
+  const last = store.messages[store.messages.length - 1];
+  if (last) n += last.text.length + last.toolCalls.length * 1000;
+  return n;
+});
+
+watch(liveSize, async () => {
+  if (!pinned.value) return;
+  await nextTick();
+  const el = historyEl.value;
+  if (el) el.scrollTop = el.scrollHeight;
+});
+
+// --- per-message UI state -------------------------------------------------
+// Track which message ids have an expanded reasoning panel. Default
+// collapsed — most assistant turns won't need to expand at all.
+const expandedReasoning = ref<Set<string>>(new Set());
+const expandedToolArgs = ref<Set<string>>(new Set()); // keyed by tool call id
+
+function toggleReasoning(id: string): void {
+  if (expandedReasoning.value.has(id)) expandedReasoning.value.delete(id);
+  else expandedReasoning.value.add(id);
+}
+
+function toggleToolArgs(id: string): void {
+  if (expandedToolArgs.value.has(id)) expandedToolArgs.value.delete(id);
+  else expandedToolArgs.value.add(id);
+}
+
+// --- formatting helpers ---------------------------------------------------
+const ARG_TRUNCATE = 200;
+
+function fmtArgValue(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+interface ArgEntry {
+  key: string;
+  display: string; // possibly-truncated
+  full: string;
+  truncated: boolean;
+}
+
+function argEntries(tc: ToolCall): ArgEntry[] {
+  const entries = Object.entries(tc.args ?? {});
+  return entries.map(([k, v]) => {
+    const full = fmtArgValue(v);
+    const truncated = full.length > ARG_TRUNCATE;
+    return {
+      key: k,
+      display: truncated ? full.slice(0, ARG_TRUNCATE) + "…" : full,
+      full,
+      truncated,
+    };
+  });
+}
+
+function toolStatusSymbol(s: ToolCall["status"]): string {
+  if (s === "ok") return "✓";
+  if (s === "error") return "✗";
+  return "…";
+}
+
+function toolStatusClass(s: ToolCall["status"]): string {
+  if (s === "ok") return "ft-ok";
+  if (s === "error") return "ft-err";
+  return "ft-pending";
+}
+
+// --- status indicator -----------------------------------------------------
+const statusLine = computed<{ en: string; zh: string }>(() => {
+  if (store.status === "idle") {
+    return { en: "Idle", zh: "空闲" };
+  }
+  if (store.status === "compiling") {
+    return { en: "Compiling PDF…", zh: "正在编译 PDF…" };
+  }
+  if (store.status === "done") {
+    return { en: "Done", zh: "完成" };
+  }
+  if (store.status === "error") {
+    return { en: "Error", zh: "错误" };
+  }
+  // running
+  if (store.activeTool) {
+    return {
+      en: `Running tool: ${store.activeTool}…`,
+      zh: `正在执行工具：${store.activeTool}…`,
+    };
+  }
+  return { en: "Thinking…", zh: "思考中…" };
+});
+
+const statusDotClass = computed<string>(() => {
+  switch (store.status) {
+    case "running":
+    case "compiling":
+      return "dot-run";
+    case "done":
+      return "dot-ok";
+    case "error":
+      return "dot-err";
+    default:
+      return "dot-idle";
+  }
+});
+
+// Convenience: typed list for the template.
+const messages = computed<Message[]>(() => store.messages);
+</script>
+
+<template>
+  <section class="ft-panel panel">
+    <div class="panel-h">
+      <div class="eyebrow">
+        06 ·
+        <T en="Fine-tune with natural language" zh="自然语言调优论文" />
+      </div>
+      <span class="ft-status mono">
+        <span class="ft-dot" :class="statusDotClass"></span>
+        <T :en="statusLine.en" :zh="statusLine.zh" />
+      </span>
+    </div>
+
+    <div class="panel-b">
+      <div
+        ref="historyEl"
+        class="ft-history"
+        @scroll="onHistoryScroll"
+      >
+        <div v-if="messages.length === 0" class="ft-empty">
+          <T
+            en="Ask the agent to revise a section, tweak a constant, or regenerate a figure. e.g. “Tighten the abstract to 180 words and re-emphasize the dual benefit.”"
+            zh="让智能体修订某一节、微调常量或重绘图表。例如：“将摘要精简到 180 字，并重点突出双重收益。”"
+          />
+        </div>
+
+        <div
+          v-for="m in messages"
+          :key="m.id"
+          class="ft-msg"
+          :class="m.role === 'user' ? 'ft-user' : 'ft-asst'"
+        >
+          <!-- USER bubble: right-aligned plain text -->
+          <template v-if="m.role === 'user'">
+            <div class="ft-bubble ft-bubble-user">{{ m.text }}</div>
+          </template>
+
+          <!-- ASSISTANT: reasoning (collapsed) + tool calls + streamed text -->
+          <template v-else>
+            <div class="ft-bubble ft-bubble-asst">
+              <!-- collapsible reasoning -->
+              <details
+                v-if="m.reasoning"
+                class="ft-reasoning"
+                :open="expandedReasoning.has(m.id)"
+              >
+                <summary @click.prevent="toggleReasoning(m.id)">
+                  <span class="mono ft-reasoning-toggle">
+                    {{ expandedReasoning.has(m.id) ? "▾" : "▸" }}
+                    <T en="reasoning" zh="推理" />
+                  </span>
+                </summary>
+                <div class="ft-reasoning-body mono">{{ m.reasoning }}</div>
+              </details>
+
+              <!-- tool calls -->
+              <div
+                v-for="tc in m.toolCalls"
+                :key="tc.id"
+                class="ft-tool"
+                :class="toolStatusClass(tc.status)"
+              >
+                <div class="ft-tool-h mono">
+                  <span class="ft-tool-icon">🔧</span>
+                  <span class="ft-tool-name">{{ tc.tool }}</span>
+                  <span class="ft-tool-status" :class="toolStatusClass(tc.status)">
+                    {{ toolStatusSymbol(tc.status) }}
+                  </span>
+                </div>
+                <div class="ft-tool-args mono">
+                  <div
+                    v-for="entry in argEntries(tc)"
+                    :key="entry.key"
+                    class="ft-arg"
+                  >
+                    <span class="ft-arg-k">{{ entry.key }}:</span>
+                    <span class="ft-arg-v">
+                      <template v-if="entry.truncated && !expandedToolArgs.has(tc.id)">
+                        "{{ entry.display }}"
+                      </template>
+                      <template v-else>
+                        "{{ entry.full }}"
+                      </template>
+                    </span>
+                    <button
+                      v-if="entry.truncated"
+                      type="button"
+                      class="ft-arg-toggle mono"
+                      @click="toggleToolArgs(tc.id)"
+                    >
+                      {{ expandedToolArgs.has(tc.id) ? "−" : "+" }}
+                    </button>
+                  </div>
+                </div>
+                <div v-if="tc.status === 'ok' && tc.result" class="ft-tool-result mono">
+                  → {{ tc.result }}
+                </div>
+                <div v-else-if="tc.status === 'error'" class="ft-tool-result ft-err mono">
+                  → {{ tc.error ?? "tool failed" }}
+                </div>
+                <div v-else-if="tc.status === 'pending'" class="ft-tool-result ft-pending mono">
+                  → <T en="running…" zh="执行中…" />
+                </div>
+              </div>
+
+              <!-- streamed assistant text (markdown) -->
+              <div
+                v-if="m.text"
+                class="ft-asst-text markdown-body"
+                v-html="renderMd(m.text)"
+              ></div>
+
+              <!-- error footer if the turn failed -->
+              <div v-if="m.error" class="ft-msg-error mono">
+                {{ m.error }}
+              </div>
+
+              <!-- caret while we're still streaming this message -->
+              <span
+                v-if="!m.done && store.isRunning"
+                class="ft-caret"
+                aria-hidden="true"
+              ></span>
+            </div>
+          </template>
+        </div>
+      </div>
+
+      <!-- POST error banner (separate from per-message errors) -->
+      <div v-if="store.postError" class="ft-post-error mono">
+        {{ store.postError }}
+      </div>
+
+      <!-- input bar -->
+      <form class="ft-input-bar" @submit.prevent="submit">
+        <textarea
+          ref="taRef"
+          v-model="input"
+          class="ft-input mono"
+          rows="1"
+          :placeholder="
+            store.isRunning
+              ? ''
+              : 'edit_section, edit_constant, regenerate_figure…'
+          "
+          :disabled="store.isRunning"
+          @keydown="onKeydown"
+        ></textarea>
+        <button
+          type="submit"
+          class="btn hi ft-submit"
+          :disabled="store.isRunning || input.trim().length === 0"
+        >
+          <T en="Send" zh="发送" /> →
+        </button>
+      </form>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.ft-panel {
+  margin-top: 18px;
+}
+
+.ft-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 10.5px;
+  color: var(--ink-3);
+}
+.ft-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink-3);
+  display: inline-block;
+}
+.ft-dot.dot-idle {
+  background: var(--ink-4);
+}
+.ft-dot.dot-run {
+  background: var(--hi);
+  box-shadow: 0 0 0 0 rgba(212, 232, 90, 0.55);
+  animation: pulse 1.4s infinite;
+}
+.ft-dot.dot-ok {
+  background: var(--ok);
+}
+.ft-dot.dot-err {
+  background: var(--err);
+}
+
+/* --- history scroller -------------------------------------------------- */
+.ft-history {
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 8px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.ft-empty {
+  color: var(--ink-3);
+  font-size: 13px;
+  line-height: 1.55;
+  padding: 16px 12px;
+  font-family: 'Instrument Serif', serif;
+  font-style: italic;
+}
+body.zh .ft-empty {
+  font-family: 'Noto Serif SC', serif;
+  font-style: normal;
+}
+
+/* --- message rows ------------------------------------------------------ */
+.ft-msg {
+  display: flex;
+  width: 100%;
+}
+.ft-msg.ft-user {
+  justify-content: flex-end;
+}
+.ft-msg.ft-asst {
+  justify-content: flex-start;
+}
+
+.ft-bubble {
+  max-width: 88%;
+  padding: 10px 14px;
+  border-radius: 2px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  border: 1px solid var(--rule-soft);
+}
+.ft-bubble-user {
+  background: var(--accent);
+  color: #ECE5D7;
+  border-color: var(--accent);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.ft-bubble-asst {
+  background: var(--paper-2);
+  color: var(--ink);
+}
+
+/* --- reasoning collapsible -------------------------------------------- */
+.ft-reasoning {
+  margin-bottom: 8px;
+}
+.ft-reasoning summary {
+  cursor: pointer;
+  list-style: none;
+}
+.ft-reasoning summary::-webkit-details-marker {
+  display: none;
+}
+.ft-reasoning-toggle {
+  font-size: 10.5px;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.ft-reasoning-body {
+  margin-top: 6px;
+  padding: 8px 10px;
+  background: var(--paper);
+  border: 1px solid var(--rule-soft);
+  border-radius: 2px;
+  font-size: 11.5px;
+  line-height: 1.6;
+  color: var(--ink-3);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/* --- tool-call card --------------------------------------------------- */
+.ft-tool {
+  border: 1px solid var(--rule-soft);
+  border-left: 3px solid var(--ink-3);
+  border-radius: 2px;
+  background: var(--paper);
+  padding: 8px 10px;
+  margin: 8px 0;
+}
+.ft-tool.ft-ok {
+  border-left-color: var(--ok);
+}
+.ft-tool.ft-err {
+  border-left-color: var(--err);
+}
+.ft-tool.ft-pending {
+  border-left-color: var(--hi);
+  animation: cell-breathe 2.4s ease-in-out infinite;
+}
+.ft-tool-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  margin-bottom: 6px;
+}
+.ft-tool-icon {
+  font-size: 11px;
+}
+.ft-tool-name {
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+.ft-tool-status {
+  margin-left: auto;
+  font-size: 12px;
+  line-height: 1;
+}
+.ft-tool-status.ft-ok {
+  color: var(--ok);
+}
+.ft-tool-status.ft-err {
+  color: var(--err);
+}
+.ft-tool-status.ft-pending {
+  color: var(--ink-3);
+}
+
+.ft-tool-args {
+  font-size: 11px;
+  line-height: 1.55;
+  color: var(--ink-2);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ft-arg {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.ft-arg-k {
+  color: var(--ink-3);
+}
+.ft-arg-v {
+  flex: 1 1 60%;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+.ft-arg-toggle {
+  font-size: 10px;
+  border: 1px solid var(--rule-soft);
+  background: var(--paper-2);
+  color: var(--ink-2);
+  padding: 0 5px;
+  height: 16px;
+  border-radius: 2px;
+  cursor: pointer;
+  align-self: flex-start;
+}
+.ft-arg-toggle:hover {
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.ft-tool-result {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--ink-2);
+  word-break: break-word;
+  white-space: pre-wrap;
+  line-height: 1.55;
+}
+.ft-tool-result.ft-err {
+  color: var(--err);
+}
+.ft-tool-result.ft-pending {
+  color: var(--ink-3);
+  font-style: italic;
+}
+
+/* --- streamed assistant text ----------------------------------------- */
+.ft-asst-text {
+  margin-top: 4px;
+  font-size: 13.5px;
+  line-height: 1.6;
+}
+.ft-asst-text :deep(p) {
+  margin: 0 0 8px;
+}
+.ft-asst-text :deep(p):last-child {
+  margin-bottom: 0;
+}
+.ft-asst-text :deep(code) {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  background: var(--paper);
+  border: 1px solid var(--rule-soft);
+  padding: 0.5px 4px;
+  border-radius: 2px;
+}
+.ft-asst-text :deep(pre) {
+  background: var(--paper);
+  border: 1px solid var(--rule-soft);
+  padding: 8px 10px;
+  border-radius: 2px;
+  overflow: auto;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11.5px;
+  margin: 4px 0 8px;
+}
+.ft-asst-text :deep(ul),
+.ft-asst-text :deep(ol) {
+  padding-left: 22px;
+  margin: 4px 0 8px;
+}
+
+.ft-msg-error {
+  margin-top: 8px;
+  padding: 6px 8px;
+  font-size: 11px;
+  color: #6B1F0C;
+  background: #F8E1D8;
+  border: 1px solid var(--rule-soft);
+  border-left: 2px solid var(--err);
+  border-radius: 2px;
+}
+
+.ft-caret {
+  display: inline-block;
+  width: 7px;
+  height: 14px;
+  background: var(--hi);
+  margin-left: 4px;
+  vertical-align: text-bottom;
+  animation: blink 1s step-end infinite;
+}
+
+/* --- post-error banner (POST failed) --------------------------------- */
+.ft-post-error {
+  margin: 8px 0 0;
+  padding: 8px 10px;
+  font-size: 11.5px;
+  background: #F8E1D8;
+  border: 1px solid var(--warn);
+  color: #6B1F0C;
+  border-radius: 2px;
+}
+
+/* --- input bar -------------------------------------------------------- */
+.ft-input-bar {
+  margin-top: 14px;
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
+}
+.ft-input {
+  flex: 1;
+  min-height: 38px;
+  max-height: 152px;
+  padding: 8px 12px;
+  font-family: 'Inter', sans-serif;
+  font-size: 13.5px;
+  line-height: 22px;
+  background: var(--paper);
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  resize: none;
+  overflow-y: auto;
+}
+body.zh .ft-input {
+  font-family: 'Inter', system-ui, sans-serif;
+}
+.ft-input:focus {
+  outline: none;
+  border-color: var(--ink);
+  box-shadow: 0 0 0 1px var(--ink);
+}
+.ft-input[disabled] {
+  background: var(--paper-2);
+  cursor: not-allowed;
+}
+.ft-submit {
+  flex: 0 0 auto;
+  padding: 9px 14px;
+  font-size: 11px;
+}
+</style>

--- a/apps/web/src/stores/finetune.ts
+++ b/apps/web/src/stores/finetune.ts
@@ -1,0 +1,334 @@
+// Finetune chat store.
+//
+// Mirrors the shape of `useRunStore` but holds the natural-language
+// fine-tuning conversation that runs on top of a completed pipeline. The
+// gateway exposes `POST /runs/<run_id>/finetune` which queues a worker job;
+// the worker emits events on the same WebSocket as the main run, tagged
+// with `kind: "finetune.{token,tool_call,tool_result,done}"`.
+//
+// The run store doesn't know how to parse those; instead it forwards any
+// event whose `kind` starts with `"finetune."` to `handleEvent` here. This
+// keeps a single WS connection per run and avoids touching the existing
+// pipeline event handling.
+//
+// One chat per page load — no session persistence (out of scope for round 1).
+
+import { defineStore } from "pinia";
+import type { AgentEvent } from "@mathodology/contracts";
+import { http } from "@/api/http";
+
+export type FinetuneStatus =
+  | "idle"
+  | "running"
+  | "compiling"
+  | "done"
+  | "error";
+
+export type ToolName =
+  | "read_paper"
+  | "edit_section"
+  | "edit_constant"
+  | "run_cell"
+  | "regenerate_figure"
+  | "recompile_pdf"
+  | (string & {}); // tolerate new tools without a recompile
+
+export interface ToolCall {
+  id: string;
+  tool: ToolName;
+  args: Record<string, unknown>;
+  status: "pending" | "ok" | "error";
+  result?: string;
+  error?: string;
+}
+
+export interface Message {
+  id: string;
+  role: "user" | "assistant";
+  text: string;          // accumulates from finetune.token events
+  reasoning: string;     // accumulates from finetune.reasoning events (if any)
+  toolCalls: ToolCall[];
+  done: boolean;         // true once finetune.done arrives
+  summary?: string;
+  error?: string;
+  createdAt: string;
+}
+
+interface State {
+  sessionId: string;
+  messages: Message[];
+  isRunning: boolean;
+  status: FinetuneStatus;
+  // Tool name currently executing — surfaced in the status indicator
+  // (e.g. "Running tool: edit_section…"). Cleared on tool_result.
+  activeTool: string | null;
+  /** Bumps each time a finetune.done arrives so the workbench can re-fetch
+   *  the paper. We expose this as a counter rather than a Vue event so the
+   *  view layer can watch() it without coupling to a specific component. */
+  paperUpdatedAt: number;
+  /** Last error from the POST /runs/:id/finetune call. */
+  postError: string | null;
+}
+
+interface FinetuneCreated {
+  session_id: string;
+  status: string;
+}
+
+function genId(): string {
+  // crypto.randomUUID is available in all evergreen browsers + jsdom 22+.
+  // Fall back to a timestamp counter just to keep this safe in older runners.
+  if (
+    typeof globalThis !== "undefined" &&
+    typeof globalThis.crypto?.randomUUID === "function"
+  ) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `id-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`;
+}
+
+function emptyMessage(role: Message["role"]): Message {
+  return {
+    id: genId(),
+    role,
+    text: "",
+    reasoning: "",
+    toolCalls: [],
+    done: false,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+// Names of the kinds we listen to. Centralised so the prefix check and the
+// switch stay in sync.
+export const FINETUNE_KIND_PREFIX = "finetune.";
+
+export function isFinetuneKind(kind: string): boolean {
+  return kind.startsWith(FINETUNE_KIND_PREFIX);
+}
+
+export const useFinetuneStore = defineStore("finetune", {
+  state: (): State => ({
+    sessionId: "",
+    messages: [],
+    isRunning: false,
+    status: "idle",
+    activeTool: null,
+    paperUpdatedAt: 0,
+    postError: null,
+  }),
+
+  getters: {
+    // Convenience: the assistant message currently receiving streamed output,
+    // or null if none. Always the latest assistant message, by construction
+    // — we push exactly one assistant message per `send()`.
+    activeAssistant(state): Message | null {
+      for (let i = state.messages.length - 1; i >= 0; i -= 1) {
+        const m = state.messages[i];
+        if (m.role === "assistant" && !m.done) return m;
+      }
+      return null;
+    },
+    // True if there is at least one assistant message that performed at least
+    // one edit-style tool call. Used to decide if `paper-updated` makes sense.
+    didEdit(state): boolean {
+      const EDIT_TOOLS = new Set([
+        "edit_section",
+        "edit_constant",
+        "regenerate_figure",
+        "recompile_pdf",
+      ]);
+      for (const m of state.messages) {
+        for (const tc of m.toolCalls) {
+          if (tc.status === "ok" && EDIT_TOOLS.has(tc.tool)) return true;
+        }
+      }
+      return false;
+    },
+  },
+
+  actions: {
+    reset() {
+      this.sessionId = "";
+      this.messages = [];
+      this.isRunning = false;
+      this.status = "idle";
+      this.activeTool = null;
+      this.paperUpdatedAt = 0;
+      this.postError = null;
+    },
+
+    async send(runId: string, message: string) {
+      const trimmed = message.trim();
+      if (!trimmed) return;
+      if (this.isRunning) return;
+
+      // 1. Optimistically append the user message — keeps the UI snappy.
+      const userMsg = emptyMessage("user");
+      userMsg.text = trimmed;
+      userMsg.done = true;
+      this.messages.push(userMsg);
+
+      this.isRunning = true;
+      this.status = "running";
+      this.activeTool = null;
+      this.postError = null;
+
+      try {
+        const body: Record<string, unknown> = { message: trimmed };
+        if (this.sessionId) body["session_id"] = this.sessionId;
+        const res = await http.post<FinetuneCreated>(
+          `/runs/${runId}/finetune`,
+          body,
+        );
+        if (res.session_id) this.sessionId = res.session_id;
+
+        // 2. Append the empty assistant message that the WS will stream into.
+        this.messages.push(emptyMessage("assistant"));
+      } catch (err) {
+        // Surface the failure in the user's message bubble. Mark the run as
+        // not running so the input is re-enabled.
+        this.isRunning = false;
+        this.status = "error";
+        this.postError = err instanceof Error ? err.message : String(err);
+        // Add a synthetic assistant message so the failure is visible inline.
+        const failed = emptyMessage("assistant");
+        failed.done = true;
+        failed.error = this.postError;
+        this.messages.push(failed);
+      }
+    },
+
+    // Called by the run store when it sees an event with
+    // `kind.startsWith("finetune.")`. The event envelope is the standard
+    // AgentEvent; this store only inspects `kind` + `payload`.
+    //
+    // The `EventKind` union in the contracts package covers only pipeline
+    // events; finetune events ride the same WS but aren't in the union.
+    // Widen to `string` once here so the switch below stays type-clean.
+    handleEvent(ev: AgentEvent) {
+      const kind: string = ev.kind as unknown as string;
+      const payload = ev.payload as Record<string, unknown>;
+      const target = this.activeAssistant;
+
+      if (kind === "finetune.token") {
+        const text = typeof payload["text"] === "string" ? payload["text"] : "";
+        if (!text || !target) return;
+        target.text = target.text + text;
+        return;
+      }
+
+      if (kind === "finetune.reasoning") {
+        // Optional channel: some models emit reasoning deltas before any
+        // visible output. Treat it like token text but into the reasoning
+        // buffer so the UI can collapse it.
+        const text = typeof payload["text"] === "string" ? payload["text"] : "";
+        if (!text || !target) return;
+        target.reasoning = target.reasoning + text;
+        return;
+      }
+
+      if (kind === "finetune.tool_call") {
+        if (!target) return;
+        const tool =
+          typeof payload["tool"] === "string" ? payload["tool"] : "unknown";
+        const args =
+          payload["args"] && typeof payload["args"] === "object"
+            ? (payload["args"] as Record<string, unknown>)
+            : {};
+        const callId =
+          typeof payload["call_id"] === "string"
+            ? payload["call_id"]
+            : genId();
+        target.toolCalls.push({
+          id: callId,
+          tool,
+          args,
+          status: "pending",
+        });
+        this.activeTool = tool;
+        // recompile_pdf -> the UI should display "Compiling PDF…" so the
+        // long tail of pdflatex doesn't read as a stall.
+        if (tool === "recompile_pdf") this.status = "compiling";
+        return;
+      }
+
+      if (kind === "finetune.tool_result") {
+        if (!target) return;
+        const callId =
+          typeof payload["call_id"] === "string" ? payload["call_id"] : "";
+        const ok = payload["ok"] === true;
+        const result =
+          typeof payload["result"] === "string"
+            ? payload["result"]
+            : payload["result"] !== undefined
+              ? JSON.stringify(payload["result"])
+              : undefined;
+        const error =
+          typeof payload["error"] === "string" ? payload["error"] : undefined;
+        // Find by call_id; fall back to the last pending entry. The latter
+        // lets us survive a worker that forgets call_id (defensive).
+        let tc = callId
+          ? target.toolCalls.find((t) => t.id === callId)
+          : undefined;
+        if (!tc) {
+          for (let i = target.toolCalls.length - 1; i >= 0; i -= 1) {
+            if (target.toolCalls[i].status === "pending") {
+              tc = target.toolCalls[i];
+              break;
+            }
+          }
+        }
+        if (tc) {
+          tc.status = ok ? "ok" : "error";
+          if (result !== undefined) tc.result = result;
+          if (error !== undefined) tc.error = error;
+        }
+        this.activeTool = null;
+        if (this.status === "compiling" && ok) {
+          // Compilation finished; if the worker hasn't yet emitted `done`
+          // we still want the status to look settled.
+          this.status = "running";
+        }
+        return;
+      }
+
+      if (kind === "finetune.done") {
+        if (target) {
+          target.done = true;
+          const summary =
+            typeof payload["summary"] === "string"
+              ? payload["summary"]
+              : undefined;
+          if (summary) target.summary = summary;
+          const errMsg =
+            typeof payload["error"] === "string"
+              ? payload["error"]
+              : undefined;
+          if (errMsg) target.error = errMsg;
+        }
+        this.isRunning = false;
+        this.activeTool = null;
+        const ok = payload["error"] === undefined;
+        this.status = ok ? "done" : "error";
+        // Bump the watch token so the Workbench can refetch paper.md.
+        this.paperUpdatedAt = Date.now();
+        return;
+      }
+
+      if (kind === "finetune.error") {
+        if (target) {
+          target.error =
+            typeof payload["message"] === "string"
+              ? payload["message"]
+              : "unknown error";
+          target.done = true;
+        }
+        this.isRunning = false;
+        this.activeTool = null;
+        this.status = "error";
+        return;
+      }
+    },
+  },
+});

--- a/apps/web/src/stores/run.ts
+++ b/apps/web/src/stores/run.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import type { AgentEvent, AgentName } from "@mathodology/contracts";
 import { http, devAuthToken } from "@/api/http";
 import { RunWsClient } from "@/api/ws";
+import { useFinetuneStore, isFinetuneKind } from "@/stores/finetune";
 
 export type RunStatus = "idle" | "queued" | "running" | "done" | "failed";
 
@@ -212,6 +213,15 @@ export const useRunStore = defineStore("run", {
     },
 
     handleEvent(ev: AgentEvent) {
+      // Fine-tune events ride the same WebSocket but belong to a different
+      // store. Forward them and bail before any pipeline-handling runs.
+      // The kind string isn't in EventKind's union (the contract is the
+      // pipeline's), so we use a prefix check that accepts any `finetune.*`.
+      if (isFinetuneKind(ev.kind as unknown as string)) {
+        useFinetuneStore().handleEvent(ev);
+        return;
+      }
+
       const agentKey = agentKeyOf(ev.agent);
 
       // `token` events are extremely chatty. We keep them out of the main

--- a/apps/web/src/views/Workbench.vue
+++ b/apps/web/src/views/Workbench.vue
@@ -22,6 +22,8 @@ import AgentOutputView from "@/components/AgentOutputView.vue";
 import PaperDraft from "@/components/PaperDraft.vue";
 import ExportPanel from "@/components/ExportPanel.vue";
 import SearchConfigPanel from "@/components/SearchConfigPanel.vue";
+import FinetuneChat from "@/components/FinetuneChat.vue";
+import { useFinetuneStore } from "@/stores/finetune";
 import { useSearchConfigStore } from "@/stores/searchConfig";
 import T from "@/components/T.vue";
 
@@ -44,6 +46,7 @@ const router = useRouter();
 const run = useRunStore();
 const settings = useRunSettingsStore();
 const searchConfig = useSearchConfigStore();
+const finetune = useFinetuneStore();
 const i18n = useI18n();
 
 // --- live clock for elapsed counters & stage pill durations -----------------
@@ -85,13 +88,16 @@ watch(
   (next, prev) => {
     if (next === prev) return;
     if (next === null) {
-      // Moved back to the empty-state page — drop the socket.
+      // Moved back to the empty-state page — drop the socket and clear any
+      // lingering finetune conversation from the previous run.
       run.reset();
+      finetune.reset();
       runRecord.value = null;
       return;
     }
     if (run.runId !== next) {
       run.reset();
+      finetune.reset();
       runRecord.value = null;
       run.runId = next;
       run.status = "running";
@@ -104,7 +110,18 @@ watch(
 
 onBeforeUnmount(() => {
   run.reset();
+  finetune.reset();
 });
+
+// Called when the finetune assistant finishes a turn that included an
+// edit-style tool. We refresh the run record so paths (paper_path,
+// notebook_path) reflect the new artifacts, and the existing event stream
+// will carry any re-emitted writer output if the worker chose to do that.
+async function onPaperUpdated(): Promise<void> {
+  const id = routeRunId.value;
+  if (!id) return;
+  await loadRunRecord(id);
+}
 
 // --- start a new run from the empty-state form ------------------------------
 async function onStart(payload: { problemText: string }) {
@@ -431,6 +448,14 @@ function agentTitle(agent: string): { en: string; zh: string; num: string } {
           v-if="paperDraft"
           :output="paperDraft"
           :run-id="routeRunId!"
+        />
+
+        <!-- Fine-tune chat — natural-language edits delegated to the
+             worker via POST /runs/:id/finetune. Runs on the same WS as
+             the pipeline; events are demultiplexed by `kind` prefix. -->
+        <FinetuneChat
+          :run-id="routeRunId!"
+          @paper-updated="onPaperUpdated"
         />
 
         <!-- Consolidated export panel: template picker + PDF / DOCX / TeX /

--- a/crates/gateway/src/app.rs
+++ b/crates/gateway/src/app.rs
@@ -13,6 +13,7 @@ pub fn build_router(state: AppState) -> Router {
     let authed = Router::new()
         .route("/runs", post(runs::create_run).get(runs::list_runs))
         .route("/runs/:run_id", get(runs::get_run))
+        .route("/runs/:run_id/finetune", post(runs::finetune_run))
         .route("/runs/:run_id/figures/*path", get(figures::serve_figure))
         .route("/runs/:run_id/notebook", get(figures::serve_notebook))
         .route("/runs/:run_id/paper", get(figures::serve_paper))

--- a/crates/gateway/src/dispatch.rs
+++ b/crates/gateway/src/dispatch.rs
@@ -9,6 +9,12 @@ use crate::error::AppError;
 pub const JOBS_STREAM: &str = "mm:jobs";
 pub const JOBS_MAXLEN: usize = 10_000;
 
+/// Separate stream for natural-language paper fine-tune requests. We keep
+/// these off `mm:jobs` so worker concurrency budgets and ack semantics
+/// don't interfere with full-pipeline runs.
+pub const FINETUNE_STREAM: &str = "mm:finetune";
+pub const FINETUNE_MAXLEN: usize = 5_000;
+
 pub fn events_stream_key(run_id: &Uuid) -> String {
     format!("mm:events:{run_id}")
 }
@@ -39,6 +45,33 @@ pub async fn enqueue_job(
         )
         .await?;
 
+    Ok(id)
+}
+
+/// XADD mm:finetune. Fields: run_id, session_id, message, created_at.
+pub async fn enqueue_finetune_job(
+    redis: &mut ConnectionManager,
+    run_id: &Uuid,
+    session_id: &Uuid,
+    message: &str,
+) -> Result<String, AppError> {
+    let created_at = Utc::now().to_rfc3339();
+    let run_id_str = run_id.to_string();
+    let session_id_str = session_id.to_string();
+    let fields: &[(&str, &str)] = &[
+        ("run_id", run_id_str.as_str()),
+        ("session_id", session_id_str.as_str()),
+        ("message", message),
+        ("created_at", created_at.as_str()),
+    ];
+    let id: String = redis
+        .xadd_maxlen(
+            FINETUNE_STREAM,
+            redis::streams::StreamMaxlen::Approx(FINETUNE_MAXLEN),
+            "*",
+            fields,
+        )
+        .await?;
     Ok(id)
 }
 

--- a/crates/gateway/src/routes/runs.rs
+++ b/crates/gateway/src/routes/runs.rs
@@ -8,7 +8,7 @@ use sqlx::FromRow;
 use uuid::Uuid;
 
 use crate::audit::spawn_audit_task;
-use crate::dispatch::enqueue_job;
+use crate::dispatch::{enqueue_finetune_job, enqueue_job};
 use crate::error::AppError;
 use crate::state::AppState;
 
@@ -117,6 +117,65 @@ pub async fn create_run(
         StatusCode::CREATED,
         Json(RunCreated {
             run_id,
+            status: "queued",
+        }),
+    ))
+}
+
+/// Body for `POST /runs/:run_id/finetune` — a single NL instruction.
+#[derive(Debug, Deserialize)]
+pub struct FinetuneRequest {
+    pub message: String,
+    #[serde(default)]
+    pub session_id: Option<Uuid>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FinetuneAccepted {
+    pub run_id: Uuid,
+    pub session_id: Uuid,
+    pub status: &'static str,
+}
+
+/// `POST /runs/:run_id/finetune` — enqueue a paper fine-tune request.
+///
+/// The worker picks up the job, loads the run's paper.md + notebook.ipynb,
+/// and runs PaperEditorAgent against the natural-language `message`. Events
+/// stream back on the same `mm:events:<run_id>` channel tagged with
+/// `kind: "finetune.*"`. The frontend filters by prefix.
+///
+/// Returns 202 + `{run_id, session_id, status: "queued"}`. session_id is
+/// either taken from the request (for resuming a thread) or freshly minted.
+#[tracing::instrument(skip_all, fields(%run_id))]
+pub async fn finetune_run(
+    State(mut state): State<AppState>,
+    Path(run_id): Path<Uuid>,
+    Json(req): Json<FinetuneRequest>,
+) -> Result<(StatusCode, Json<FinetuneAccepted>), AppError> {
+    if req.message.trim().is_empty() {
+        return Err(AppError::BadRequest("message must be non-empty".to_string()));
+    }
+    // Verify the run exists. We don't require status='success' — users may
+    // want to fine-tune a paper from a partially-failed run too.
+    let exists: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM runs WHERE id = $1")
+        .bind(run_id)
+        .fetch_optional(&state.pg)
+        .await
+        .map_err(|e| AppError::Internal(format!("lookup run: {e}")))?;
+    if exists.is_none() {
+        return Err(AppError::NotFound);
+    }
+
+    let session_id = req.session_id.unwrap_or_else(Uuid::new_v4);
+    let stream_id =
+        enqueue_finetune_job(&mut state.redis, &run_id, &session_id, &req.message).await?;
+    tracing::info!(%run_id, %session_id, stream_id, "finetune job enqueued");
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(FinetuneAccepted {
+            run_id,
+            session_id,
             status: "queued",
         }),
     ))


### PR DESCRIPTION
Stacked on #30. Round 5: NL paper fine-tune MVP.

Users can post natural-language instructions ("tighten the abstract to 500 words", "set K_R=5000 and rerun sensitivity", "regenerate the tornado figure with axis labels") and the worker uses the existing `gpt-5.5` / cornna gateway path to drive 5 tools against the run dir. Architecture B from the design poll — self-built editor, no external Claude Agent SDK dependency.

## A. Backend: PaperEditorAgent + 5 tools

- `agents/paper_editor.py` — 8-turn tool-using loop mirroring CoderAgent pattern (JSON directive → dispatch → result-feedback → next turn). Reuses `_stream_with_retry` so cornna's empty-200 + 5xx pathology is handled uniformly.
- `editor_tools/tools.py` — 5 tools with `Tool` / `ToolContext` / `ToolResult` protocol (sourcemap `Tool.ts` style):
  - `read_paper(section_title?)` — returns one or all sections
  - `edit_section(title, body_md)` — rewrites both `paper.meta.json` and `paper.md`
  - `edit_constant(name, value, rerun_from?)` — regex-patches notebook + reruns affected cells
  - `run_cell(code)` — arbitrary Python via the persistent `KernelSession`
  - `regenerate_figure(id, code)` — runs + verifies `figures/<id>.png` landed
  - `recompile_pdf()` — calls gateway `/export/pdf`
- `prompts/paper_editor/v1.toml` — system prompt with workflow patterns
- **23 unit tests** (17 tool + 6 agent loop), all mocked LLM/kernel/gateway

## B. Dispatcher wiring

- `finetune_main.py` — parallel `mm:finetune` consumer (separate Redis Stream + group from `mm:jobs` so chat traffic doesn't starve full pipelines)
- `main.py` — spawns finetune consumer alongside the run consumer
- Events tagged `finetune.tool_call` / `.tool_result` / `.session.start` / `.session.done`, all on the existing `mm:events:<run_id>` stream so the UI's WS subscription picks them up unchanged

## C. Gateway

- `dispatch.rs` — `enqueue_finetune_job` + `FINETUNE_STREAM` constant
- `routes/runs.rs` — `POST /runs/:run_id/finetune` handler, validates run exists, mints session_id when omitted, returns 202 + queued
- `app.rs` — route registered under existing auth middleware

## D. Frontend: FinetuneChat.vue + finetune.ts store

- Chat panel below the `PaperDraft` preview in Workbench
- WS event router in `stores/run.ts` forwards `finetune.*` → finetune store (single connection preserved)
- Per-message: collapsible reasoning + tool-call cards with pending/ok/error rail + streamed assistant text
- Auto-grow textarea, Enter-to-send, Shift+Enter newline; status indicator: Idle → Thinking → Running tool: X → Compiling PDF → Done
- On `finetune.done` with edits, emits `paper-updated`; Workbench re-fetches the run record
- Bilingual via existing `<T en zh />` throughout

## Test plan

- [x] `uv run --frozen pytest apps/agent-worker -q` — **424 passed** (+23)
- [x] `uvx ruff check apps/agent-worker/src apps/agent-worker/tests` — clean
- [x] `cargo build -p gateway` — clean
- [x] `cargo clippy -p gateway` — clean
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web build` — clean
- [ ] End-to-end smoke against real cornna `gpt-5.5` (manual test pending)

## Deferred to round 6

- **Mid-run interrupt** (chosen for "两者都要" but requires checkpoint / pause / resume machinery in `pipeline.py`; substantial)
- Multi-turn session resume (currently one chat per page-load)
- Extend `ts-contracts` `EventKind` union to include `finetune.*` (low priority — current as-string casts are pinned to one well-isolated line each)