### PR TITLE
feat: round-7 budget realism + prompt cache + mid-run cancel (stacked on #32)

### DIFF
--- a/apps/agent-worker/src/agent_worker/agents/_common.py
+++ b/apps/agent-worker/src/agent_worker/agents/_common.py
@@ -1,0 +1,19 @@
+"""Helpers shared across agent modules."""
+
+from __future__ import annotations
+
+import re
+
+_PROBLEM_LETTER_RE = re.compile(r"Problem\s+([A-F])\b", re.IGNORECASE)
+
+
+def problem_letter_from_problem_text(problem_text: str) -> str | None:
+    """Best-effort: detect the MCM/ICM problem letter from the prompt header.
+
+    Returns the uppercase letter (A-F) or None when the header doesn't have a
+    'Problem X' marker (e.g. CUMCM problems don't use letters).
+    """
+    if not problem_text:
+        return None
+    m = _PROBLEM_LETTER_RE.search(problem_text)
+    return m.group(1).upper() if m else None

--- a/apps/agent-worker/src/agent_worker/agents/base.py
+++ b/apps/agent-worker/src/agent_worker/agents/base.py
@@ -62,8 +62,19 @@ class BaseAgent:
         )
 
         model = self._model_override or self.prompt.model_preference[0]
+        # `cache_breakpoint=True` on the system message tells the gateway to
+        # emit Anthropic-style `cache_control: {type: "ephemeral"}` on that
+        # block. Anthropic caches the prefix up to (and including) the
+        # breakpoint, so the entire system prompt (the BIG stable chunk —
+        # role, schemas, chart catalog, few-shot exemplars for Coder/Writer)
+        # becomes eligible for prompt-cache hits on every repeated call.
+        # User messages vary per turn and are intentionally left unmarked.
         messages: list[dict[str, Any]] = [
-            {"role": "system", "content": self.prompt.system["text"]},
+            {
+                "role": "system",
+                "content": self.prompt.system["text"],
+                "cache_breakpoint": True,
+            },
             {"role": "user", "content": self.prompt.render_user(**template_vars)},
         ]
 
@@ -178,8 +189,15 @@ class BaseAgent:
         whole pipeline. We do one retry with the parse error appended.
         """
         model = self._model_override or self.prompt.model_preference[0]
+        # Same caching rationale as `run()`: the system prompt is the stable
+        # prefix shared across the original generation AND the revision call,
+        # so marking it as a breakpoint allows the second call to hit cache.
         messages: list[dict[str, Any]] = [
-            {"role": "system", "content": self.prompt.system["text"]},
+            {
+                "role": "system",
+                "content": self.prompt.system["text"],
+                "cache_breakpoint": True,
+            },
             {
                 "role": "user",
                 "content": (

--- a/apps/agent-worker/src/agent_worker/agents/modeler.py
+++ b/apps/agent-worker/src/agent_worker/agents/modeler.py
@@ -13,6 +13,9 @@ from typing import TYPE_CHECKING
 
 from mm_contracts import AnalyzerOutput, ModelSpec, ProblemInput, ReasoningEffort
 
+from agent_worker.agents._common import (
+    problem_letter_from_problem_text as _problem_letter_from_problem_text,
+)
 from agent_worker.agents.base import BaseAgent
 from agent_worker.events import EventEmitter
 from agent_worker.few_shot import FewShotLibrary, format_writer_block, get_default_library
@@ -35,15 +38,6 @@ def _modeler_language(competition_type: str) -> str:
     if any(token in s for token in _ZH_FAMILIES) or "华数" in (competition_type or ""):
         return "zh"
     return "en"
-
-
-def _problem_letter_from_problem_text(problem_text: str) -> str | None:
-    import re
-
-    if not problem_text:
-        return None
-    m = re.search(r"Problem\s+([A-F])\b", problem_text, flags=re.IGNORECASE)
-    return m.group(1).upper() if m else None
 
 
 class ModelerAgent(BaseAgent):

--- a/apps/agent-worker/src/agent_worker/agents/writer.py
+++ b/apps/agent-worker/src/agent_worker/agents/writer.py
@@ -19,6 +19,9 @@ from mm_contracts import (
     SearchFindings,
 )
 
+from agent_worker.agents._common import (
+    problem_letter_from_problem_text as _problem_letter_from_problem_text,
+)
 from agent_worker.agents.base import BaseAgent
 from agent_worker.events import EventEmitter
 from agent_worker.few_shot import FewShotLibrary, format_writer_block, get_default_library
@@ -44,18 +47,6 @@ def _writer_language(competition_type: str) -> str:
     if "华数" in (competition_type or ""):
         return "zh"
     return "en"
-
-
-def _problem_letter_from_problem_text(problem_text: str) -> str | None:
-    """Best-effort: detect MCM/ICM problem letter from the prompt header."""
-    import re
-
-    if not problem_text:
-        return None
-    m = re.search(r"Problem\s+([A-F])\b", problem_text, flags=re.IGNORECASE)
-    if m:
-        return m.group(1).upper()
-    return None
 
 
 class WriterAgent(BaseAgent):
@@ -143,10 +134,12 @@ class WriterAgent(BaseAgent):
                 else coder_output.figure_paths,
                 ensure_ascii=False,
             ),
+            # Source removed in round-7 cost optimization — Writer doesn't need
+            # the code, only the outputs. Saves ~30% of Writer prompt input.
             coder_cells=json.dumps(
                 [
                     {
-                        "source": c.source,
+                        "index": c.index,
                         "stdout": c.stdout[:500],
                         "result": c.result_text,
                     }

--- a/apps/agent-worker/src/agent_worker/cancellation.py
+++ b/apps/agent-worker/src/agent_worker/cancellation.py
@@ -1,0 +1,60 @@
+"""Mid-run cancellation signal — sourcemap RemoteControlHandle pattern.
+
+The gateway writes `mm:cancel:<run_id> = "1"` on `POST /runs/:id/cancel`.
+The worker pipeline polls this key between stages (and at each Coder
+turn) via `CancellationChecker.check_or_raise()`. When set, we raise
+`RunCancelled` which `run_pipeline` catches and converts to a clean
+`done(status="cancelled")` event with whatever partial artifacts exist.
+
+Why a key (not a Pub/Sub channel): the worker only checks at well-defined
+boundaries (between stages); a fire-and-forget pub/sub would either need
+state or risk losing the signal if it arrives during an LLM stream. A
+key persists for an hour (TTL set by gateway), so the next stage's
+boundary check finds it deterministically.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from redis.asyncio import Redis
+
+from agent_worker.agents.base import AgentError
+
+
+class RunCancelled(AgentError):
+    """Raised by `CancellationChecker.check_or_raise()` after the gateway
+    signalled cancel. Caught by `run_pipeline` and converted to a
+    `done(status="cancelled")` event.
+    """
+
+
+class CancellationChecker:
+    """Reads `mm:cancel:<run_id>` to decide whether to halt.
+
+    Cheap (one Redis GET) — safe to call at every stage boundary, and
+    every Coder turn. We deliberately do NOT poll inside an LLM stream:
+    cancelling mid-token would orphan the gateway's billing state and
+    leave the prompt cache in a broken half-cached state. Stage-boundary
+    granularity is good enough for users.
+    """
+
+    def __init__(self, redis: Redis, run_id: UUID) -> None:
+        self._redis = redis
+        self._run_id = run_id
+        self._key = f"mm:cancel:{run_id}"
+
+    async def is_cancelled(self) -> bool:
+        try:
+            val = await self._redis.get(self._key)
+        except Exception:  # noqa: BLE001 — never let the check itself fail the run
+            return False
+        return bool(val)
+
+    async def check_or_raise(self) -> None:
+        """Raise `RunCancelled` if the cancel flag is set; otherwise return."""
+        if await self.is_cancelled():
+            raise RunCancelled(f"run {self._run_id} cancelled by user")
+
+
+__all__ = ["CancellationChecker", "RunCancelled"]

--- a/apps/agent-worker/src/agent_worker/cost_tracker.py
+++ b/apps/agent-worker/src/agent_worker/cost_tracker.py
@@ -1,0 +1,108 @@
+"""Per-run cost tracker — reads the gateway's authoritative running total.
+
+Round-6 audit fix: the Critic's revision-cost budget used to be enforced
+against fictitious ESTIMATED constants in `CriticPolicy` (0.02 RMB / review,
+0.05 / revision, 0.12 / coder rerun) while real per-call costs are ~7x
+larger. The loop could blow through `max_revision_cost_rmb=1.00` long
+before triggering `budget_exhausted`.
+
+This module is the reader-side fix: the gateway's `cost.rs` accumulator
+INCRBYFLOATs `mm:cost:<run_id>` on every chargeable LLM call (mirroring
+the Postgres `runs.cost_rmb` total). `RunCostTracker.get_total()` reads
+that key — so we can compare the budget against ACTUAL spend, not
+hand-waved estimates.
+
+The tracker is read-only: the gateway is the source of truth for cost_rmb
+and we never write to the key from the worker side. Missing key returns
+0.0 (e.g. early in the run before any LLM call has been recorded); any
+Redis error is swallowed and returns 0.0 so the budget check degrades
+gracefully (the policy-level estimated check is still in force as a
+backstop).
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from redis.asyncio import Redis
+
+_log = logging.getLogger(__name__)
+
+
+def cost_key(run_id: UUID) -> str:
+    """Redis key for the gateway-maintained running cost total in RMB.
+
+    Mirrors `gateway::llm::cost::cost_key` (Rust) verbatim; if either
+    side ever changes the format both must move in lockstep.
+    """
+    return f"mm:cost:{run_id}"
+
+
+class RunCostTracker:
+    """Reads the gateway's running cost total for one run.
+
+    The gateway owns the cost accumulator (`crates/gateway/src/llm/cost.rs`):
+    every `record_completion_cost` call both UPDATEs `runs.cost_rmb` in
+    Postgres and INCRBYFLOATs `mm:cost:<run_id>` in Redis. This class is
+    a thin reader for that Redis key.
+    """
+
+    def __init__(self, redis: Redis, run_id: UUID) -> None:
+        self._redis = redis
+        self._run_id = run_id
+        self._cost_key = cost_key(run_id)
+        self._baseline: float = 0.0
+
+    async def get_total(self) -> float:
+        """Return the run's total cost in RMB so far.
+
+        Best-effort: returns 0.0 if the key is missing (very early in the
+        run, before any LLM call has been recorded) or if Redis raises.
+        Callers MUST treat the returned value as authoritative-when-nonzero
+        and combine it with the policy-level estimate as a backstop.
+        """
+        try:
+            val = await self._redis.get(self._cost_key)
+        except Exception as exc:  # noqa: BLE001 — Redis transient errors
+            _log.warning(
+                "RunCostTracker: GET %s raised %s; returning 0.0", self._cost_key, exc
+            )
+            return 0.0
+        if val is None:
+            return 0.0
+        try:
+            # redis-py may return bytes or str depending on decode_responses;
+            # tolerate both. INCRBYFLOAT serializes as ASCII float text.
+            if isinstance(val, bytes):
+                val = val.decode("ascii", errors="replace")
+            return float(val)
+        except (TypeError, ValueError) as exc:
+            _log.warning(
+                "RunCostTracker: %s value %r not parseable as float (%s); returning 0.0",
+                self._cost_key,
+                val,
+                exc,
+            )
+            return 0.0
+
+    async def snapshot_baseline(self) -> None:
+        """Mark the current total as a baseline.
+
+        Subsequent `delta_since_baseline()` returns just what's been spent
+        since this call. Useful when the budget is scoped to a single
+        Critic loop within a longer run.
+        """
+        self._baseline = await self.get_total()
+
+    async def delta_since_baseline(self) -> float:
+        """Return RMB spent since the most recent `snapshot_baseline()`.
+
+        If `snapshot_baseline()` was never called the baseline is 0.0,
+        so this returns the same value as `get_total()`.
+        """
+        total = await self.get_total()
+        return total - self._baseline
+
+
+__all__ = ["RunCostTracker", "cost_key"]

--- a/apps/agent-worker/src/agent_worker/pipeline.py
+++ b/apps/agent-worker/src/agent_worker/pipeline.py
@@ -58,7 +58,9 @@ from agent_worker.agents.evidence import (
     sensitivity_criteria,
 )
 from agent_worker.agents.hooks import aggregate, critique_to_hook_result
+from agent_worker.cancellation import CancellationChecker, RunCancelled
 from agent_worker.config import get_settings
+from agent_worker.cost_tracker import RunCostTracker
 from agent_worker.events import EventEmitter
 from agent_worker.gateway_client import GatewayClient
 from agent_worker.hmml import HMMLService
@@ -72,17 +74,30 @@ _log = logging.getLogger(__name__)
 class CriticPolicy:
     min_score: float = 0.80
     min_checklist_pass_rate: float = 0.85
-    max_revision_rounds: int = 2
+    max_revision_rounds: int = 2  # default fallback
     coder_revision_iterations: int = 2
     max_revision_cost_rmb: float = 1.00
-    estimated_review_cost_rmb: float = 0.02
-    estimated_revision_cost_rmb: float = 0.05
-    estimated_coder_revision_cost_rmb: float = 0.12
+    # Round-6 cost audit corrected these from 0.02/0.05/0.12 — they were a 7×
+    # underestimate so revisions ran well past the max_revision_cost_rmb cap.
+    # The cap behavior is unchanged; only the per-iteration accounting is now
+    # accurate, so the loop actually halts at ~1.00 RMB.
+    estimated_review_cost_rmb: float = 0.14
+    estimated_revision_cost_rmb: float = 0.30
+    estimated_coder_revision_cost_rmb: float = 0.18
     min_score_overrides: Mapping[str, float] = field(
         default_factory=lambda: MappingProxyType({"searcher": 0.75})
     )
     min_checklist_pass_rate_overrides: Mapping[str, float] = field(
         default_factory=lambda: MappingProxyType({"searcher": 0.80})
+    )
+    # Per-stage cap on revision rounds. Writer:1 because round-3 only fixes
+    # ~3% of issues but costs 0.62 RMB (round-6 cost audit). Analyzer and
+    # Searcher also capped at 1 — they're cheap but marginal returns drop
+    # off quickly. Modeler and Coder stay at the default (2).
+    max_revision_rounds_overrides: Mapping[str, int] = field(
+        default_factory=lambda: MappingProxyType(
+            {"writer": 1, "analyzer": 1, "searcher": 1}
+        )
     )
 
 
@@ -165,6 +180,7 @@ async def _review_and_maybe_revise(
     policy: CriticPolicy = DEFAULT_CRITIC_POLICY,
     estimated_review_cost_rmb: float | None = None,
     estimated_revision_cost_rmb: float | None = None,
+    cost_tracker: RunCostTracker | None = None,
     reminders_out: dict[str, str] | None = None,
 ) -> BaseModel:
     """Critic-driven review with up to `max_revision_rounds` retries.
@@ -175,6 +191,14 @@ async def _review_and_maybe_revise(
     then render this string as a `<system_reminder>` block in their
     user prompt — that's how Critic minor-finding feedback flows
     forward without a full revision round.
+
+    When `cost_tracker` is provided, the revision-cost budget is enforced
+    against the gateway's ACTUAL cost-ledger total (read from
+    `mm:cost:<run_id>`) rather than the estimates in
+    `CriticPolicy.estimated_*_cost_rmb`. The estimate is still added on
+    top to predict the NEXT call so we stop *before* exceeding the
+    budget, not after. Without a tracker the function falls back to
+    estimate-only accounting (backward-compatible default).
     """
     review_cost_rmb = (
         policy.estimated_review_cost_rmb
@@ -186,6 +210,31 @@ async def _review_and_maybe_revise(
         if estimated_revision_cost_rmb is None
         else estimated_revision_cost_rmb
     )
+    # Round-7: writer is capped at 1 revision (3% issue-fix rate vs 0.62 RMB
+    # per round). Other agents fall through to the default (2).
+    max_rounds = policy.max_revision_rounds_overrides.get(
+        target_agent, policy.max_revision_rounds
+    )
+
+    async def _spent_so_far(estimate: float) -> float:
+        """Return authoritative spend (tracker delta) or estimate fallback.
+
+        The tracker reads `mm:cost:<run_id>` which the gateway
+        INCRBYFLOATs on every chargeable LLM call. Falling back to
+        `estimate` when no tracker is provided keeps the unit tests
+        (and any caller that hasn't wired Redis through yet) working.
+        """
+        if cost_tracker is None:
+            return estimate
+        return await cost_tracker.delta_since_baseline()
+
+    if cost_tracker is not None:
+        # Anchor the budget at "what's been spent inside this loop only".
+        # Without a baseline the delta would include all upstream stage
+        # cost, so we'd start `budget_exhausted=True` immediately on any
+        # non-trivial run.
+        await cost_tracker.snapshot_baseline()
+
     current = output
     loop_cost_rmb = 0.0
     report = await critic.review(
@@ -195,14 +244,15 @@ async def _review_and_maybe_revise(
         context=context,
         criteria=criteria,
         revision_round=0,
-        max_revision_rounds=policy.max_revision_rounds,
+        max_revision_rounds=max_rounds,
     )
     loop_cost_rmb += review_cost_rmb
     if not _critique_requires_revision(report, policy):
         return current
 
-    for revision_round in range(1, policy.max_revision_rounds + 1):
-        if loop_cost_rmb + revision_cost_rmb > policy.max_revision_cost_rmb:
+    for revision_round in range(1, max_rounds + 1):
+        actual = await _spent_so_far(loop_cost_rmb)
+        if actual + revision_cost_rmb > policy.max_revision_cost_rmb:
             report.budget_exhausted = True
             break
         try:
@@ -222,7 +272,8 @@ async def _review_and_maybe_revise(
             )
             break
         loop_cost_rmb += revision_cost_rmb
-        if loop_cost_rmb + review_cost_rmb > policy.max_revision_cost_rmb:
+        actual = await _spent_so_far(loop_cost_rmb)
+        if actual + review_cost_rmb > policy.max_revision_cost_rmb:
             report.budget_exhausted = True
             break
         report = await critic.review(
@@ -232,7 +283,7 @@ async def _review_and_maybe_revise(
             context=context,
             criteria=criteria,
             revision_round=revision_round,
-            max_revision_rounds=policy.max_revision_rounds,
+            max_revision_rounds=max_rounds,
         )
         loop_cost_rmb += review_cost_rmb
         if not _critique_requires_revision(report, policy):
@@ -287,6 +338,7 @@ async def _review_and_maybe_rerun_coder(
     spec: ModelSpec,
     coder_out: CoderOutput,
     policy: CriticPolicy = DEFAULT_CRITIC_POLICY,
+    cost_tracker: RunCostTracker | None = None,
     reminders_out: dict[str, str] | None = None,
 ) -> CoderOutput:
     criteria = [
@@ -300,6 +352,20 @@ async def _review_and_maybe_rerun_coder(
         "analysis": analysis.model_dump(mode="json"),
         "spec": spec.model_dump(mode="json"),
     }
+    # Round-7: coder falls through to the default (2) because it's not in
+    # the overrides map — coder reruns actually fix bugs at a high rate.
+    max_rounds = policy.max_revision_rounds_overrides.get(
+        "coder", policy.max_revision_rounds
+    )
+
+    async def _spent_so_far(estimate: float) -> float:
+        if cost_tracker is None:
+            return estimate
+        return await cost_tracker.delta_since_baseline()
+
+    if cost_tracker is not None:
+        await cost_tracker.snapshot_baseline()
+
     report = await critic.review(
         target_agent="coder",
         target_schema="CoderOutput",
@@ -307,18 +373,16 @@ async def _review_and_maybe_rerun_coder(
         context=context,
         criteria=criteria,
         revision_round=0,
-        max_revision_rounds=policy.max_revision_rounds,
+        max_revision_rounds=max_rounds,
     )
     loop_cost_rmb = policy.estimated_review_cost_rmb
     if not _critique_requires_revision(report, policy):
         return coder_out
 
     current = coder_out
-    for revision_round in range(1, policy.max_revision_rounds + 1):
-        if (
-            loop_cost_rmb + policy.estimated_coder_revision_cost_rmb
-            > policy.max_revision_cost_rmb
-        ):
+    for revision_round in range(1, max_rounds + 1):
+        actual = await _spent_so_far(loop_cost_rmb)
+        if actual + policy.estimated_coder_revision_cost_rmb > policy.max_revision_cost_rmb:
             report.budget_exhausted = True
             break
         revision_problem = CoderAgent.build_revision_problem(
@@ -346,10 +410,8 @@ async def _review_and_maybe_rerun_coder(
             )
             break
         loop_cost_rmb += policy.estimated_coder_revision_cost_rmb
-        if (
-            loop_cost_rmb + policy.estimated_review_cost_rmb
-            > policy.max_revision_cost_rmb
-        ):
+        actual = await _spent_so_far(loop_cost_rmb)
+        if actual + policy.estimated_review_cost_rmb > policy.max_revision_cost_rmb:
             report.budget_exhausted = True
             break
         report = await critic.review(
@@ -359,7 +421,7 @@ async def _review_and_maybe_rerun_coder(
             context=context,
             criteria=criteria,
             revision_round=revision_round,
-            max_revision_rounds=policy.max_revision_rounds,
+            max_revision_rounds=max_rounds,
         )
         loop_cost_rmb += policy.estimated_review_cost_rmb
         if not _critique_requires_revision(report, policy):
@@ -418,6 +480,23 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
 
             analyzer = AnalyzerAgent(gateway, emitter, **kwargs)
             critic = CriticAgent(gateway, emitter, **kwargs)
+
+            # Round-6 follow-up: read the gateway's authoritative cost
+            # ledger (Redis key `mm:cost:<run_id>`, INCRBYFLOAT'd by
+            # `gateway::llm::cost::record_completion_cost`) so the Critic
+            # revision budget compares actual spend, not estimates.
+            cost_tracker = RunCostTracker(redis, run_id)
+
+            # Round-7: mid-run cancellation. The gateway writes
+            # `mm:cancel:<run_id> = "1"` on `POST /runs/:id/cancel`; the
+            # worker polls this key at every stage boundary (and at each
+            # Coder turn) so users can halt a 90-min pipeline without
+            # waiting it out. `RunCancelled` is an `AgentError` subclass
+            # — caught by the outer try below and converted to a clean
+            # `done(status="cancelled")` event with partial artifacts.
+            cancel = CancellationChecker(redis, run_id)
+
+            await cancel.check_or_raise()
             analysis = await analyzer.run_for_problem(problem)
             analysis = await _review_and_maybe_revise(
                 critic=critic,
@@ -434,10 +513,12 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                     "Lists concrete data requirements.",
                     "Proposes at least one usable modeling approach.",
                 ],
+                cost_tracker=cost_tracker,
                 reminders_out=upstream_reminders,
             )
             assert isinstance(analysis, AnalyzerOutput)
 
+            await cancel.check_or_raise()
             searcher = SearcherAgent(gateway, emitter, runs_dir=runs_dir, **kwargs)
             findings = await searcher.run_for(
                 problem,
@@ -455,10 +536,12 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                     "analysis": analysis.model_dump(mode="json"),
                 },
                 criteria=_searcher_review_criteria(),
+                cost_tracker=cost_tracker,
                 reminders_out=upstream_reminders,
             )
             assert isinstance(findings, SearchFindings)
 
+            await cancel.check_or_raise()
             modeler = ModelerAgent(gateway, emitter, hmml=hmml, **kwargs)
             spec = await modeler.run_for(
                 problem,
@@ -480,10 +563,12 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                     "Algorithm outline is executable by Coder.",
                     "Validation strategy is concrete.",
                 ],
+                cost_tracker=cost_tracker,
                 reminders_out=upstream_reminders,
             )
             assert isinstance(spec, ModelSpec)
 
+            await cancel.check_or_raise()
             coder = CoderAgent(
                 gateway, emitter, kernel, matlab_session=matlab_session, **kwargs
             )
@@ -500,9 +585,11 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                 analysis=analysis,
                 spec=spec,
                 coder_out=coder_out,
+                cost_tracker=cost_tracker,
                 reminders_out=upstream_reminders,
             )
 
+            await cancel.check_or_raise()
             writer = WriterAgent(gateway, emitter, run_dir=run_dir, **kwargs)
             paper = await writer.run_for(
                 problem,
@@ -553,6 +640,7 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                 producer=writer,
                 target_agent="writer",
                 output=paper,
+                cost_tracker=cost_tracker,
                 reminders_out=upstream_reminders,  # final stage; for post-mortem
                 context={
                     "problem_text": problem.problem_text,
@@ -622,6 +710,21 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
             if pdf_path is not None:
                 done_payload["pdf_path"] = str(pdf_path)
             await emitter.emit("done", done_payload, agent=None)
+        except RunCancelled as exc:
+            # User-initiated cancel. Differentiate from "failed" so the UI
+            # shows it as an intentional stop (status='cancelled'), and so
+            # the cost ledger isn't treated as a bug — we want this in the
+            # dashboard. Whatever partial artifacts exist (paper.md from a
+            # prior stage, notebook from Coder) are left on disk; the user
+            # can inspect via the existing serve_paper / serve_notebook
+            # routes.
+            _log.info("pipeline cancelled by user: %s", exc)
+            await emitter.emit(
+                "log",
+                {"level": "info", "message": "run cancelled by user"},
+                agent=None,
+            )
+            await emitter.emit("done", {"status": "cancelled"}, agent=None)
         except AgentError as exc:
             # Surface the real reason before declaring failure. Without this
             # the run terminates silently and forensics requires hand-walking

--- a/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/writer/v1.toml
@@ -149,7 +149,7 @@ Coder final summary:
 Available figures from the Coder (JSON array; each has id, caption, path_png, path_svg, width). Reference them in sections with `[[FIG:<id>]]` on its own line:
 {{ coder_figures }}
 
-Coder executed cells (JSON array; each has source, stdout[:500], result):
+Coder executed cells (JSON array; each has index, stdout[:500], result):
 {{ coder_cells }}
 
 Searcher findings (JSON; may be empty):

--- a/apps/agent-worker/tests/test_cancellation.py
+++ b/apps/agent-worker/tests/test_cancellation.py
@@ -1,0 +1,71 @@
+"""Tests for the mid-run cancellation signal."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from agent_worker.cancellation import CancellationChecker, RunCancelled
+
+
+async def test_is_cancelled_returns_false_when_key_missing() -> None:
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    chk = CancellationChecker(redis, uuid4())
+    assert await chk.is_cancelled() is False
+
+
+async def test_is_cancelled_returns_true_when_key_set() -> None:
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=b"1")
+    chk = CancellationChecker(redis, uuid4())
+    assert await chk.is_cancelled() is True
+
+
+async def test_check_or_raise_is_noop_when_not_cancelled() -> None:
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    chk = CancellationChecker(redis, uuid4())
+    # Must NOT raise
+    await chk.check_or_raise()
+
+
+async def test_check_or_raise_raises_RunCancelled_when_set() -> None:
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=b"1")
+    run_id = uuid4()
+    chk = CancellationChecker(redis, run_id)
+    with pytest.raises(RunCancelled) as exc:
+        await chk.check_or_raise()
+    assert str(run_id) in str(exc.value)
+
+
+async def test_redis_get_error_is_swallowed() -> None:
+    """A Redis hiccup must NEVER fail the run — the check is best-effort.
+
+    Worst case: a real cancel signal is missed, the run keeps going. Better
+    than the inverse (false-positive cancel from a Redis blip).
+    """
+    redis = AsyncMock()
+    redis.get = AsyncMock(side_effect=ConnectionError("redis flaky"))
+    chk = CancellationChecker(redis, uuid4())
+    assert await chk.is_cancelled() is False
+
+
+async def test_run_cancelled_is_agent_error_subclass() -> None:
+    """Pipeline catches `AgentError` at the top — RunCancelled must
+    funnel through that catch block to land in the clean done(failed)
+    path, then be re-classified to done(status='cancelled')."""
+    from agent_worker.agents.base import AgentError
+
+    assert issubclass(RunCancelled, AgentError)
+
+
+async def test_check_or_raise_uses_run_specific_key() -> None:
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    run_id = uuid4()
+    chk = CancellationChecker(redis, run_id)
+    await chk.is_cancelled()
+    redis.get.assert_awaited_once_with(f"mm:cancel:{run_id}")

--- a/apps/agent-worker/tests/test_cost_tracker.py
+++ b/apps/agent-worker/tests/test_cost_tracker.py
@@ -1,0 +1,110 @@
+"""Tests for `RunCostTracker` — the reader of the gateway's `mm:cost:<run_id>`.
+
+The gateway side (`crates/gateway/src/llm/cost.rs::record_completion_cost`)
+INCRBYFLOATs that key on every chargeable LLM call. We don't exercise the
+gateway path here (it's covered separately); these tests fake Redis so the
+tracker's behavior — including graceful degradation when the key is missing
+or Redis raises — is locked down independently of the gateway build.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from agent_worker.cost_tracker import RunCostTracker, cost_key
+
+
+def _make_redis(get_return_value: object) -> AsyncMock:
+    """Build an AsyncMock that mimics redis.asyncio.Redis.get()."""
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=get_return_value)
+    return redis
+
+
+@pytest.fixture
+def run_id() -> UUID:
+    return uuid4()
+
+
+def test_cost_key_format_matches_gateway(run_id: UUID) -> None:
+    """The key format MUST stay locked to the gateway's Rust `cost_key`.
+
+    If this assertion breaks the worker can't read the gateway-maintained
+    total and the budget regresses to estimate-only behavior.
+    """
+    assert cost_key(run_id) == f"mm:cost:{run_id}"
+
+
+async def test_get_total_returns_zero_when_key_missing(run_id: UUID) -> None:
+    redis = _make_redis(None)
+    tracker = RunCostTracker(redis, run_id)
+
+    assert await tracker.get_total() == 0.0
+    redis.get.assert_awaited_once_with(f"mm:cost:{run_id}")
+
+
+async def test_get_total_reads_redis_value(run_id: UUID) -> None:
+    redis = _make_redis("0.42")
+    tracker = RunCostTracker(redis, run_id)
+
+    assert await tracker.get_total() == pytest.approx(0.42)
+
+
+async def test_get_total_handles_bytes_payload(run_id: UUID) -> None:
+    """INCRBYFLOAT replies are ASCII text; redis-py without decode_responses
+    surfaces them as bytes. The tracker must handle both transparently."""
+    redis = _make_redis(b"1.23")
+    tracker = RunCostTracker(redis, run_id)
+
+    assert await tracker.get_total() == pytest.approx(1.23)
+
+
+async def test_get_total_resilient_to_redis_error(run_id: UUID) -> None:
+    redis = AsyncMock()
+    redis.get = AsyncMock(side_effect=RuntimeError("connection lost"))
+    tracker = RunCostTracker(redis, run_id)
+
+    # MUST NOT raise — budget enforcement degrades to estimate fallback
+    # at the call site, but the tracker contract is "never raise".
+    assert await tracker.get_total() == 0.0
+
+
+async def test_get_total_resilient_to_unparseable_value(run_id: UUID) -> None:
+    redis = _make_redis("not-a-float")
+    tracker = RunCostTracker(redis, run_id)
+
+    assert await tracker.get_total() == 0.0
+
+
+async def test_snapshot_baseline_resets_delta(run_id: UUID) -> None:
+    redis = _make_redis("0.50")
+    tracker = RunCostTracker(redis, run_id)
+
+    await tracker.snapshot_baseline()
+    # After snapshot at 0.50, delta is 0.0
+    assert await tracker.delta_since_baseline() == pytest.approx(0.0)
+
+
+async def test_delta_since_baseline_after_increment(run_id: UUID) -> None:
+    """Simulate Redis values rising as the gateway records more LLM calls."""
+    redis = AsyncMock()
+    redis.get = AsyncMock(side_effect=["0.20", "0.20", "0.75"])
+    tracker = RunCostTracker(redis, run_id)
+
+    # call 1: snapshot at 0.20 (one GET)
+    await tracker.snapshot_baseline()
+    # call 2: still at 0.20 → delta 0.0
+    assert await tracker.delta_since_baseline() == pytest.approx(0.0)
+    # call 3: now at 0.75 → delta 0.55
+    assert await tracker.delta_since_baseline() == pytest.approx(0.55)
+
+
+async def test_delta_without_explicit_baseline_equals_total(run_id: UUID) -> None:
+    """If `snapshot_baseline()` is never called the baseline is 0.0 so
+    `delta_since_baseline()` returns the same value as `get_total()`."""
+    redis = _make_redis("0.30")
+    tracker = RunCostTracker(redis, run_id)
+
+    assert await tracker.delta_since_baseline() == pytest.approx(0.30)

--- a/apps/agent-worker/tests/test_critic_policy_actual_cost.py
+++ b/apps/agent-worker/tests/test_critic_policy_actual_cost.py
@@ -1,0 +1,296 @@
+"""Tests for the Critic revision loop's ACTUAL-cost budget enforcement.
+
+Round-6 audit fix: `_review_and_maybe_revise` used to enforce
+`max_revision_cost_rmb` against fictitious estimates in `CriticPolicy`. We
+now optionally consume a `RunCostTracker` that reads the gateway's
+authoritative running total. These tests lock down:
+
+1. Tracker-equipped loops compare against actual spend.
+2. No-tracker loops keep the old estimate-based behavior (backward compat).
+3. When actual spend balloons past the budget the loop sets
+   `report.budget_exhausted = True` and stops.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+from agent_worker.cost_tracker import RunCostTracker
+from agent_worker.pipeline import (
+    CriticPolicy,
+    _review_and_maybe_revise,
+)
+from mm_contracts import AnalyzerOutput, ApproachSketch, CritiqueFinding, CritiqueReport
+
+# ---------------------------------------------------------------------------
+# Test doubles — duplicated from test_pipeline_critic_review_flow rather than
+# imported to keep the new file self-contained and decoupled from the older
+# Round-1 test scaffolding.
+# ---------------------------------------------------------------------------
+
+
+class _SequenceProducer:
+    AGENT_NAME = "analyzer"
+    OUTPUT_MODEL = AnalyzerOutput
+
+    def __init__(self, revisions: list[AnalyzerOutput]) -> None:
+        self.revisions = revisions
+        self.revision_calls = 0
+
+    async def revise_with_critique(
+        self,
+        *,
+        original_output: AnalyzerOutput,
+        critique: CritiqueReport,
+        context: dict[str, Any],
+    ) -> AnalyzerOutput:
+        self.revision_calls += 1
+        return self.revisions[min(self.revision_calls - 1, len(self.revisions) - 1)]
+
+
+class _FakeCritic:
+    def __init__(self, reports: list[CritiqueReport]) -> None:
+        self.reports = reports
+        self.calls = 0
+
+    async def review(self, **_: Any) -> CritiqueReport:
+        self.calls += 1
+        return self.reports.pop(0)
+
+
+def _analysis(sub_questions: list[str]) -> AnalyzerOutput:
+    return AnalyzerOutput(
+        restated_problem="A 20-character restatement of the problem.",
+        sub_questions=sub_questions,
+        proposed_approaches=[
+            ApproachSketch(name="LP", rationale="Fits allocation", methods=["LP"])
+        ],
+    )
+
+
+def _report(
+    *,
+    passed: bool,
+    major: bool = False,
+    blocking: bool = False,
+) -> CritiqueReport:
+    findings = []
+    if major or blocking:
+        findings.append(
+            CritiqueFinding(
+                severity="blocking" if blocking else "major",
+                area="coverage",
+                message="Missing allocation sub-question.",
+                evidence="Only demand is listed.",
+                required_change="Add allocation optimization.",
+            )
+        )
+    return CritiqueReport(
+        target_agent="analyzer",
+        target_schema="AnalyzerOutput",
+        passed=passed,
+        score=0.9 if passed else 0.5,
+        summary="ok" if passed else "needs revision",
+        findings=findings,
+        required_changes=["Add allocation optimization."] if findings else [],
+    )
+
+
+def _fake_tracker(values: list[float]) -> RunCostTracker:
+    """Build a RunCostTracker that returns `values[i]` on the i-th GET.
+
+    We patch `get_total` directly so we don't have to construct a fake
+    Redis chain — the tracker's Redis-reading behavior is exercised
+    separately in `test_cost_tracker.py`.
+    """
+    # Use a real RunCostTracker instance so snapshot_baseline /
+    # delta_since_baseline preserve their stateful semantics; only the
+    # leaf method that touches Redis is mocked.
+    from uuid import uuid4
+
+    tracker = RunCostTracker(AsyncMock(), uuid4())
+    tracker.get_total = AsyncMock(side_effect=values)  # type: ignore[method-assign]
+    return tracker
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_revision_loop_falls_back_to_estimates_without_tracker() -> None:
+    """Backward-compat: no tracker => estimate-only accounting (Round-1 behavior).
+
+    With 0.04 RMB budget, 0.01 review + 0.02 revision, the loop:
+    - review (0.01) -> needs revision
+    - check budget: 0.01 + 0.02 = 0.03 <= 0.04 -> revise
+    - revise (cumulative 0.03)
+    - check budget: 0.03 + 0.01 = 0.04 <= 0.04 -> review again
+    - review (cumulative 0.04) -> needs revision
+    - check budget: 0.04 + 0.02 = 0.06 > 0.04 -> budget_exhausted, break
+    Result: 1 revision call, 2 critic calls.
+    """
+    original = _analysis(["Estimate demand"])
+    producer = _SequenceProducer(
+        [
+            _analysis(["Estimate demand", "Optimize allocation"]),
+            _analysis(["Estimate demand", "Optimize allocation", "Validate robustness"]),
+        ]
+    )
+    critic = _FakeCritic([_report(passed=False, major=True), _report(passed=False, major=True)])
+
+    result = await _review_and_maybe_revise(
+        critic=critic,  # type: ignore[arg-type]
+        producer=producer,  # type: ignore[arg-type]
+        target_agent="analyzer",
+        output=original,
+        context={"problem_text": "Estimate demand."},
+        criteria=["covers all sub-questions"],
+        policy=CriticPolicy(max_revision_rounds=2, max_revision_cost_rmb=0.04),
+        estimated_review_cost_rmb=0.01,
+        estimated_revision_cost_rmb=0.02,
+        cost_tracker=None,
+    )
+
+    # Loop stopped after one revision because estimate-based budget hit.
+    assert result is producer.revisions[0]
+    assert producer.revision_calls == 1
+    assert critic.calls == 2
+
+
+async def test_revision_loop_uses_actual_cost_when_tracker_provided() -> None:
+    """With a tracker, the loop consults actual spend on each iteration.
+
+    Tracker returns 0.0 throughout (gateway has recorded no cost), so even
+    though the estimate would predict a budget breach, the actual+estimate
+    check passes and the loop runs to completion.
+
+    Budget 0.04, estimates 0.01/0.02 — without a tracker the equivalent
+    loop stops after 1 revision (see the previous test). With a
+    zero-tracker it completes both rounds.
+
+    We clear the per-stage `max_revision_rounds_overrides` because the
+    default caps the analyzer at 1 round (Round-7 tuning); this test is
+    about cost accounting, not stage-policy.
+    """
+    original = _analysis(["Estimate demand"])
+    first = _analysis(["Estimate demand", "Optimize allocation"])
+    second = _analysis(["Estimate demand", "Optimize allocation", "Validate"])
+    producer = _SequenceProducer([first, second])
+    critic = _FakeCritic(
+        [
+            _report(passed=False, major=True),  # initial review
+            _report(passed=False, major=True),  # after revision 1
+            _report(passed=True),  # after revision 2 → accept
+        ]
+    )
+
+    # snapshot_baseline -> 0.0; then delta calls for round 1 (pre + post)
+    # and round 2 (pre + post). Provide enough zeros for the worst case.
+    tracker = _fake_tracker([0.0] * 10)
+
+    result = await _review_and_maybe_revise(
+        critic=critic,  # type: ignore[arg-type]
+        producer=producer,  # type: ignore[arg-type]
+        target_agent="analyzer",
+        output=original,
+        context={"problem_text": "Estimate demand and optimize allocation."},
+        criteria=["covers all sub-questions"],
+        policy=CriticPolicy(
+            max_revision_rounds=2,
+            max_revision_cost_rmb=0.04,
+            max_revision_rounds_overrides={},
+        ),
+        estimated_review_cost_rmb=0.01,
+        estimated_revision_cost_rmb=0.02,
+        cost_tracker=tracker,
+    )
+
+    # Tracker reported zero actual cost so the budget never trips; loop
+    # finished naturally (revision 2 review passed).
+    assert result is second
+    assert producer.revision_calls == 2
+    assert critic.calls == 3
+
+
+async def test_loop_breaks_when_actual_cost_exceeds_budget() -> None:
+    """Tracker reports a huge spend after the first revision — the loop
+    must immediately set `budget_exhausted` and bail.
+
+    This is the round-6 regression: even though estimates would say
+    "plenty of budget left", the gateway's actual ledger shows we've
+    blown through and we MUST stop.
+    """
+    original = _analysis(["Estimate demand"])
+    producer = _SequenceProducer(
+        [
+            _analysis(["Estimate demand", "Optimize allocation"]),
+            _analysis(["Estimate demand", "Optimize allocation", "Validate"]),
+        ]
+    )
+    critic = _FakeCritic(
+        [
+            _report(passed=False, major=True),  # initial review
+            _report(passed=False, major=True),  # after revision 1
+        ]
+    )
+
+    # Sequence of GET values consumed by the tracker:
+    #   1. snapshot_baseline() at start                 -> 0.0
+    #   2. pre-revision delta check (round 1)           -> 0.10 (under cap)
+    #   3. post-revision/pre-review delta (round 1)     -> 5.00 (>>> 1.0)
+    # Should trip budget_exhausted before the second critic.review.
+    tracker = _fake_tracker([0.0, 0.10, 5.00])
+
+    result = await _review_and_maybe_revise(
+        critic=critic,  # type: ignore[arg-type]
+        producer=producer,  # type: ignore[arg-type]
+        target_agent="analyzer",
+        output=original,
+        context={"problem_text": "Estimate demand."},
+        criteria=["covers all sub-questions"],
+        policy=CriticPolicy(max_revision_rounds=2, max_revision_cost_rmb=1.0),
+        estimated_review_cost_rmb=0.14,
+        estimated_revision_cost_rmb=0.30,
+        cost_tracker=tracker,
+    )
+
+    # Round 1 revision happened, but after that the tracker showed
+    # 5.0 RMB so we broke before the round-1 follow-up review.
+    assert result is producer.revisions[0]
+    assert producer.revision_calls == 1
+    # Critic called only for the initial review — the post-revision
+    # follow-up was skipped because budget tripped first.
+    assert critic.calls == 1
+
+
+async def test_actual_cost_baseline_isolates_loop_spend() -> None:
+    """`snapshot_baseline()` must isolate the in-loop delta from upstream
+    cost. If a prior stage spent 0.90 RMB, the analyzer loop should see
+    delta=0.0 at start, not 0.90.
+    """
+    original = _analysis(["Estimate demand"])
+    producer = _SequenceProducer([_analysis(["unused"])])
+    critic = _FakeCritic([_report(passed=True)])
+
+    # Snapshot reads 0.90 (upstream spend). If baseline isn't subtracted,
+    # any later delta check would immediately fail. But with a passing
+    # report on the first review, the loop returns before any delta
+    # check fires — we just assert no spurious failure.
+    tracker = _fake_tracker([0.90])
+
+    result = await _review_and_maybe_revise(
+        critic=critic,  # type: ignore[arg-type]
+        producer=producer,  # type: ignore[arg-type]
+        target_agent="analyzer",
+        output=original,
+        context={"problem_text": "Estimate demand."},
+        criteria=["covers all sub-questions"],
+        policy=CriticPolicy(max_revision_rounds=2, max_revision_cost_rmb=1.0),
+        cost_tracker=tracker,
+    )
+
+    assert result is original
+    assert producer.revision_calls == 0
+    assert critic.calls == 1

--- a/apps/agent-worker/tests/test_critic_policy_overrides.py
+++ b/apps/agent-worker/tests/test_critic_policy_overrides.py
@@ -1,0 +1,97 @@
+"""Round-7 cost-cap: per-stage max_revision_rounds overrides.
+
+Writer/Analyzer/Searcher are capped at 1 revision round (round-6 cost audit
+found round-3 only fixed ~3% of Writer issues at 0.62 RMB/round). Modeler
+and Coder fall through to the default (2) because their reruns reliably
+fix bugs.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from agent_worker.pipeline import DEFAULT_CRITIC_POLICY, CriticPolicy
+
+
+def test_writer_capped_at_one_revision_round() -> None:
+    policy = CriticPolicy()
+    assert (
+        policy.max_revision_rounds_overrides.get(
+            "writer", policy.max_revision_rounds
+        )
+        == 1
+    )
+
+
+def test_coder_uses_default_two_rounds() -> None:
+    policy = CriticPolicy()
+    # Coder is intentionally NOT in the overrides map; .get falls through
+    # to the default (2). Coder reruns are the highest-value revisions.
+    assert (
+        policy.max_revision_rounds_overrides.get(
+            "coder", policy.max_revision_rounds
+        )
+        == 2
+    )
+    assert "coder" not in policy.max_revision_rounds_overrides
+
+
+def test_modeler_uses_default_two_rounds() -> None:
+    policy = CriticPolicy()
+    assert (
+        policy.max_revision_rounds_overrides.get(
+            "modeler", policy.max_revision_rounds
+        )
+        == 2
+    )
+    assert "modeler" not in policy.max_revision_rounds_overrides
+
+
+def test_analyzer_and_searcher_capped_at_one() -> None:
+    policy = CriticPolicy()
+    assert (
+        policy.max_revision_rounds_overrides.get(
+            "analyzer", policy.max_revision_rounds
+        )
+        == 1
+    )
+    assert (
+        policy.max_revision_rounds_overrides.get(
+            "searcher", policy.max_revision_rounds
+        )
+        == 1
+    )
+
+
+def test_unknown_agent_falls_through_to_default() -> None:
+    policy = CriticPolicy()
+    assert (
+        policy.max_revision_rounds_overrides.get(
+            "definitely_not_a_real_agent", policy.max_revision_rounds
+        )
+        == policy.max_revision_rounds
+        == 2
+    )
+
+
+def test_overrides_default_is_immutable_mapping() -> None:
+    # Matches the existing pattern for min_score_overrides — frozen=True
+    # dataclasses can't safely hand out mutable dicts as default_factory output.
+    policy = CriticPolicy()
+    assert isinstance(policy.max_revision_rounds_overrides, MappingProxyType)
+
+
+def test_default_policy_singleton_matches() -> None:
+    # Sanity: DEFAULT_CRITIC_POLICY is the one the pipeline actually consults.
+    assert DEFAULT_CRITIC_POLICY.max_revision_rounds_overrides["writer"] == 1
+    assert DEFAULT_CRITIC_POLICY.max_revision_rounds == 2
+
+
+def test_corrected_cost_estimates() -> None:
+    # Round-6 audit: original estimates were 7× underestimate; this is the
+    # corrected accounting (cap behavior unchanged at 1.00 RMB).
+    policy = CriticPolicy()
+    assert policy.estimated_review_cost_rmb == 0.14
+    assert policy.estimated_revision_cost_rmb == 0.30
+    assert policy.estimated_coder_revision_cost_rmb == 0.18
+    assert policy.max_revision_cost_rmb == 1.00

--- a/apps/agent-worker/tests/test_gateway_client_cache.py
+++ b/apps/agent-worker/tests/test_gateway_client_cache.py
@@ -1,0 +1,100 @@
+"""Verify `GatewayClient.stream_completion` forwards `cache_breakpoint`.
+
+The Anthropic prompt-cache wire-up relies on the gateway receiving the
+`cache_breakpoint` flag on stable-prefix messages. The flag is what the
+gateway's Rust adapter translates into `cache_control: { type: "ephemeral" }`
+for Anthropic (native or proxied). Caller-side regressions are silent —
+they don't raise, they just stop yielding cache hits — so this test asserts
+the bytes-on-the-wire shape directly.
+"""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+from agent_worker.gateway_client import GatewayClient
+
+
+async def test_stream_completion_forwards_cache_breakpoint(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    """A message with `cache_breakpoint: True` must reach the gateway intact."""
+    httpx_mock.add_response(
+        url="http://gw.invalid/llm/chat/completions",
+        method="POST",
+        # Minimal valid SSE body so the stream parser terminates cleanly.
+        text="data: [DONE]\n\n",
+        headers={"content-type": "text/event-stream"},
+    )
+
+    client = GatewayClient("http://gw.invalid", dev_token="t")
+    try:
+        # Drain the (empty) stream to make sure the request was sent.
+        async for _ in client.stream_completion(
+            run_id=uuid4(),
+            agent="analyzer",
+            model="gpt-5.5",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "stable system prompt",
+                    "cache_breakpoint": True,
+                },
+                {"role": "user", "content": "go"},
+            ],
+        ):
+            pass
+    finally:
+        await client.close()
+
+    sent = httpx_mock.get_request()
+    assert sent is not None, "gateway must be called"
+    body = json.loads(sent.read())
+    msgs = body["messages"]
+    assert len(msgs) == 2
+
+    # System message keeps the breakpoint flag — the gateway uses it to emit
+    # Anthropic-style cache_control on the corresponding content block.
+    assert msgs[0]["role"] == "system"
+    assert msgs[0]["content"] == "stable system prompt"
+    assert msgs[0]["cache_breakpoint"] is True, (
+        "cache_breakpoint must round-trip through the gateway client untouched; "
+        "missing this flag silently disables prompt caching."
+    )
+
+    # User message has no flag — verifies we didn't accidentally tag everything.
+    assert msgs[1]["role"] == "user"
+    assert "cache_breakpoint" not in msgs[1]
+
+
+async def test_stream_completion_without_breakpoint_omits_flag(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    """Default callers (no flag) must produce a body with no `cache_breakpoint`."""
+    httpx_mock.add_response(
+        url="http://gw.invalid/llm/chat/completions",
+        method="POST",
+        text="data: [DONE]\n\n",
+        headers={"content-type": "text/event-stream"},
+    )
+
+    client = GatewayClient("http://gw.invalid", dev_token="t")
+    try:
+        async for _ in client.stream_completion(
+            run_id=uuid4(),
+            agent="analyzer",
+            model="gpt-5.5",
+            messages=[
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "go"},
+            ],
+        ):
+            pass
+    finally:
+        await client.close()
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    body = json.loads(sent.read())
+    for m in body["messages"]:
+        assert "cache_breakpoint" not in m, (
+            "absent flag must not be filled in by the client (gateway treats "
+            "the field as default-false)"
+        )

--- a/apps/agent-worker/tests/test_pipeline_critic_gate.py
+++ b/apps/agent-worker/tests/test_pipeline_critic_gate.py
@@ -124,7 +124,11 @@ def test_default_policy_has_active_revision_cost_estimates() -> None:
 
     assert policy.estimated_review_cost_rmb > 0
     assert policy.estimated_revision_cost_rmb > 0
-    assert policy.estimated_coder_revision_cost_rmb > policy.estimated_revision_cost_rmb
+    assert policy.estimated_coder_revision_cost_rmb > 0
+    # Round-6 audit corrected: writer/modeler revision (0.30) > coder rerun
+    # (0.18) because the upstream-context payload is larger than a targeted
+    # bug-fix prompt. The original test assumed the inverse and is now stale.
+    assert policy.estimated_revision_cost_rmb > policy.estimated_coder_revision_cost_rmb
 
 
 # checklist_pass_rate = 21/25 = 0.84 (between the 0.80 searcher override and

--- a/apps/agent-worker/tests/test_pipeline_critic_review_flow.py
+++ b/apps/agent-worker/tests/test_pipeline_critic_review_flow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import MappingProxyType
 from typing import Any
 
 import pytest
@@ -10,6 +11,12 @@ from agent_worker.pipeline import (
     _searcher_review_criteria,
 )
 from mm_contracts import AnalyzerOutput, ApproachSketch, CritiqueFinding, CritiqueReport
+
+# Round-7: the default CriticPolicy caps analyzer at 1 revision round. These
+# flow tests target_agent="analyzer" but are testing the policy MECHANISM
+# (does the loop honor max_revision_rounds=2?), not the analyzer-specific
+# cap, so we disable the per-stage overrides for them.
+_NO_OVERRIDES: MappingProxyType[str, int] = MappingProxyType({})
 
 
 class _FakeProducer:
@@ -147,7 +154,11 @@ async def test_review_and_maybe_revise_allows_two_revision_rounds() -> None:
         output=original,
         context={"problem_text": "Estimate demand and optimize allocation."},
         criteria=["covers all sub-questions"],
-        policy=CriticPolicy(max_revision_rounds=2),
+        policy=CriticPolicy(
+            max_revision_rounds=2,
+            max_revision_rounds_overrides=_NO_OVERRIDES,
+            max_revision_cost_rmb=10.0,
+        ),
     )
 
     assert result is second_revision
@@ -187,7 +198,11 @@ async def test_review_and_maybe_revise_stops_when_cost_budget_is_exhausted() -> 
         output=original,
         context={"problem_text": "Estimate demand and optimize allocation."},
         criteria=["covers all sub-questions"],
-        policy=CriticPolicy(max_revision_rounds=2, max_revision_cost_rmb=0.04),
+        policy=CriticPolicy(
+            max_revision_rounds=2,
+            max_revision_cost_rmb=0.04,
+            max_revision_rounds_overrides=_NO_OVERRIDES,
+        ),
         estimated_review_cost_rmb=0.01,
         estimated_revision_cost_rmb=0.02,
     )
@@ -221,7 +236,11 @@ async def test_review_and_maybe_revise_fails_after_budget_with_blocking() -> Non
             output=original,
             context={"problem_text": "Estimate demand and optimize allocation."},
             criteria=["covers all sub-questions"],
-            policy=CriticPolicy(max_revision_rounds=2),
+            policy=CriticPolicy(
+                max_revision_rounds=2,
+                max_revision_rounds_overrides=_NO_OVERRIDES,
+                max_revision_cost_rmb=10.0,
+            ),
         )
 
     assert producer.revision_calls == 2

--- a/apps/web/src/views/Workbench.vue
+++ b/apps/web/src/views/Workbench.vue
@@ -83,6 +83,32 @@ async function loadRunRecord(id: string) {
   }
 }
 
+// Mid-run cancellation. POST /runs/:id/cancel writes a Redis flag the
+// worker polls between stages; the user sees status flip to "cancelled"
+// once the current stage finishes (worst case ~2 min latency for a
+// streaming LLM call to return). Idempotent — clicking twice is a no-op.
+const cancelInFlight = ref(false);
+async function cancelRun(): Promise<void> {
+  if (!routeRunId.value) return;
+  cancelInFlight.value = true;
+  try {
+    await http.post(`/runs/${routeRunId.value}/cancel`, {});
+  } catch (err) {
+    console.error("[Workbench] cancel POST failed", err);
+  } finally {
+    cancelInFlight.value = false;
+  }
+}
+
+// Cancel button is only useful while the pipeline is still in flight.
+// Treat "queued" + "running" as in-flight; anything else (done / failed /
+// future "cancelled") hides the button. Store's RunStatus doesn't yet
+// model "cancelled" — that's a follow-up; the gateway emits done.status =
+// "cancelled" and the audit task persists it to runs.status.
+const isInFlight = computed<boolean>(() =>
+  run.status === "running" || run.status === "queued"
+);
+
 watch(
   routeRunId,
   (next, prev) => {
@@ -353,9 +379,18 @@ function agentTitle(agent: string): { en: string; zh: string; num: string } {
             </div>
           </div>
           <div style="display:flex; gap:8px;">
-            <!-- Pause button removed in round-6 UX pass: it was disabled
-                 with only a tooltip explanation (Agent C #5). Replace with
-                 a real Cancel route once the backend exposes one. -->
+            <!-- Real Cancel button (round-7): POSTs /runs/:id/cancel which
+                 writes mm:cancel:<run_id>=1; worker halts at next stage
+                 boundary. Hidden once the run is in a terminal state. -->
+            <button
+              v-if="isInFlight"
+              class="btn ghost"
+              :disabled="cancelInFlight"
+              @click="cancelRun"
+            >
+              <span aria-hidden="true">■</span>
+              <T en="Cancel" zh="取消" />
+            </button>
             <RouterLink class="btn hi" :to="{ name: 'workbench' }">
               <span aria-hidden="true">▶</span> <T en="New run" zh="新建运行" />
             </RouterLink>

--- a/crates/gateway/src/app.rs
+++ b/crates/gateway/src/app.rs
@@ -14,6 +14,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/runs", post(runs::create_run).get(runs::list_runs))
         .route("/runs/:run_id", get(runs::get_run))
         .route("/runs/:run_id/finetune", post(runs::finetune_run))
+        .route("/runs/:run_id/cancel", post(runs::cancel_run))
         .route("/runs/:run_id/figures/*path", get(figures::serve_figure))
         .route("/runs/:run_id/notebook", get(figures::serve_notebook))
         .route("/runs/:run_id/paper", get(figures::serve_paper))

--- a/crates/gateway/src/dispatch.rs
+++ b/crates/gateway/src/dispatch.rs
@@ -48,6 +48,35 @@ pub async fn enqueue_job(
     Ok(id)
 }
 
+/// Redis-key TTL for `mm:cancel:<run_id>` cancellation signal. Worker
+/// polls between stages and raises `RunCancelled` when this is set.
+/// 1 hour is plenty — a run never lives longer than ~90 minutes today.
+pub const CANCEL_KEY_TTL_SECS: u64 = 3600;
+
+pub fn cancel_key(run_id: &Uuid) -> String {
+    format!("mm:cancel:{run_id}")
+}
+
+/// SET mm:cancel:<run_id> = "1" with TTL, signalling the worker to halt
+/// the pipeline at its next stage boundary. Returns `true` if newly set,
+/// `false` if it was already set (idempotent).
+pub async fn signal_cancel(
+    redis: &mut ConnectionManager,
+    run_id: &Uuid,
+) -> Result<bool, AppError> {
+    let key = cancel_key(run_id);
+    // SET key "1" EX <ttl> NX so a second click doesn't reset the TTL.
+    let was_set: Option<String> = redis::cmd("SET")
+        .arg(&key)
+        .arg("1")
+        .arg("EX")
+        .arg(CANCEL_KEY_TTL_SECS)
+        .arg("NX")
+        .query_async(redis)
+        .await?;
+    Ok(was_set.is_some())
+}
+
 /// XADD mm:finetune. Fields: run_id, session_id, message, created_at.
 pub async fn enqueue_finetune_job(
     redis: &mut ConnectionManager,

--- a/crates/gateway/src/llm/cache.rs
+++ b/crates/gateway/src/llm/cache.rs
@@ -124,11 +124,13 @@ mod tests {
                     role: "system".into(),
                     content: "you are helpful".into(),
                     name: None,
+                    cache_breakpoint: false,
                 },
                 ChatMessage {
                     role: "user".into(),
                     content: "hello".into(),
                     name: None,
+                    cache_breakpoint: false,
                 },
             ],
             temperature: Some(0.2),

--- a/crates/gateway/src/llm/canonical.rs
+++ b/crates/gateway/src/llm/canonical.rs
@@ -17,6 +17,28 @@ pub struct ChatMessage {
     pub content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Mark this message as an Anthropic prompt-cache break point.
+    ///
+    /// Anthropic's `/v1/messages` accepts `cache_control: { type: "ephemeral" }`
+    /// on individual content blocks; the API caches the entire prefix up to
+    /// (and including) the marked block. Anthropic allows up to 4 breakpoints
+    /// per request, but v1 of this wiring uses exactly one — typically the
+    /// system message, which is the largest stable prefix.
+    ///
+    /// Adapters translate per provider:
+    /// - `anthropic`: serializes the message with `content` as a 1-element
+    ///   text-block array carrying `cache_control: {type: "ephemeral"}` on
+    ///   the block. For the system role, the lifted `system` field becomes
+    ///   an array of system blocks with the same marker.
+    /// - `openai_compat`: passes `cache_control: {type: "ephemeral"}` through
+    ///   as an extra message-level key. Upstream Claude-backed proxies (e.g.
+    ///   cornna's `cdnapi.cornna.xyz`) may honour it; other shops ignore it
+    ///   silently — the field is unknown but harmless.
+    ///
+    /// Defaults to `false` and is omitted from the serialized JSON in that
+    /// case so the on-the-wire shape is unchanged for non-cache callers.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub cache_breakpoint: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/gateway/src/llm/cost.rs
+++ b/crates/gateway/src/llm/cost.rs
@@ -19,6 +19,16 @@ use crate::llm::stream::next_seq;
 /// Stream MAXLEN for `mm:events:<run_id>`. Matches worker emitter.
 const EVENTS_MAXLEN: usize = 5000;
 
+/// Redis key that holds the per-run running cost total in RMB. Mirrors
+/// `runs.cost_rmb` in Postgres so consumers (e.g. the Python worker's
+/// Critic budget tracker) can query the authoritative running total
+/// without a database round-trip. INCRBYFLOAT'd on every chargeable LLM
+/// call. Caller is expected to set TTL externally if cleanup is desired;
+/// keys are small and bounded by the run lifecycle.
+pub fn cost_key(run_id: &Uuid) -> String {
+    format!("mm:cost:{run_id}")
+}
+
 pub fn compute_cost_rmb(price: Price, usage: &Usage) -> f64 {
     (usage.prompt_tokens as f64 / 1_000_000.0) * price.input_per_1m
         + (usage.completion_tokens as f64 / 1_000_000.0) * price.output_per_1m
@@ -90,6 +100,17 @@ pub async fn record_completion_cost(
         .fetch_one(pg)
         .await?;
         let run_total: f64 = row.0.parse().unwrap_or(0.0);
+
+        // Mirror the running total into Redis so consumers (Critic budget
+        // tracker) can read the authoritative value without a Postgres
+        // round-trip. We use INCRBYFLOAT with `delta` rather than SET
+        // `run_total` so concurrent calls accumulate correctly even if
+        // ordered differently with respect to the Postgres UPDATE. A 0.0
+        // delta is fine (no-op net) and we still call it so the key
+        // exists eagerly for the run.
+        let cost_redis_key = cost_key(&rid);
+        let _: redis::RedisResult<f64> =
+            redis.incr(cost_redis_key, delta).await;
 
         // XADD kind=cost event to the run stream. Seq from shared counter.
         let seq = next_seq(redis, &rid).await?;

--- a/crates/gateway/src/llm/providers/anthropic.rs
+++ b/crates/gateway/src/llm/providers/anthropic.rs
@@ -12,7 +12,14 @@
 //! a new stable version and re-verify the SSE event names).
 //!
 //! Intentionally out of scope for M8: tool use / function calling, image /
-//! vision content blocks, prompt caching directives, extended thinking.
+//! vision content blocks, extended thinking.
+//!
+//! Prompt caching: when a `ChatMessage` sets `cache_breakpoint = true`, the
+//! adapter emits `cache_control: { type: "ephemeral" }` on the final content
+//! block of that message (or on the system content array, for the system
+//! role). Anthropic caches the prefix up to that breakpoint; one breakpoint
+//! per request is enough to cache the large stable prefix (system prompt +
+//! few-shot exemplars). Multi-breakpoint support is intentionally deferred.
 
 use std::sync::Arc;
 
@@ -86,11 +93,33 @@ impl AnthropicAdapter {
     ///   the system prompt telling the model to emit JSON only. Future
     ///   schemas (e.g. `json_schema`) would need their own handling.
     fn build_body(&self, req: &CanonicalRequest, stream: bool) -> Value {
+        // Track whether any system message asked to be a cache breakpoint. We
+        // need to know this BEFORE we know whether `response_format` will
+        // append the JSON suffix, so cache_control attaches to the final
+        // system content block in either case.
         let mut system_parts: Vec<String> = Vec::new();
+        let mut system_has_cache_breakpoint = false;
         let mut messages: Vec<Value> = Vec::with_capacity(req.messages.len());
         for m in &req.messages {
             if m.role == "system" {
                 system_parts.push(m.content.clone());
+                if m.cache_breakpoint {
+                    system_has_cache_breakpoint = true;
+                }
+            } else if m.cache_breakpoint {
+                // Anthropic's prompt cache reads `cache_control` only off
+                // content blocks, so we have to upgrade `content` from a
+                // bare string into a 1-element text-block array with the
+                // marker on it. The cache prefix runs from the start of the
+                // request up to and including this block.
+                messages.push(json!({
+                    "role": m.role,
+                    "content": [{
+                        "type": "text",
+                        "text": m.content,
+                        "cache_control": { "type": "ephemeral" },
+                    }],
+                }));
             } else {
                 messages.push(json!({
                     "role": m.role,
@@ -145,7 +174,20 @@ impl AnthropicAdapter {
             "stream": stream,
         });
         if !system.is_empty() {
-            body["system"] = json!(system);
+            if system_has_cache_breakpoint {
+                // System-level cache_control: Anthropic accepts `system` as
+                // either a bare string OR an array of content blocks. We use
+                // the array form so the final block can carry the ephemeral
+                // marker, caching the whole system prompt (the biggest stable
+                // prefix in most agent calls).
+                body["system"] = json!([{
+                    "type": "text",
+                    "text": system,
+                    "cache_control": { "type": "ephemeral" },
+                }]);
+            } else {
+                body["system"] = json!(system);
+            }
         }
         if let Some(t) = req.temperature {
             body["temperature"] = json!(t);
@@ -490,6 +532,7 @@ mod tests {
                     role: r.into(),
                     content: c.into(),
                     name: None,
+                    cache_breakpoint: false,
                 })
                 .collect(),
             temperature: Some(0.2),
@@ -715,5 +758,123 @@ mod tests {
         )
         .unwrap()
         .is_none());
+    }
+
+    /// `cache_breakpoint = true` on a system message must promote the
+    /// top-level `system` field from a bare string to an array of content
+    /// blocks with `cache_control: { type: "ephemeral" }` on the final
+    /// (only) block. This is the shape Anthropic's prompt cache reads.
+    #[test]
+    fn build_body_emits_cache_control_on_system_breakpoint() {
+        let adapter = AnthropicAdapter::new(
+            "anth".into(),
+            "https://api.anthropic.com".into(),
+            "sk".into(),
+            vec!["claude-sonnet-4-6".into()],
+            Client::new(),
+        );
+        let req = CanonicalRequest {
+            model: "claude-sonnet-4-6".into(),
+            messages: vec![
+                ChatMessage {
+                    role: "system".into(),
+                    content: "big stable system prompt".into(),
+                    name: None,
+                    cache_breakpoint: true,
+                },
+                ChatMessage {
+                    role: "user".into(),
+                    content: "go".into(),
+                    name: None,
+                    cache_breakpoint: false,
+                },
+            ],
+            temperature: None,
+            max_tokens: None,
+            stream: false,
+            response_format: None,
+            reasoning_effort: None,
+        };
+        let body = adapter.build_body(&req, false);
+
+        let system = body
+            .get("system")
+            .expect("system field present when system messages exist");
+        let arr = system
+            .as_array()
+            .expect("system must be an array of content blocks when a breakpoint is set");
+        assert_eq!(arr.len(), 1, "single stable system block");
+        assert_eq!(arr[0]["type"], "text");
+        assert_eq!(arr[0]["text"], "big stable system prompt");
+        assert_eq!(
+            arr[0]["cache_control"]["type"], "ephemeral",
+            "ephemeral cache_control marks the prefix boundary"
+        );
+
+        // The user message stays a plain string — no breakpoint requested.
+        let msgs = body["messages"].as_array().expect("messages array");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0]["content"], "go");
+    }
+
+    /// When a non-system message is marked as the breakpoint, its `content`
+    /// must be promoted to a 1-element text-block array with `cache_control`.
+    #[test]
+    fn build_body_emits_cache_control_on_user_breakpoint() {
+        let adapter = AnthropicAdapter::new(
+            "anth".into(),
+            "https://api.anthropic.com".into(),
+            "sk".into(),
+            vec!["claude-sonnet-4-6".into()],
+            Client::new(),
+        );
+        let req = CanonicalRequest {
+            model: "claude-sonnet-4-6".into(),
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: "shared stable prefix...".into(),
+                name: None,
+                cache_breakpoint: true,
+            }],
+            temperature: None,
+            max_tokens: None,
+            stream: false,
+            response_format: None,
+            reasoning_effort: None,
+        };
+        let body = adapter.build_body(&req, false);
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 1);
+        let content = msgs[0]["content"]
+            .as_array()
+            .expect("breakpoint message content is a block array");
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "shared stable prefix...");
+        assert_eq!(content[0]["cache_control"]["type"], "ephemeral");
+    }
+
+    /// Without any `cache_breakpoint` markers, the on-the-wire body must be
+    /// byte-identical to the pre-caching shape: bare-string `system` and
+    /// bare-string message content. This keeps the change zero-risk for
+    /// callers that don't opt into caching.
+    #[test]
+    fn build_body_unchanged_without_breakpoint() {
+        let adapter = AnthropicAdapter::new(
+            "anth".into(),
+            "https://x".into(),
+            "k".into(),
+            vec!["claude-sonnet-4-6".into()],
+            Client::new(),
+        );
+        let req = mk_req_with(vec![("system", "be brief"), ("user", "go")]);
+        let body = adapter.build_body(&req, false);
+        assert_eq!(
+            body["system"].as_str(),
+            Some("be brief"),
+            "system stays a bare string when no breakpoint is set"
+        );
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs[0]["content"].as_str(), Some("go"));
     }
 }

--- a/crates/gateway/src/llm/providers/openai_compat.rs
+++ b/crates/gateway/src/llm/providers/openai_compat.rs
@@ -44,9 +44,36 @@ impl OpenAICompatAdapter {
     }
 
     fn build_body(&self, req: &CanonicalRequest, stream: bool) -> Value {
+        // Translate canonical messages to JSON. When a message asks to be a
+        // prompt-cache breakpoint we attach `cache_control: { type:
+        // "ephemeral" }` at the message level — Anthropic-backed OpenAI-compat
+        // proxies (e.g. cornna's cdnapi.cornna.xyz) forward it to the
+        // upstream Claude `/v1/messages` call; vanilla OpenAI providers
+        // ignore the extra field silently, so this is safe to emit
+        // unconditionally for breakpoint messages.
+        let messages: Vec<Value> = req
+            .messages
+            .iter()
+            .map(|m| {
+                let mut obj = serde_json::Map::new();
+                obj.insert("role".into(), json!(m.role));
+                obj.insert("content".into(), json!(m.content));
+                if let Some(ref n) = m.name {
+                    obj.insert("name".into(), json!(n));
+                }
+                if m.cache_breakpoint {
+                    obj.insert(
+                        "cache_control".into(),
+                        json!({ "type": "ephemeral" }),
+                    );
+                }
+                Value::Object(obj)
+            })
+            .collect();
+
         let mut body = json!({
             "model": req.model,
-            "messages": req.messages,
+            "messages": messages,
             "stream": stream,
         });
         if let Some(t) = req.temperature {
@@ -210,6 +237,7 @@ mod tests {
                 role: "user".into(),
                 content: "hi".into(),
                 name: None,
+                cache_breakpoint: false,
             }],
             temperature: Some(0.2),
             max_tokens: None,
@@ -266,5 +294,69 @@ mod tests {
         let body = adapter.build_body(&req, false);
         assert!(body.get("reasoning_effort").is_none());
         assert!(body.get("reasoning").is_none());
+    }
+
+    /// `cache_breakpoint = true` on a canonical message must surface as
+    /// `cache_control: { type: "ephemeral" }` at the message level in the
+    /// outgoing body. Anthropic-backed OpenAI-compat proxies (cornna's
+    /// cdnapi.cornna.xyz pointing at Claude) honour this; vanilla OpenAI
+    /// ignores the extra field, which is the design goal — single canonical
+    /// shape that's safe to emit unconditionally for opt-in messages.
+    #[test]
+    fn build_body_forwards_cache_breakpoint_as_cache_control() {
+        let adapter = mk_adapter();
+        let req = CanonicalRequest {
+            model: "gpt-5".into(),
+            messages: vec![
+                ChatMessage {
+                    role: "system".into(),
+                    content: "big stable system prompt".into(),
+                    name: None,
+                    cache_breakpoint: true,
+                },
+                ChatMessage {
+                    role: "user".into(),
+                    content: "go".into(),
+                    name: None,
+                    cache_breakpoint: false,
+                },
+            ],
+            temperature: None,
+            max_tokens: None,
+            stream: false,
+            response_format: None,
+            reasoning_effort: None,
+        };
+        let body = adapter.build_body(&req, false);
+        let msgs = body["messages"].as_array().expect("messages array");
+        assert_eq!(msgs.len(), 2);
+
+        // System message: tagged.
+        assert_eq!(msgs[0]["role"], "system");
+        assert_eq!(msgs[0]["content"], "big stable system prompt");
+        assert_eq!(
+            msgs[0]["cache_control"]["type"], "ephemeral",
+            "system breakpoint must surface cache_control"
+        );
+
+        // User message: untouched.
+        assert_eq!(msgs[1]["role"], "user");
+        assert_eq!(msgs[1]["content"], "go");
+        assert!(
+            msgs[1].get("cache_control").is_none(),
+            "non-breakpoint messages must NOT carry cache_control"
+        );
+    }
+
+    /// Without any breakpoints, the message JSON shape is unchanged: bare
+    /// role + content keys, no extra `cache_control` noise on the wire.
+    #[test]
+    fn build_body_omits_cache_control_without_breakpoint() {
+        let adapter = mk_adapter();
+        let req = mk_req();
+        let body = adapter.build_body(&req, false);
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].get("cache_control").is_none());
     }
 }

--- a/crates/gateway/src/routes/runs.rs
+++ b/crates/gateway/src/routes/runs.rs
@@ -8,7 +8,7 @@ use sqlx::FromRow;
 use uuid::Uuid;
 
 use crate::audit::spawn_audit_task;
-use crate::dispatch::{enqueue_finetune_job, enqueue_job};
+use crate::dispatch::{enqueue_finetune_job, enqueue_job, signal_cancel};
 use crate::error::AppError;
 use crate::state::AppState;
 
@@ -177,6 +177,44 @@ pub async fn finetune_run(
             run_id,
             session_id,
             status: "queued",
+        }),
+    ))
+}
+
+#[derive(Debug, Serialize)]
+pub struct CancelAccepted {
+    pub run_id: Uuid,
+    pub status: &'static str,
+}
+
+/// `POST /runs/:run_id/cancel` — signal the worker to halt the run.
+///
+/// Idempotent: re-posting while a cancel is already pending is a no-op
+/// (returns the same shape). The worker polls `mm:cancel:<run_id>`
+/// between stages and raises `RunCancelled`, terminating with
+/// `done.status = "cancelled"` and the partial paper.md / notebook
+/// artifacts intact (cancellation is graceful — we never tear down a
+/// stage mid-write).
+#[tracing::instrument(skip_all, fields(%run_id))]
+pub async fn cancel_run(
+    State(mut state): State<AppState>,
+    Path(run_id): Path<Uuid>,
+) -> Result<(StatusCode, Json<CancelAccepted>), AppError> {
+    let exists: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM runs WHERE id = $1")
+        .bind(run_id)
+        .fetch_optional(&state.pg)
+        .await
+        .map_err(|e| AppError::Internal(format!("lookup run: {e}")))?;
+    if exists.is_none() {
+        return Err(AppError::NotFound);
+    }
+    let newly_set = signal_cancel(&mut state.redis, &run_id).await?;
+    tracing::info!(%run_id, newly_set, "cancel signal sent");
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(CancelAccepted {
+            run_id,
+            status: "cancel_signalled",
         }),
     ))
 }

--- a/packages/contracts/openapi.yaml
+++ b/packages/contracts/openapi.yaml
@@ -261,6 +261,18 @@ components:
         role: { type: string, enum: [system, user, assistant, tool] }
         content: { type: string }
         name: { type: string }
+        cache_breakpoint:
+          type: boolean
+          default: false
+          description: |
+            Mark this message as an Anthropic prompt-cache break point. When
+            true, the gateway emits `cache_control: { "type": "ephemeral" }`
+            on the message (Anthropic native: as a content-block attribute;
+            OpenAI-compat: as an extra message-level key for Claude-backed
+            proxies). The cached prefix runs from the start of the request
+            through this message; Anthropic supports up to 4 breakpoints per
+            request, but v1 of this wiring uses exactly one. Silently
+            ignored by providers that don't support prompt caching.
 
     ChatCompletionResponse:
       type: object


### PR DESCRIPTION
## Summary
Four independent optimization tracks against MCM/CUMCM run cost, latency, and UX:

- **A. Per-stage revision caps + writer prompt trim** — caps writer/analyzer/searcher at 1 revision (was 2; rarely paid off), realistic 0.14/0.30/0.18 RMB stage estimates, drop `coder_cells.source` from Writer input (~30% prompt savings).
- **B. RunCostTracker** — gateway mirrors per-call cost into Redis `mm:cost:<run_id>` via INCRBYFLOAT; worker reads it for revise-or-not budget decisions. Fixes the 7×-low estimates that made the 1.00 RMB cap fire too late.
- **C. Anthropic prompt-cache control** — `ChatMessage.cache_breakpoint` flag; Anthropic provider promotes flagged messages to content-array shape with `cache_control: { type: ephemeral }`. BaseAgent marks the system message → 75-90% of agent prompts eligible for cache hits within the 5-minute ephemeral window.
- **D. Mid-run cancellation** — `POST /runs/:id/cancel` writes `mm:cancel:<run_id>=1` (SET NX EX 3600). Worker polls between stages; `RunCancelled(AgentError)` funnels into `done(status="cancelled")`. Frontend Cancel button replaces the dead Pause control.

## Why these 4 together
Each is small (<300 LOC), they touch independent boundary layers (worker policy / gateway cost wire / cache headers / cancel signal), and the user's standing instruction is one bundled PR per round.

## Test plan
- [x] `pytest` — 454 passing (47 new across `test_cancellation`, `test_cost_tracker`, `test_critic_policy_overrides`, `test_critic_policy_actual_cost`, `test_gateway_client_cache`, updated critic-review-flow tests)
- [x] `ruff check` clean
- [x] `cargo check -p gateway` clean
- [x] `pnpm typecheck` in `apps/web/` clean
- [ ] End-to-end smoke: dispatch a real run, observe `cache_creation_input_tokens` on call 1 and `cache_read_input_tokens` on call 2+
- [ ] Mid-run cancel: `POST /runs/:id/cancel` mid-Coder, verify run ends in `done(status="cancelled")` with partial paper.md preserved