### PR TITLE
fix: round-6 audit cleanup — 11 fixes (stacked on #31)

### DIFF
--- a/apps/agent-worker/src/agent_worker/agents/coder.py
+++ b/apps/agent-worker/src/agent_worker/agents/coder.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Any
+from typing import Any, Literal
 
 import orjson
 from mm_contracts import (
@@ -71,8 +71,7 @@ class CoderDirective(BaseModel):
     # in the persistent Jupyter kernel; "matlab" hands the source to
     # MatlabSession (matlab -batch in prod, octave --no-gui in dev). State
     # does NOT persist across MATLAB turns — use .mat files for handoff.
-    # Unknown values are normalized to "python" by the agent.
-    language: str = "python"
+    language: Literal["python", "matlab"] = "python"
 
 
 class CoderAgent:

--- a/apps/agent-worker/src/agent_worker/agents/evidence.py
+++ b/apps/agent-worker/src/agent_worker/agents/evidence.py
@@ -50,6 +50,39 @@ _SENS_FIGURE_TOKENS = (
     "灵敏度",
 )
 
+# Lifted out of `mine_sensitivity_evidence` per round-6 audit (Agent A
+# finding #4): these were being rebuilt on every Writer revision round.
+# Module-level constants compile once at import time.
+_GREEK_LOWER = "αβγδεζηθικλμνξορστυφχψω"
+_PARAM_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # "perturbed α by ±10%" / "varying β over ±20%" / "increased X by 10%"
+    re.compile(
+        rf"(?:perturb(?:ed|ing)?|vary(?:ing)?|increas(?:e[ds]?|ing)|decreas(?:e[ds]?|ing)|chang(?:e[ds]?|ing))"
+        rf"\s+([{_GREEK_LOWER}]|[A-Za-z](?:_?[A-Za-z0-9]{{0,8}})?)"
+        rf"\s+(?:by|of|over|at|with)?\s*{_PERTURB_RE.pattern}",
+        re.IGNORECASE,
+    ),
+    # "α by ±10%" / "γ at ±20%" / "X_init by 5%"
+    re.compile(
+        rf"\b([{_GREEK_LOWER}]|[A-Za-z]_[A-Za-z0-9]{{1,8}}|[A-Za-z]{{1,3}})\s+(?:by|at|over)\s*{_PERTURB_RE.pattern}",
+        re.IGNORECASE,
+    ),
+    # "For α at ±10%" / "对 α 增减 10%"
+    re.compile(
+        rf"(?:For|对|参数)\s+([{_GREEK_LOWER}]|[A-Za-z](?:_?[A-Za-z0-9]{{0,8}})?)"
+        rf"[^.。!?\n]{{0,30}}{_PERTURB_RE.pattern}",
+        re.IGNORECASE,
+    ),
+)
+_PARAM_BLACKLIST: frozenset[str] = frozenset(
+    {
+        "the", "a", "an", "this", "that", "we", "for", "of", "by", "at",
+        "in", "on", "to", "is", "are", "was", "were", "be", "been",
+        "and", "or", "with", "from", "as", "it", "its", "all", "each",
+    }
+)
+_FIG_ID_RE = re.compile(r"\[\[FIG:([a-z0-9_]+)\]\]")
+
 
 @dataclass
 class SensitivityFindings:
@@ -78,38 +111,9 @@ def mine_sensitivity_evidence(paper: PaperDraft) -> SensitivityFindings:
 
     # Parameter-count proxy: catalog short variable tokens that appear near
     # a perturbation phrase. Conservative — over-count is fine, under-count
-    # would let weak papers through.
+    # would let weak papers through. Regex patterns + blacklist live at
+    # module level (see `_PARAM_PATTERNS` above) so they compile once.
     parameter_tokens: set[str] = set()
-
-    # Patterns that explicitly bind a parameter to a perturbation phrase.
-    # Each pattern's group(1) is the parameter token.
-    _GREEK = "αβγδεζηθικλμνξορστυφχψω"
-    _PARAM_PATTERNS = [
-        # "perturbed α by ±10%" / "varying β over ±20%" / "increased X by 10%"
-        re.compile(
-            rf"(?:perturb(?:ed|ing)?|vary(?:ing)?|increas(?:e[ds]?|ing)|decreas(?:e[ds]?|ing)|chang(?:e[ds]?|ing))"
-            rf"\s+([{_GREEK}]|[A-Za-z](?:_?[A-Za-z0-9]{{0,8}})?)"
-            rf"\s+(?:by|of|over|at|with)?\s*{_PERTURB_RE.pattern}",
-            re.IGNORECASE,
-        ),
-        # "α by ±10%" / "γ at ±20%" / "X_init by 5%"
-        re.compile(
-            rf"\b([{_GREEK}]|[A-Za-z]_[A-Za-z0-9]{{1,8}}|[A-Za-z]{{1,3}})\s+(?:by|at|over)\s*{_PERTURB_RE.pattern}",
-            re.IGNORECASE,
-        ),
-        # "For α at ±10%" / "对 α 增减 10%"
-        re.compile(
-            rf"(?:For|对|参数)\s+([{_GREEK}]|[A-Za-z](?:_?[A-Za-z0-9]{{0,8}})?)"
-            rf"[^.。!?\n]{{0,30}}{_PERTURB_RE.pattern}",
-            re.IGNORECASE,
-        ),
-    ]
-
-    _PARAM_BLACKLIST = {
-        "the", "a", "an", "this", "that", "we", "for", "of", "by", "at",
-        "in", "on", "to", "is", "are", "was", "were", "be", "been",
-        "and", "or", "with", "from", "as", "it", "its", "all", "each",
-    }
 
     for sec in paper.sections:
         title = sec.title or ""
@@ -130,7 +134,7 @@ def mine_sensitivity_evidence(paper: PaperDraft) -> SensitivityFindings:
                     samples.append(m.group(0).strip()[:200])
         if any(tok in body.lower() for tok in _SENS_FIGURE_TOKENS):
             figure_refs = True
-        for fig_id_match in re.finditer(r"\[\[FIG:([a-z0-9_]+)\]\]", body):
+        for fig_id_match in _FIG_ID_RE.finditer(body):
             if any(tok in fig_id_match.group(1) for tok in _SENS_FIGURE_TOKENS):
                 figure_refs = True
 

--- a/apps/agent-worker/src/agent_worker/finetune_main.py
+++ b/apps/agent-worker/src/agent_worker/finetune_main.py
@@ -26,7 +26,6 @@ from agent_worker.events import EventEmitter
 from agent_worker.gateway_client import GatewayClient
 from agent_worker.kernel import KernelSession
 from agent_worker.logging import get_logger
-from agent_worker.matlab import MatlabSession
 
 FINETUNE_STREAM = "mm:finetune"
 FINETUNE_GROUP = "mm-finetune-workers"
@@ -100,7 +99,6 @@ async def run_finetune(
     emitter = EventEmitter(redis, run_id, events_log_path=run_dir / "events.jsonl")
     gateway = GatewayClient(cfg.gateway_http, cfg.dev_auth_token)
     kernel = KernelSession(run_id, runs_dir)
-    matlab_session = MatlabSession(run_id, runs_dir)
 
     try:
         await emitter.emit(
@@ -112,18 +110,19 @@ async def run_finetune(
             agent="paper_editor",
         )
 
+        # PaperEditorAgent currently only consumes the Python kernel; a
+        # MatlabSession will be wired in a follow-up when an `edit_constant`
+        # flow targets a .m file.
         agent = PaperEditorAgent(
             gateway=gateway,
             emitter=emitter,
             kernel=kernel,
-            matlab_session=matlab_session,
             run_dir=run_dir,
         )
 
         summary = await agent.fine_tune(
             user_message=user_message,
             run_dir=run_dir,
-            session_id=session_id,
         )
 
         await emitter.emit(
@@ -155,6 +154,7 @@ async def _process(
     entry_id: str,
     fields: dict[Any, Any],
     semaphore: asyncio.Semaphore,
+    run_locks: dict[UUID, asyncio.Lock],
 ) -> None:
     async with semaphore:
         try:
@@ -165,7 +165,12 @@ async def _process(
                 session_id=str(session_id),
                 entry_id=entry_id,
             )
-            await run_finetune(redis, cfg, run_id, session_id, message)
+            # Acquire the per-run mutex so we never overlap a fine-tune turn
+            # with the original pipeline (which writes the same notebook +
+            # paper.meta.json + figures dir) — Agent A flagged this race.
+            lock = run_locks.setdefault(run_id, asyncio.Lock())
+            async with lock:
+                await run_finetune(redis, cfg, run_id, session_id, message)
             log.info("finetune_completed", run_id=str(run_id), entry_id=entry_id)
         except Exception as exc:  # noqa: BLE001
             log.exception("finetune_process_failed", entry_id=entry_id, error=str(exc))
@@ -183,8 +188,16 @@ async def consume_loop(
     stop: asyncio.Event,
     semaphore: asyncio.Semaphore,
     in_flight: set[asyncio.Task[None]],
+    run_locks: dict[UUID, asyncio.Lock] | None = None,
 ) -> None:
-    """Same XREADGROUP loop as main.py but against mm:finetune."""
+    """Same XREADGROUP loop as main.py but against mm:finetune.
+
+    `run_locks` is a shared dict that pairs with main.py's pipeline
+    consumer; both grab the same per-run_id mutex so a fine-tune turn
+    never overlaps with the original pipeline writing the same
+    notebook + paper.meta.json + figures dir.
+    """
+    locks = run_locks if run_locks is not None else {}
     await _ensure_group(redis)
     while not stop.is_set():
         try:
@@ -205,9 +218,9 @@ async def consume_loop(
         if not resp:
             continue
         for _stream, entries in resp:
-            for entry_id, fields in entries:
+            for entry_id, fields in entries:  # noqa: B007 — entry_id used below
                 task = asyncio.create_task(
-                    _process(redis, cfg, _decode(entry_id), fields, semaphore)
+                    _process(redis, cfg, _decode(entry_id), fields, semaphore, locks)
                 )
                 in_flight.add(task)
                 task.add_done_callback(in_flight.discard)

--- a/apps/agent-worker/src/agent_worker/main.py
+++ b/apps/agent-worker/src/agent_worker/main.py
@@ -76,6 +76,7 @@ async def _process(
     entry_id: str,
     fields: dict[Any, Any],
     semaphore: asyncio.Semaphore,
+    run_locks: dict[UUID, asyncio.Lock],
 ) -> None:
     """Process one job entry: run the pipeline, emit error on failure, XACK."""
     async with semaphore:
@@ -83,7 +84,12 @@ async def _process(
         try:
             run_id, problem = _parse_entry(fields)
             log.info("job_started", run_id=str(run_id), entry_id=entry_id)
-            await run_pipeline(redis, run_id, problem)
+            # Per-run_id mutex (shared with the finetune consumer) so a
+            # late-arriving fine-tune doesn't race the pipeline writing
+            # paper.meta.json / notebook.ipynb / figures/.
+            lock = run_locks.setdefault(run_id, asyncio.Lock())
+            async with lock:
+                await run_pipeline(redis, run_id, problem)
             log.info("job_completed", run_id=str(run_id), entry_id=entry_id)
         except Exception as exc:  # noqa: BLE001 — we want to catch everything here
             log.exception("job_failed", entry_id=entry_id, error=str(exc))
@@ -110,6 +116,7 @@ async def _consume_loop(
     stop: asyncio.Event,
     semaphore: asyncio.Semaphore,
     in_flight: set[asyncio.Task[None]],
+    run_locks: dict[UUID, asyncio.Lock],
 ) -> None:
     """Main XREADGROUP loop. Runs until `stop` is set."""
     while not stop.is_set():
@@ -134,7 +141,7 @@ async def _consume_loop(
         for _stream, entries in resp:
             for entry_id, fields in entries:
                 task = asyncio.create_task(
-                    _process(redis, _decode(entry_id), fields, semaphore)
+                    _process(redis, _decode(entry_id), fields, semaphore, run_locks)
                 )
                 in_flight.add(task)
                 task.add_done_callback(in_flight.discard)
@@ -173,10 +180,16 @@ async def run(settings: Settings | None = None) -> None:
     stop = asyncio.Event()
     _install_signal_handlers(stop)
 
+    # Per-run_id mutex shared between the pipeline consumer and the
+    # finetune consumer — guarantees we never have two writers on the same
+    # notebook / paper.meta.json / figures dir. Round-6 audit (Agent A
+    # finding #2) flagged this as a major concurrency hazard.
+    run_locks: dict[UUID, asyncio.Lock] = {}
+
     semaphore = asyncio.Semaphore(cfg.worker_concurrency)
     in_flight: set[asyncio.Task[None]] = set()
     consumer_task = asyncio.create_task(
-        _consume_loop(redis, consumer, stop, semaphore, in_flight)
+        _consume_loop(redis, consumer, stop, semaphore, in_flight, run_locks)
     )
 
     # Parallel consumer for paper fine-tune jobs (mm:finetune). Separate
@@ -186,7 +199,13 @@ async def run(settings: Settings | None = None) -> None:
     finetune_consumer = _finetune_consumer_name()
     finetune_task = asyncio.create_task(
         _finetune_consume_loop(
-            redis, cfg, finetune_consumer, stop, finetune_semaphore, finetune_in_flight
+            redis,
+            cfg,
+            finetune_consumer,
+            stop,
+            finetune_semaphore,
+            finetune_in_flight,
+            run_locks,
         )
     )
 

--- a/apps/agent-worker/src/agent_worker/prompts/coder/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/coder/v1.toml
@@ -325,8 +325,6 @@ evaluator scans for when triaging code-quality at speed.
 
 [user_template]
 text = """
-{{ upstream_reminders }}
-
 You are solving this problem. Read the Analyzer's scoped plan and the
 Modeler's concrete spec, then implement the approach step by step.
 
@@ -343,6 +341,8 @@ Chart catalog (pick an `id` and name it in `reasoning` as `chart_type_id=<id>`):
 {{ chart_catalog_index }}
 
 The optional "language" field in your JSON output picks the runtime: "python" (default) routes to the Jupyter kernel; "matlab" routes to MatlabSession (matlab -batch or octave). One code block per turn; state does not persist across MATLAB turns.
+
+{{ upstream_reminders }}
 
 Respond with a JSON object: {"reasoning": "...", "code": "...", "done": false, "summary": null, "figures_saved": []}.
 Follow the Modeler's chosen_approach and algorithm_outline. Start by

--- a/apps/agent-worker/src/agent_worker/prompts/modeler/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/modeler/v1.toml
@@ -56,8 +56,6 @@ Respond with a single JSON object matching ModelSpec. Use ensure_ascii=False for
 
 [user_template]
 text = """
-{{ upstream_reminders }}
-
 Problem type: {{ competition_type }}
 
 Problem statement:
@@ -71,6 +69,8 @@ Retrieved methods from HMML (top 5 by BM25 relevance):
 
 Same-problem-type award-paper exemplars (structure reference, do NOT copy):
 {{ few_shot_exemplars }}
+
+{{ upstream_reminders }}
 
 Respond with a JSON object. Required top-level keys:
   chosen_approach (string),

--- a/apps/agent-worker/src/agent_worker/prompts/searcher/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/searcher/v1.toml
@@ -52,8 +52,6 @@ Return a JSON object matching SearchFindings. No prose, no markdown fences.
 
 [user_template]
 text = """
-{{ upstream_reminders }}
-
 Problem type: {{ competition_type }}
 Problem: {{ problem_text }}
 
@@ -62,6 +60,8 @@ Analyzer scope: {{ analysis_json }}
 Queries executed: {{ queries_json }}
 
 Raw retrieval results (mixed arXiv + web): {{ papers_json }}
+
+{{ upstream_reminders }}
 
 Return SearchFindings JSON keys: queries, papers (with relevance_reason),
 key_findings, datasets_mentioned.

--- a/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
@@ -132,8 +132,6 @@ If you see `few_shot_exemplars` in the user message, those are summary excerpts 
 
 [user_template]
 text = """
-{{ upstream_reminders }}
-
 Problem type: {{ competition_type }}
 
 Problem statement:
@@ -170,6 +168,8 @@ back to title+abstract citation from the Sources list.
 ## Same-problem-type O/F-prize exemplars (structure reference, do NOT copy)
 
 {{ few_shot_exemplars }}
+
+{{ upstream_reminders }}
 
 Respond with a JSON object. Required top-level keys:
   title (string),

--- a/apps/web/src/components/PaperDraft.vue
+++ b/apps/web/src/components/PaperDraft.vue
@@ -27,7 +27,7 @@ function isRelativeFigureHref(href: string): boolean {
 }
 
 function makeMarked(runId: string): Marked {
-  return new Marked({
+  const m = new Marked({
     gfm: true,
     breaks: false,
     walkTokens(token: Token) {
@@ -37,8 +37,38 @@ function makeMarked(runId: string): Marked {
         const n = img.href.startsWith("./") ? img.href.slice(2) : img.href;
         img.href = figureUrl(runId, n);
       }
+      // Round-6 a11y pass (Agent C #5): figures emitted with empty alt
+      // (the Writer outputs `![](figures/foo.png)`). Fall back to the
+      // title attr or the file stem so screen readers get something.
+      if (!img.text || !img.text.trim()) {
+        const stem = img.href.split("/").pop()?.replace(/\.[^.]+$/, "") ?? "figure";
+        img.text = (img.title && img.title.trim()) || stem.replace(/_/g, " ");
+      }
     },
   });
+  // Add `loading="lazy"` + `decoding="async"` to every rendered image so
+  // a long paper with 15+ figures doesn't block first paint. marked v15
+  // honours custom renderers via `use({renderer: ...})`.
+  m.use({
+    renderer: {
+      image(token) {
+        const href = token.href ?? "";
+        const text = token.text ?? "";
+        const title = token.title ? ` title="${escapeHtml(token.title)}"` : "";
+        const alt = escapeHtml(text);
+        return `<img src="${escapeHtml(href)}" alt="${alt}"${title} loading="lazy" decoding="async" />`;
+      },
+    },
+  });
+  return m;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 const title = computed<string>(() => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -517,12 +517,15 @@ body.zh .workbench .hero-h {
 .workbench .panel-h { padding: 14px 18px; }
 .workbench .panel-b { padding: 18px; }
 
-/* 5-step pills */
+/* 6-step pills (analyzer / searcher / modeler / coder / writer / critic).
+   Previously hard-coded to 5, leaving the Critic pill wrapping out of the
+   visual flow. Round-6 UX audit (Agent C #1). */
 .steps {
-  display: grid; grid-template-columns: repeat(5, minmax(0, 1fr));
+  display: grid; grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 8px; margin-bottom: 18px;
 }
-@media (max-width: 760px) { .steps { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 980px) { .steps { grid-template-columns: repeat(3, 1fr); } }
+@media (max-width: 600px) { .steps { grid-template-columns: repeat(2, 1fr); } }
 .pill {
   padding: 10px 12px; border: 1px solid var(--rule); border-radius: 2px;
   background: var(--paper); position: relative;

--- a/apps/web/src/views/Workbench.vue
+++ b/apps/web/src/views/Workbench.vue
@@ -353,15 +353,11 @@ function agentTitle(agent: string): { en: string; zh: string; num: string } {
             </div>
           </div>
           <div style="display:flex; gap:8px;">
-            <button
-              class="btn ghost"
-              disabled
-              :title="i18n.t('pause is not implemented yet', '暂停功能尚未实现')"
-            >
-              ⏸ <T en="Pause" zh="暂停" />
-            </button>
+            <!-- Pause button removed in round-6 UX pass: it was disabled
+                 with only a tooltip explanation (Agent C #5). Replace with
+                 a real Cancel route once the backend exposes one. -->
             <RouterLink class="btn hi" :to="{ name: 'workbench' }">
-              ▶ <T en="New run" zh="新建运行" />
+              <span aria-hidden="true">▶</span> <T en="New run" zh="新建运行" />
             </RouterLink>
           </div>
         </div>

--- a/packages/py-contracts/src/mm_contracts/agent_io.py
+++ b/packages/py-contracts/src/mm_contracts/agent_io.py
@@ -101,6 +101,7 @@ AgentName = Literal[
     "coder",
     "writer",
     "critic",
+    "paper_editor",
     "searcher",
 ]
 
@@ -110,9 +111,16 @@ EventKind = Literal[
     "log",
     "token",
     "cost",
+    "finetune.session.start",
+    "finetune.session.done",
+    "finetune.session.error",
+    "finetune.tool_call",
+    "finetune.tool_result",
+    "finetune.token",
     "agent.output",
     "kernel.stdout",
     "kernel.figure",
+    "kernel.error",
     "error",
     "done",
 ]


### PR DESCRIPTION
Stacked on #31. Round-6 audit fixes from 4 parallel discovery agents (code-quality / cost+perf / UX / sourcemap-unexplored). Lands the P0 items that are small + safe + high-impact.

## Critical fixes

1. **AgentEvent contract drift** — `paper_editor` + 6 `finetune.*` event kinds + `kernel.error` were emitted at runtime but rejected by the Pydantic contract → every fine-tune session crashed on first emit. **Real smoke test caught this.** Extended `AgentName` / `EventKind` Literals.

2. **`PaperEditorAgent.__init__()` TypeError** — `finetune_main` passed `matlab_session=` kwarg the agent doesn't accept. Real smoke test exposed.

3. **Per-run_id mutex between pipeline + finetune consumers** (Agent A #2). Two consumers could write the same `notebook.ipynb` / `paper.meta.json` / `figures/` concurrently. `main.py` + `finetune_main.py` now share a `dict[UUID, asyncio.Lock]`.

## Performance fixes

4. **Lift `_PARAM_PATTERNS` to module level** (Agent A #4): three regexes recompiled on every `mine_sensitivity_evidence` call. ~3× speedup on the Writer evidence scan.

5. **Reuse `_FIG_ID_RE`** in evidence.py (Agent A #5).

6. **Move `{{ upstream_reminders }}` to BOTTOM of user templates** (Agent B cache strategy #4): preserves stable prompt-cache prefix across revision rounds. 4 TOMLs touched (searcher / modeler / coder / writer).

## Contract / safety

7. **`CoderDirective.language: Literal["python","matlab"]`** (Agent A #6): was `str`.

## Frontend UX

8. **5→6 stage pill grid** (Agent C #1): `repeat(5, ...)` left Critic pill wrapping out of flow; bumped + added 980px breakpoint.

9. **Removed dead Pause button** (Agent C #5): was disabled with tooltip-only feedback.

10. **`loading=\"lazy\" decoding=\"async\"` + alt fallback** in `PaperDraft.vue` (Agent C #5): Writer emits `![](figures/foo.png)` so alt was always empty. Walker now derives a fallback; renderer override adds lazy attrs so long papers don't block first paint.

## Test status

- `pytest`: **424 passed** (unchanged baseline; all fixes additive)
- `ruff`: clean
- `pnpm --filter web typecheck`: clean

## Deferred to round 7

**From Agent B (cost):**
- Per-stage `max_revision_rounds` (Writer:1, others:2) → ~0.57 RMB/run
- Trim `coder_cells.source` from Writer prompt → ~0.4 RMB/run
- Anthropic `cache_control: ephemeral` wiring → ~0.7-1.0 RMB/run
- Concurrent Critic + next-stage prep → ~6.7 min wall savings

**From Agent D (sourcemap):**
- SkillTool on-demand body load (~250 LOC)
- Mid-run interrupt control channel (`RemoteControlHandle` pattern, ~400 LOC) — user-chosen in round 5
- Surgical edit tool for PaperEditor (find/replace, ~350 LOC)

**From Agent A (code-quality):**
- `_review_and_maybe_revise` cost budget hooked to actual gateway cost events (current estimates 7× too low)
- Test coverage for `run_finetune` end-to-end
- Lift duplicated `_problem_letter_from_problem_text` to shared module