### PR TITLE
feat: round-8 — surgical edit + SkillTool + UX polish + a11y (stacked on #33)

### DIFF
--- a/apps/agent-worker/src/agent_worker/agents/base.py
+++ b/apps/agent-worker/src/agent_worker/agents/base.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ValidationError
 from agent_worker.events import EventEmitter
 from agent_worker.gateway_client import GatewayClient
 from agent_worker.prompts import load_prompt
+from agent_worker.skills import SkillRegistry, SkillTool
 
 
 class AgentError(Exception):
@@ -41,6 +42,8 @@ class BaseAgent:
         run_effort: ReasoningEffort = "high",
         long_context: bool = False,
         model_override: str | None = None,
+        skill_registry: SkillRegistry | None = None,
+        use_skill_tool: bool = False,
     ) -> None:
         self.gateway = gateway
         self.emitter = emitter
@@ -53,6 +56,40 @@ class BaseAgent:
         # `ProblemInput.model_override`. When set, it wins over the TOML's
         # `model_preference[0]` for every agent in the run.
         self._model_override: str | None = model_override
+        # On-demand skill loading. When `use_skill_tool=True` and the
+        # registry has at least one entry, the system prompt carries the
+        # menu (frontmatter only) and the `get_skill` tool. Default off
+        # so existing eager-load behavior is preserved for every agent
+        # until we have signal that the tool path is safe.
+        self._skill_registry: SkillRegistry | None = skill_registry
+        self._use_skill_tool: bool = use_skill_tool
+        self._skill_tool: SkillTool | None = (
+            SkillTool(skill_registry)
+            if (use_skill_tool and skill_registry is not None and len(skill_registry) > 0)
+            else None
+        )
+
+    def _system_prompt_text(self) -> str:
+        """System prompt text with the on-demand skill menu optionally appended.
+
+        Kept as a method so subclasses (and `Coder`, which doesn't inherit
+        but mirrors the same shape) can share the assembly rule without
+        each one re-implementing the conditional. The menu is appended
+        AFTER the original system text so existing prompt-cache breakpoints
+        still align with the same prefix when the flag is off.
+        """
+        base = self.prompt.system["text"]
+        if self._skill_tool is None or self._skill_registry is None:
+            return base
+        menu = self._skill_registry.render_menu()
+        if not menu:
+            return base
+        return f"{base}\n\n{menu}"
+
+    @property
+    def skill_tool(self) -> SkillTool | None:
+        """The configured ``SkillTool`` instance, or ``None`` when disabled."""
+        return self._skill_tool
 
     async def run(self, **template_vars: Any) -> BaseModel:
         """Emit stage.start, call the LLM (with one parse-retry), emit output + stage.done."""
@@ -72,7 +109,7 @@ class BaseAgent:
         messages: list[dict[str, Any]] = [
             {
                 "role": "system",
-                "content": self.prompt.system["text"],
+                "content": self._system_prompt_text(),
                 "cache_breakpoint": True,
             },
             {"role": "user", "content": self.prompt.render_user(**template_vars)},
@@ -195,7 +232,7 @@ class BaseAgent:
         messages: list[dict[str, Any]] = [
             {
                 "role": "system",
-                "content": self.prompt.system["text"],
+                "content": self._system_prompt_text(),
                 "cache_breakpoint": True,
             },
             {

--- a/apps/agent-worker/src/agent_worker/agents/coder.py
+++ b/apps/agent-worker/src/agent_worker/agents/coder.py
@@ -35,6 +35,7 @@ from agent_worker.gateway_client import GatewayClient
 from agent_worker.kernel import KernelSession
 from agent_worker.matlab import MatlabSession
 from agent_worker.prompts import load_prompt
+from agent_worker.skills import SkillRegistry, SkillTool
 
 # Iteration budget for the Coder loop. Originally 3 (MVP), bumped to 7 so the
 # agent can produce multiple figures across turns rather than cramming
@@ -72,6 +73,13 @@ class CoderDirective(BaseModel):
     # MatlabSession (matlab -batch in prod, octave --no-gui in dev). State
     # does NOT persist across MATLAB turns — use .mat files for handoff.
     language: Literal["python", "matlab"] = "python"
+    # When set, this turn is a skill-tool lookup instead of an execution.
+    # The agent loop returns the requested skill's body as a synthetic
+    # feedback message and continues without burning an iteration on the
+    # kernel. ``None`` (the default) is the normal execution path; we keep
+    # it optional so prompts that don't enable the skill tool can simply
+    # omit the field.
+    skill_request: str | None = None
 
 
 class CoderAgent:
@@ -90,6 +98,8 @@ class CoderAgent:
         long_context: bool = False,
         model_override: str | None = None,
         matlab_session: MatlabSession | None = None,
+        skill_registry: SkillRegistry | None = None,
+        use_skill_tool: bool = True,
     ) -> None:
         self.gateway = gateway
         self.emitter = emitter
@@ -101,6 +111,36 @@ class CoderAgent:
         self._run_effort: ReasoningEffort = run_effort
         self._long_context: bool = long_context
         self._model_override: str | None = model_override
+        # Coder is the first agent to opt into the on-demand skill tool —
+        # it has 8+ kernel/MATLAB skills whose bodies would otherwise sit
+        # in the system prompt unused for most turns. Other BaseAgent
+        # subclasses keep ``use_skill_tool=False`` until we have signal
+        # the tool path is safe. The flag still defaults True here so a
+        # caller that wires a registry in gets the new behavior; if no
+        # registry is supplied, the tool stays None and behavior is
+        # identical to the eager-load baseline.
+        self._skill_registry: SkillRegistry | None = skill_registry
+        self._use_skill_tool: bool = use_skill_tool
+        self._skill_tool: SkillTool | None = (
+            SkillTool(skill_registry)
+            if (use_skill_tool and skill_registry is not None and len(skill_registry) > 0)
+            else None
+        )
+
+    def _system_prompt_text(self) -> str:
+        """Coder system prompt with optional on-demand skill menu appended."""
+        base = self.prompt.system["text"]
+        if self._skill_tool is None or self._skill_registry is None:
+            return base
+        menu = self._skill_registry.render_menu()
+        if not menu:
+            return base
+        return f"{base}\n\n{menu}"
+
+    @property
+    def skill_tool(self) -> SkillTool | None:
+        """Expose the bound ``SkillTool`` for tests + the agent loop."""
+        return self._skill_tool
 
     async def run(
         self,
@@ -121,7 +161,7 @@ class CoderAgent:
         figures: list[Figure] = []
         seen_ids: set[str] = set()
         messages: list[dict[str, Any]] = [
-            {"role": "system", "content": self.prompt.system["text"]},
+            {"role": "system", "content": self._system_prompt_text()},
             {
                 "role": "user",
                 "content": self.prompt.render_user(
@@ -148,9 +188,67 @@ class CoderAgent:
         model = self._model_override or self.prompt.model_preference[0]
         final_summary: str | None = None
 
+        # Cap on synthetic skill-tool turns between two real execution turns.
+        # Prevents a runaway loop where the model keeps re-requesting bodies
+        # without making progress; 6 is generous (more than the largest
+        # number of skills any agent could plausibly need in one pass).
+        SKILL_LOOKUP_BUDGET = 6
+
         try:
-            for i in range(max_iterations):
+            i = 0
+            while i < max_iterations:
                 directive = await self._ask_llm(model, messages)
+
+                # ---- skill-tool dispatch (does not consume a code iteration) ----
+                # When the model asks for a skill body, we splice the body
+                # in as a synthetic user-feedback turn and re-ask without
+                # advancing ``i``. The body becomes part of the conversation
+                # transcript for the rest of the loop, so subsequent turns
+                # see it cached in the prompt prefix on every retry.
+                skill_lookups_this_step = 0
+                while (
+                    directive.skill_request
+                    and self._skill_tool is not None
+                    and skill_lookups_this_step < SKILL_LOOKUP_BUDGET
+                ):
+                    skill_lookups_this_step += 1
+                    result = self._skill_tool.handle({"name": directive.skill_request})
+                    await self.emitter.emit(
+                        "log",
+                        {
+                            "level": "info" if result.ok else "warn",
+                            "message": (
+                                f"skill_tool: get_skill({directive.skill_request!r}) "
+                                f"-> {'ok' if result.ok else 'error'} "
+                                f"({len(result.content)} chars)"
+                            ),
+                        },
+                        agent=self.AGENT_NAME,
+                    )
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": json.dumps(directive.model_dump(mode="json")),
+                        }
+                    )
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": (
+                                f"get_skill({directive.skill_request!r}) result:\n\n"
+                                f"{result.content}\n\n"
+                                "Now produce your next CoderDirective. Set "
+                                "`skill_request` to null and return executable "
+                                "code, OR request another skill if needed."
+                            ),
+                        }
+                    )
+                    directive = await self._ask_llm(model, messages)
+
+                # If the model is still asking for a skill after the budget
+                # is exhausted, fall through and execute whatever code it
+                # supplied (likely empty); this surfaces as a real iteration
+                # so the run can make forward progress instead of looping.
 
                 lang = (directive.language or "python").lower()
                 if lang not in ("python", "matlab"):
@@ -243,6 +341,7 @@ class CoderAgent:
                         "content": self._render_execution_feedback(cell),
                     }
                 )
+                i += 1
             if final_summary is None:
                 final_summary = "Reached iteration limit without explicit done."
 

--- a/apps/agent-worker/src/agent_worker/agents/paper_editor.py
+++ b/apps/agent-worker/src/agent_worker/agents/paper_editor.py
@@ -42,6 +42,7 @@ MAX_ITERATIONS = 8
 ToolName = Literal[
     "read_paper",
     "edit_section",
+    "surgical_edit",
     "edit_constant",
     "run_cell",
     "regenerate_figure",

--- a/apps/agent-worker/src/agent_worker/editor_tools/__init__.py
+++ b/apps/agent-worker/src/agent_worker/editor_tools/__init__.py
@@ -1,6 +1,6 @@
 """Paper-editor tool catalogue.
 
-Exposes the six tools the PaperEditorAgent dispatches to plus the shared
+Exposes the tools the PaperEditorAgent dispatches to plus the shared
 `ToolContext` / `ToolResult` / `Tool` protocol. See `tools.py` for details.
 """
 
@@ -11,6 +11,7 @@ from agent_worker.editor_tools.tools import (
     RecompilePdfTool,
     RegenerateFigureTool,
     RunCellTool,
+    SurgicalEditTool,
     Tool,
     ToolContext,
     ToolResult,
@@ -24,6 +25,7 @@ __all__ = [
     "RecompilePdfTool",
     "RegenerateFigureTool",
     "RunCellTool",
+    "SurgicalEditTool",
     "Tool",
     "ToolContext",
     "ToolResult",

--- a/apps/agent-worker/src/agent_worker/editor_tools/tools.py
+++ b/apps/agent-worker/src/agent_worker/editor_tools/tools.py
@@ -7,11 +7,15 @@ executing kernel cells, calling the gateway exporter) — the agent loop is
 the only thing that decides WHEN to call them; the tools themselves never
 talk to the LLM.
 
-The five-tool catalogue mirrors the most common fine-tune verbs we observed
+The tool catalogue mirrors the most common fine-tune verbs we observed
 during the M2/M3 award-mode rollout:
 
 * `read_paper`        — inspect the current draft.
-* `edit_section`      — replace one section's body markdown verbatim.
+* `edit_section`      — replace one section's body markdown verbatim
+                        (full-rewrite path, expensive on large sections).
+* `surgical_edit`     — find/replace a unique anchor string inside the
+                        paper body — same discipline as Anthropic's Edit tool
+                        (exact match, uniqueness, optional replace_all).
 * `edit_constant`     — patch a `NAME = ...` assignment in the notebook AND
                         re-execute the affected cells in the persistent kernel.
 * `run_cell`          — run arbitrary Python (regenerate a chart, sanity-check
@@ -234,6 +238,226 @@ class EditSectionTool:
             ok=True,
             summary=f"Replaced section {title!r} body ({len(new_body)} chars).",
         )
+
+
+# ------------------------------------------------------------- surgical edit
+
+
+def _editable_targets(meta: dict[str, Any]) -> list[tuple[str, dict[str, Any], str]]:
+    """Enumerate (label, container, field) tuples we are willing to surgically edit.
+
+    A "target" is a (label, container, field) triple where:
+      * label    — human-readable name surfaced in error/diff messages
+                   ("abstract" or the section title)
+      * container — the dict whose `field` we will rewrite in place
+      * field    — the key inside `container` holding the markdown body
+
+    We deliberately exclude `title` (single-line, surgical edit is overkill)
+    and `references` (numbered list; replacing one item by its rendered prefix
+    breaks renumbering). Both can still be handled via `edit_section` / a
+    follow-up rewrite if needed.
+    """
+    targets: list[tuple[str, dict[str, Any], str]] = []
+    if "abstract" in meta:
+        targets.append(("Abstract", meta, "abstract"))
+    for sec in meta.get("sections", []) or []:
+        title = sec.get("title", "") or "(untitled)"
+        targets.append((title, sec, "body_markdown"))
+    return targets
+
+
+def _diff_window(body: str, idx: int, old_text: str, new_text: str) -> str:
+    """Return a small windowed diff context for the agent to verify.
+
+    Shows ~60 chars of context on either side of the splice point with the
+    old/new strings rendered as a unified-style fragment. We do NOT depend on
+    the stdlib `difflib` to keep the output deterministic and compact — the
+    agent only needs enough context to confirm "you edited the right place".
+    """
+    ctx_before = body[max(0, idx - 60) : idx]
+    ctx_after = body[idx + len(old_text) : idx + len(old_text) + 60]
+    return (
+        "  ..."
+        + ctx_before.replace("\n", "\\n")
+        + "\n"
+        + "- "
+        + old_text.replace("\n", "\\n")
+        + "\n"
+        + "+ "
+        + new_text.replace("\n", "\\n")
+        + "\n"
+        + "  "
+        + ctx_after.replace("\n", "\\n")
+        + "..."
+    )
+
+
+class SurgicalEditTool:
+    """Find-and-replace an exact substring inside paper.meta.json bodies.
+
+    The discipline mirrors Anthropic's Edit tool: exact string match (NO regex
+    — too easy to misfire on markdown / LaTeX), uniqueness across the searched
+    scope, and an explicit `replace_all` flag for when the agent *does* want to
+    touch every occurrence (rename a variable across the paper, etc.).
+
+    Scope:
+      * If `section_title` is provided, the search is limited to that one
+        section's body markdown (or the abstract if `Abstract`).
+      * Otherwise we search abstract + every section body and locate the
+        SINGLE container that holds the anchor. We do NOT span containers:
+        if "X" appears once in Summary and once in Sensitivity Analysis,
+        that counts as TWO occurrences (not one), and we ask the agent to
+        widen the anchor or pass `section_title`.
+
+    args:
+      old_text:       str   (required) — exact substring to find
+      new_text:       str   (required) — replacement text (may be empty
+                                          to delete the anchor)
+      replace_all:    bool  (default False) — override uniqueness check
+      section_title:  str | None — narrow search to one section
+    """
+
+    name = "surgical_edit"
+
+    async def execute(self, args: dict[str, Any], ctx: ToolContext) -> ToolResult:
+        old_text = args.get("old_text")
+        new_text = args.get("new_text")
+        replace_all = bool(args.get("replace_all", False))
+        section_title = args.get("section_title")
+
+        if not isinstance(old_text, str) or not old_text:
+            return ToolResult(
+                ok=False,
+                summary="surgical_edit requires a non-empty `old_text`.",
+                error="missing old_text",
+            )
+        if not isinstance(new_text, str):
+            return ToolResult(
+                ok=False,
+                summary="surgical_edit requires `new_text` as a string.",
+                error="missing or non-string new_text",
+            )
+        if old_text == new_text:
+            return ToolResult(
+                ok=False,
+                summary="surgical_edit refused: old_text == new_text (noop).",
+                error="old_text equals new_text",
+            )
+
+        all_targets = _editable_targets(ctx.paper_meta)
+        if section_title is not None:
+            if not isinstance(section_title, str) or not section_title:
+                return ToolResult(
+                    ok=False,
+                    summary="surgical_edit `section_title` must be a non-empty string.",
+                    error="bad section_title",
+                )
+            scoped = [
+                t
+                for t in all_targets
+                if t[0] == section_title
+                or (
+                    section_title.lower() == "abstract" and t[0] == "Abstract"
+                )
+            ]
+            if not scoped:
+                known = [t[0] for t in all_targets]
+                return ToolResult(
+                    ok=False,
+                    summary=f"surgical_edit: unknown section_title {section_title!r}.",
+                    error=f"Unknown section_title {section_title!r}. Known: {known}",
+                )
+            targets = scoped
+        else:
+            targets = all_targets
+
+        # Count total occurrences across all in-scope targets.
+        hits: list[tuple[int, str, dict[str, Any], str, str]] = []
+        # tuple: (count_in_body, label, container, field, body)
+        total = 0
+        for label, container, field_name in targets:
+            body = container.get(field_name, "") or ""
+            if not isinstance(body, str):
+                continue
+            count = body.count(old_text)
+            if count > 0:
+                hits.append((count, label, container, field_name, body))
+                total += count
+
+        if total == 0:
+            scope_desc = (
+                f"section {section_title!r}"
+                if section_title
+                else "any abstract/section body"
+            )
+            preview = old_text if len(old_text) <= 80 else old_text[:80] + "..."
+            return ToolResult(
+                ok=False,
+                summary=(
+                    f"surgical_edit: no match for old_text in {scope_desc}. "
+                    "Retry with a different anchor."
+                ),
+                error=(
+                    f"old_text not found in {scope_desc}. "
+                    f"Searched anchor (first 80 chars): {preview!r}"
+                ),
+            )
+
+        if total > 1 and not replace_all:
+            locations = ", ".join(
+                f"{label}×{count}" for count, label, _c, _f, _b in hits
+            )
+            return ToolResult(
+                ok=False,
+                summary=(
+                    f"surgical_edit: old_text appears {total} times "
+                    f"({locations}). Widen the anchor with more surrounding "
+                    "context, narrow with `section_title`, or pass "
+                    "`replace_all=true`."
+                ),
+                error=f"non-unique match ({total} occurrences): {locations}",
+            )
+
+        # Apply the replacement. For single-hit we record a diff window; for
+        # replace_all we record the count per target.
+        per_target_counts: list[tuple[str, int]] = []
+        diff_lines: list[str] = []
+        for count, label, container, field_name, body in hits:
+            if replace_all:
+                new_body = body.replace(old_text, new_text)
+                replaced = count
+            else:
+                # Unique-mode: exactly one hit, in exactly one container.
+                idx = body.find(old_text)
+                new_body = body[:idx] + new_text + body[idx + len(old_text) :]
+                replaced = 1
+                diff_lines.append(f"@ {label}:")
+                diff_lines.append(_diff_window(body, idx, old_text, new_text))
+            container[field_name] = new_body
+            per_target_counts.append((label, replaced))
+
+        _write_paper_artifacts(ctx)
+
+        total_replaced = sum(n for _, n in per_target_counts)
+        if replace_all:
+            target_summary = ", ".join(f"{lbl}×{n}" for lbl, n in per_target_counts)
+            summary = (
+                f"surgical_edit: replaced {total_replaced} occurrence(s) "
+                f"across {target_summary}."
+            )
+            detail = (
+                f"old_text ({len(old_text)} chars) -> "
+                f"new_text ({len(new_text)} chars); replace_all=true."
+            )
+        else:
+            lbl, _ = per_target_counts[0]
+            summary = (
+                f"surgical_edit: replaced 1 occurrence in {lbl} "
+                f"({len(old_text)} -> {len(new_text)} chars)."
+            )
+            detail = "\n".join(diff_lines)
+
+        return ToolResult(ok=True, summary=summary, detail=detail)
 
 
 # Matches `NAME = <rhs>` at the start of a line (allowing leading whitespace).
@@ -550,6 +774,7 @@ def build_tool_registry() -> dict[str, Tool]:
     instances: list[Tool] = [
         ReadPaperTool(),
         EditSectionTool(),
+        SurgicalEditTool(),
         EditConstantTool(),
         RunCellTool(),
         RegenerateFigureTool(),
@@ -565,6 +790,7 @@ __all__ = [
     "RecompilePdfTool",
     "RegenerateFigureTool",
     "RunCellTool",
+    "SurgicalEditTool",
     "Tool",
     "ToolContext",
     "ToolResult",

--- a/apps/agent-worker/src/agent_worker/pipeline.py
+++ b/apps/agent-worker/src/agent_worker/pipeline.py
@@ -66,6 +66,7 @@ from agent_worker.gateway_client import GatewayClient
 from agent_worker.hmml import HMMLService
 from agent_worker.kernel import KernelSession
 from agent_worker.matlab import MatlabSession
+from agent_worker.skills import SkillRegistry, load_skills_dir
 
 _log = logging.getLogger(__name__)
 
@@ -116,6 +117,27 @@ def _get_hmml() -> HMMLService | None:
         _log.warning("HMML seed dir is empty; Modeler will run without it.")
         return None
     return service
+
+
+def _load_pipeline_skills() -> SkillRegistry:
+    """Load the SKILL.md files from ``docs/skills`` for on-demand body lookup.
+
+    Resolution walks up from this file to find ``docs/skills`` so the
+    function works both from the installed package and the source tree.
+    Missing dir is non-fatal — registry is just empty and the Coder skips
+    the get_skill tool entirely.
+    """
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        candidate = ancestor / "docs" / "skills"
+        if candidate.exists():
+            try:
+                return load_skills_dir(candidate)
+            except Exception as e:  # noqa: BLE001 — skill discovery must never fail a run
+                _log.warning("skill discovery failed at %s: %s", candidate, e)
+                return SkillRegistry([])
+    _log.debug("no docs/skills directory found; skill tool will be inert")
+    return SkillRegistry([])
 
 
 def _critique_requires_revision(
@@ -459,6 +481,13 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
     # cell when the Coder picks language='matlab' rather than crashing the run.
     matlab_session = MatlabSession(run_id, runs_dir)
     hmml = _get_hmml()
+    # Skill registry — round-8 on-demand body loading. CoderAgent renders
+    # the frontmatter-only menu into its system prompt and looks up bodies
+    # via `get_skill` only when it decides one is relevant, instead of
+    # eagerly inlining all 8+ kernel/MATLAB skill bodies into every turn.
+    # Empty registry (no docs/skills/* on disk) is a clean no-op — the
+    # tool simply isn't exposed to the LLM.
+    skill_registry: SkillRegistry = _load_pipeline_skills()
 
     try:
         try:
@@ -570,7 +599,12 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
 
             await cancel.check_or_raise()
             coder = CoderAgent(
-                gateway, emitter, kernel, matlab_session=matlab_session, **kwargs
+                gateway,
+                emitter,
+                kernel,
+                matlab_session=matlab_session,
+                skill_registry=skill_registry,
+                **kwargs,
             )
             coder_out = await coder.run(
                 problem,

--- a/apps/agent-worker/src/agent_worker/prompts/paper_editor/v1.toml
+++ b/apps/agent-worker/src/agent_worker/prompts/paper_editor/v1.toml
@@ -17,7 +17,8 @@ up to 8 turns. Set `done=true` when the user's instruction is satisfied.
 # Tool catalog
 
 - `read_paper(section_title?: str)` — return current paper sections; default returns the full structure (titles + first 200 chars per section).
-- `edit_section(section_title: str, new_body_md: str)` — replace one section's body verbatim. The title is matched exactly. Both paper.md and paper.meta.json get updated.
+- `surgical_edit(old_text: str, new_text: str, replace_all?: bool, section_title?: str)` — find an exact substring `old_text` inside the paper bodies (abstract + sections) and replace it with `new_text`. The anchor MUST appear EXACTLY ONCE in the searched scope, or the call errors with the occurrence count (then widen the anchor or pass `section_title`). Set `replace_all=true` only when you intentionally want every occurrence (e.g. renaming a variable across the whole paper). PREFER this for small/targeted changes — fixing a typo, swapping a citation, tightening a sentence — because it costs O(anchor + replacement) tokens instead of rewriting the whole section.
+- `edit_section(section_title: str, new_body_md: str)` — replace one section's body verbatim. The title is matched exactly. Both paper.md and paper.meta.json get updated. Use this when MORE than ~30% of a section needs to change, or when the structure / paragraph order is being reshuffled. For smaller spot-fixes, use `surgical_edit` instead.
 - `edit_constant(name: str, value: number|str, rerun_cells_from?: int)` — find the `NAME = ...` assignment in the notebook, replace its RHS, and re-execute cells from the given index (default: the cell containing the edit). Use this for numerical tweaks like "set K_R=5000".
 - `run_cell(code: str)` — execute arbitrary Python in the run's persistent kernel; the cell is appended to notebook.ipynb. Use for regenerating figures, running quick checks.
 - `regenerate_figure(figure_id: str, code: str)` — like `run_cell` but also verifies that `figures/<figure_id>.png` was produced. Use when the user asks to redo a specific plot.
@@ -25,9 +26,17 @@ up to 8 turns. Set `done=true` when the user's instruction is satisfied.
 
 # Workflow patterns
 
-- "Tighten the abstract to 500 words": call `read_paper(section_title="Summary")`, see current; call `edit_section("Summary", "<new 500-word version>")`; optionally call `recompile_pdf()`.
-- "Set K_R=5000 and rerun sensitivity": call `read_paper(section_title="Sensitivity Analysis")`; call `edit_constant("K_R", 5000)`; call `regenerate_figure("heatmap_kr_ks_adaptive", "<new code>")` for any affected plots; update Sensitivity section narrative via `edit_section`; `recompile_pdf()`.
-- "The Strengths section is too generic": call `read_paper("Strengths and Weaknesses")` to see current text; call `edit_section` with revised content; `recompile_pdf()`.
+- "Fix the typo `lampery` to `lamprey`": call `surgical_edit(old_text="lampery", new_text="lamprey", replace_all=true)`; `recompile_pdf()`.
+- "Add a citation after the proof in Section 3": call `read_paper("<section 3 title>")` to find the exact sentence; call `surgical_edit(old_text="<the unique trailing sentence of the proof>", new_text="<the same sentence> [CITE: smith2020]", section_title="<section 3 title>")`; `recompile_pdf()`.
+- "Tighten the abstract to 500 words" (whole abstract rewrite): call `read_paper(section_title="Abstract")`; call `edit_section("Abstract", "<new 500-word version>")`; `recompile_pdf()`.
+- "Set K_R=5000 and rerun sensitivity": call `read_paper(section_title="Sensitivity Analysis")`; call `edit_constant("K_R", 5000)`; call `regenerate_figure("heatmap_kr_ks_adaptive", "<new code>")` for any affected plots; update Sensitivity narrative via `surgical_edit` (small touch) or `edit_section` (rewrite); `recompile_pdf()`.
+- "The Strengths section is too generic" (broad rewrite): call `read_paper("Strengths and Weaknesses")`; call `edit_section` with revised content; `recompile_pdf()`.
+
+# Edit-tool choice rule
+
+- DEFAULT to `surgical_edit` for any change that touches less than ~30% of a section. It is dramatically cheaper, only rewrites the lines you care about, and minimises regression risk in untouched paragraphs.
+- ESCALATE to `edit_section` only when you would otherwise need ~3+ `surgical_edit` calls in one section, OR when paragraph order / overall structure is changing.
+- If `surgical_edit` returns "no match", widen the anchor (use a longer surrounding phrase). If it returns "non-unique match (N occurrences)", either lengthen the anchor with more context until it is unique, OR pass `section_title` to narrow the scope, OR pass `replace_all=true` if you really do mean every occurrence.
 
 # Discipline
 
@@ -43,7 +52,7 @@ Each turn, emit exactly:
 ```json
 {
   "reasoning": "brief plan for this turn",
-  "tool": "read_paper" | "edit_section" | "edit_constant" | "run_cell" | "regenerate_figure" | "recompile_pdf",
+  "tool": "read_paper" | "edit_section" | "surgical_edit" | "edit_constant" | "run_cell" | "regenerate_figure" | "recompile_pdf",
   "args": {...},
   "done": false,
   "summary": null

--- a/apps/agent-worker/src/agent_worker/skills/__init__.py
+++ b/apps/agent-worker/src/agent_worker/skills/__init__.py
@@ -1,7 +1,9 @@
 """Skill registry — SKILL.md discovery for the agent worker.
 
 See ``loader.py`` for the design notes on the two-layer (frontmatter vs.
-body) pattern borrowed from Claude Code.
+body) pattern borrowed from Claude Code. ``tool.py`` adds the on-demand
+``get_skill`` tool that pulls a single body into the conversation only
+when the agent decides to use it.
 """
 
 from agent_worker.skills.loader import (
@@ -10,10 +12,22 @@ from agent_worker.skills.loader import (
     format_index_for_prompt,
     load_skills_dir,
 )
+from agent_worker.skills.tool import (
+    GET_SKILL_TOOL_NAME,
+    SkillTool,
+    SkillToolResult,
+    build_get_skill_tool_spec,
+    render_skill_menu,
+)
 
 __all__ = [
+    "GET_SKILL_TOOL_NAME",
     "Skill",
     "SkillRegistry",
+    "SkillTool",
+    "SkillToolResult",
+    "build_get_skill_tool_spec",
     "format_index_for_prompt",
     "load_skills_dir",
+    "render_skill_menu",
 ]

--- a/apps/agent-worker/src/agent_worker/skills/loader.py
+++ b/apps/agent-worker/src/agent_worker/skills/loader.py
@@ -104,6 +104,21 @@ class SkillRegistry:
             lines.append(f"- {s.name}: {desc}")
         return "\n".join(lines)
 
+    def render_menu(self, language: str = "en") -> str:
+        """Render the on-demand-tool menu (frontmatter only — no bodies).
+
+        Differs from :meth:`index_summary` by surfacing ``when_to_use``
+        triggers, which the model needs to decide *whether* to invoke
+        ``get_skill``. The body is intentionally omitted; that is what
+        the tool returns. Implementation lives in
+        ``agent_worker.skills.tool.render_skill_menu`` to avoid a circular
+        import — this method is a thin re-export so callers can stay on
+        the ``SkillRegistry`` surface.
+        """
+        from agent_worker.skills.tool import render_skill_menu
+
+        return render_skill_menu(self, language=language)
+
 
 # ----------------------------------------------------------- frontmatter parsing
 

--- a/apps/agent-worker/src/agent_worker/skills/tool.py
+++ b/apps/agent-worker/src/agent_worker/skills/tool.py
@@ -1,0 +1,217 @@
+"""On-demand skill body loading via a `get_skill` tool.
+
+Background
+----------
+``SkillRegistry`` ships two layers (see ``loader.py``): cheap frontmatter
+discovery in the system prompt, plus a full markdown ``body`` that is only
+worth surfacing when the agent has actually decided to invoke a skill.
+
+Round-7 prompt caching tames the system-prompt cost somewhat, but eagerly
+inlining every skill body still has two real costs:
+
+1. The system prompt grows past the *optimal* cache boundary. For the
+   Coder, which is the only agent today with 8+ kernel/MATLAB skills, the
+   bodies routinely add 5-10k tokens that the LLM rarely consumes in any
+   single turn.
+2. Discovery quality drops: the model sees a wall of text instead of a
+   clean menu and has to scan the whole prefix to remember what is
+   available.
+
+This module exposes the body behind an OpenAI-style ``get_skill`` tool.
+The agent's system prompt carries only the *menu* (one line per skill,
+plus a short `when_to_use` block) and lists ``get_skill`` as a callable
+tool. When the model decides a skill is relevant it emits a tool call;
+the registry returns the raw markdown body which enters the conversation
+as a tool result — cacheable within the run, scoped to the single turn
+where it was needed.
+
+Wire-up
+-------
+``BaseAgent`` consumes ``SkillTool`` via two constructor knobs
+(``skill_registry`` + ``use_skill_tool``). When the flag is False (the
+default) nothing about the existing prompt pipeline changes — the menu is
+not rendered and the tool is not exposed. Per-agent gradual rollout is
+the whole point of the flag; we flip it for the Coder in this PR because
+Coder has the most skills and the worst eager-load tax, and leave the
+other agents on the eager path until we have signal that the tool path
+is safe.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from agent_worker.skills.loader import Skill, SkillRegistry
+
+# Public tool name — kept short for token efficiency in the system prompt's
+# tool listing. Matches the convention sourcemap uses (``view_skill`` in
+# their tree) but renamed to ``get_skill`` to match the surrounding
+# Mathodology vocabulary ("get" verbs everywhere in the worker tools dir).
+GET_SKILL_TOOL_NAME = "get_skill"
+
+
+def build_get_skill_tool_spec() -> dict[str, Any]:
+    """Return the OpenAI-style JSONSchema spec for the ``get_skill`` tool.
+
+    The shape matches what an OpenAI-compat / Anthropic-compat gateway
+    expects in ``tools=[{type: "function", function: {...}}]``. Keeping
+    this in a factory (rather than a module constant) lets us pin the
+    schema once per turn — model providers occasionally complain about
+    shared mutable dicts in their request bodies.
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": GET_SKILL_TOOL_NAME,
+            "description": (
+                "Load the full body of a skill by name. The menu in the system "
+                "prompt lists every skill's name, short description, and "
+                "when_to_use triggers; call this tool only when one of those "
+                "triggers matches the current task. The tool result is the raw "
+                "markdown body of the skill."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": (
+                            "Exact skill name as listed in the system prompt menu. "
+                            "Case-sensitive; do not pass a path or extension."
+                        ),
+                    },
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+@dataclass
+class SkillToolResult:
+    """Tagged return type for ``SkillTool.handle``.
+
+    Using a dataclass instead of bare strings lets callers tell success
+    apart from a structured error (e.g. "unknown skill") without parsing
+    the body — handy when the agent loop wants to emit a different event
+    on failure.
+    """
+
+    ok: bool
+    name: str
+    content: str
+
+
+class SkillTool:
+    """Thin runtime adapter around ``SkillRegistry`` for tool-call dispatch.
+
+    The class is intentionally tiny: it owns no state besides the
+    registry reference and the canonical tool spec. Construction is
+    cheap, so per-agent or per-run instances are both fine.
+    """
+
+    def __init__(self, registry: SkillRegistry) -> None:
+        self.registry = registry
+
+    @property
+    def name(self) -> str:
+        return GET_SKILL_TOOL_NAME
+
+    def tool_spec(self) -> dict[str, Any]:
+        """OpenAI-compat function spec — copy-on-read so callers can mutate."""
+        return build_get_skill_tool_spec()
+
+    def handle(self, arguments: dict[str, Any] | None) -> SkillToolResult:
+        """Dispatch a tool call. Never raises — errors become structured results.
+
+        Callers (the agent loop) take the ``content`` field verbatim as
+        the tool message in the next turn. We deliberately do not raise
+        on bad input: a noisy stack trace from a malformed tool call
+        would break the run, whereas an error string lets the model
+        recover (retry with a corrected name).
+        """
+        args = arguments or {}
+        name_raw = args.get("name")
+        if not isinstance(name_raw, str) or not name_raw.strip():
+            return SkillToolResult(
+                ok=False,
+                name="",
+                content=(
+                    "Error: `get_skill` requires a non-empty string `name` "
+                    "argument. Check the skill menu in the system prompt and "
+                    "retry."
+                ),
+            )
+        name = name_raw.strip()
+        skill = self.registry.get(name)
+        if skill is None:
+            available = self.registry.names()
+            preview = ", ".join(available[:10])
+            if len(available) > 10:
+                preview += ", …"
+            return SkillToolResult(
+                ok=False,
+                name=name,
+                content=(
+                    f"Error: no skill named {name!r}. "
+                    f"Available skills: [{preview}]. "
+                    "Skill names are case-sensitive — copy from the menu."
+                ),
+            )
+        return SkillToolResult(ok=True, name=skill.name, content=skill.body)
+
+
+def render_skill_menu(
+    registry: SkillRegistry,
+    language: str = "en",
+) -> str:
+    """Render the agent-facing menu (frontmatter only — no skill bodies).
+
+    Format::
+
+        ## Available skills (call `get_skill` to load body)
+        ### <name>
+        <description>
+        when_to_use:
+          - <trigger 1>
+          - <trigger 2>
+
+    The header explicitly names ``get_skill`` so the model has the link
+    between the menu and the tool one block away in context. The
+    when_to_use bullets are the *trigger* hints the model uses to decide
+    whether to call the tool — those have to live in the menu, not behind
+    the tool, otherwise the model has nothing to dispatch from.
+    """
+    if len(registry) == 0:
+        return ""
+    if language == "zh":
+        header = (
+            "## 可用技能（调用 `get_skill` 加载正文）"
+        )
+    else:
+        header = "## Available skills (call `get_skill` to load body)"
+    lines: list[str] = [header]
+    for s in registry:
+        lines.append(f"### {s.name}")
+        lines.append(s.description)
+        if s.when_to_use:
+            lines.append("when_to_use:")
+            for trig in s.when_to_use:
+                lines.append(f"  - {trig}")
+        lines.append("")  # blank line between entries
+    # Trim trailing blank line for tidier concatenation.
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines)
+
+
+__all__ = [
+    "GET_SKILL_TOOL_NAME",
+    "Skill",
+    "SkillTool",
+    "SkillToolResult",
+    "build_get_skill_tool_spec",
+    "render_skill_menu",
+]

--- a/apps/agent-worker/tests/test_paper_editor_surgical_edit.py
+++ b/apps/agent-worker/tests/test_paper_editor_surgical_edit.py
@@ -1,0 +1,393 @@
+"""Tests for the surgical_edit tool added in round 8.
+
+The tool mirrors Anthropic's Edit-tool discipline:
+  * exact-string `old_text` match (NO regex)
+  * uniqueness across the searched scope; ambiguity surfaces a clear error
+  * optional `replace_all` to override uniqueness
+  * clear, actionable errors so the agent can retry without a full rewrite
+
+These tests cover:
+  * happy path (unique match, single replacement)
+  * no-match (clear error, paper unchanged on disk)
+  * duplicate match without `replace_all` (error with location count)
+  * duplicate match WITH `replace_all` (every occurrence rewritten)
+  * scoping via `section_title`
+  * empty / non-string args
+  * paper.md gets re-rendered from paper.meta.json after a write
+  * the agent loop emits `finetune.tool_call` + `finetune.tool_result`
+    events when dispatching to surgical_edit (event-stream contract).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from agent_worker.agents import PaperEditorAgent
+from agent_worker.editor_tools import SurgicalEditTool, ToolContext
+
+PAPER_META: dict[str, Any] = {
+    "title": "On the Stability of Lamprey Sex Ratios",
+    "abstract": "We model sea-lamprey sex determination as a function of resource availability. The K_R parameter dominates.",
+    "competition_type": "mcm",
+    "problem_text": "Some problem text.",
+    "sections": [
+        {
+            "title": "Summary",
+            "body_markdown": (
+                "The lamprey population is sensitive to K_R. "
+                "Reducing K_R by 20% halves the male fraction."
+            ),
+        },
+        {
+            "title": "Sensitivity Analysis",
+            "body_markdown": (
+                "We perturb K_R by +/-20% and observe the male fraction shift. "
+                "K_R dominates the tornado plot."
+            ),
+        },
+        {
+            "title": "Strengths and Weaknesses",
+            "body_markdown": "Strengths: parsimonious. Weaknesses: ignores migration.",
+        },
+    ],
+    "references": ["Ref 1", "Ref 2"],
+    "figures": [],
+}
+
+
+def _make_run_dir(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "figures").mkdir()
+    (run_dir / "paper.meta.json").write_text(
+        json.dumps(PAPER_META, ensure_ascii=False), encoding="utf-8"
+    )
+    (run_dir / "paper.md").write_text(
+        "# title\n\n## Abstract\n\nbody\n", encoding="utf-8"
+    )
+    (run_dir / "notebook.ipynb").write_text(
+        json.dumps(
+            {
+                "cells": [],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def _make_ctx(tmp_path: Path) -> ToolContext:
+    run_dir = _make_run_dir(tmp_path)
+    return ToolContext(
+        run_dir=run_dir,
+        paper_meta=json.loads(json.dumps(PAPER_META)),
+        notebook={"cells": []},
+        kernel=None,
+        gateway=None,
+        emitter=None,
+        next_cell_index=0,
+    )
+
+
+# --------------------------------------------------------------- happy paths
+
+
+async def test_surgical_edit_unique_match_replaces_once(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    # "parsimonious" appears exactly once (in Strengths and Weaknesses).
+    result = await SurgicalEditTool().execute(
+        {"old_text": "parsimonious", "new_text": "minimal"}, ctx
+    )
+    assert result.ok, result.error
+    strengths = next(
+        s for s in ctx.paper_meta["sections"] if s["title"] == "Strengths and Weaknesses"
+    )
+    assert "minimal" in strengths["body_markdown"]
+    assert "parsimonious" not in strengths["body_markdown"]
+    # paper.meta.json was persisted to disk
+    on_disk = json.loads(
+        (ctx.run_dir / "paper.meta.json").read_text(encoding="utf-8")
+    )
+    on_disk_strengths = next(
+        s for s in on_disk["sections"] if s["title"] == "Strengths and Weaknesses"
+    )
+    assert "minimal" in on_disk_strengths["body_markdown"]
+    # paper.md re-rendered too
+    md = (ctx.run_dir / "paper.md").read_text(encoding="utf-8")
+    assert "minimal" in md
+    # diff window in detail
+    assert result.detail is not None
+    assert "- parsimonious" in result.detail
+    assert "+ minimal" in result.detail
+
+
+async def test_surgical_edit_can_edit_abstract(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    # "resource availability" appears once (in abstract).
+    result = await SurgicalEditTool().execute(
+        {
+            "old_text": "resource availability",
+            "new_text": "habitat carrying capacity",
+        },
+        ctx,
+    )
+    assert result.ok, result.error
+    assert "habitat carrying capacity" in ctx.paper_meta["abstract"]
+    assert "resource availability" not in ctx.paper_meta["abstract"]
+
+
+# ------------------------------------------------------------------ no match
+
+
+async def test_surgical_edit_no_match_returns_error_and_does_not_write(
+    tmp_path: Path,
+) -> None:
+    ctx = _make_ctx(tmp_path)
+    before = (ctx.run_dir / "paper.meta.json").read_text(encoding="utf-8")
+    result = await SurgicalEditTool().execute(
+        {"old_text": "totally-not-in-the-paper-xyz", "new_text": "anything"}, ctx
+    )
+    assert not result.ok
+    assert "not found" in (result.error or "").lower()
+    # No write should have happened.
+    after = (ctx.run_dir / "paper.meta.json").read_text(encoding="utf-8")
+    assert before == after
+
+
+# -------------------------------------------------------------- duplicate match
+
+
+async def test_surgical_edit_duplicate_match_without_replace_all_errors(
+    tmp_path: Path,
+) -> None:
+    ctx = _make_ctx(tmp_path)
+    # "K_R" appears in abstract + Summary + Sensitivity Analysis (multiple times).
+    before = (ctx.run_dir / "paper.meta.json").read_text(encoding="utf-8")
+    result = await SurgicalEditTool().execute(
+        {"old_text": "K_R", "new_text": "K_recruit"}, ctx
+    )
+    assert not result.ok
+    err = (result.error or "").lower()
+    assert "non-unique" in err or "occurrence" in err
+    # The error should mention at least one container so the agent knows where.
+    assert "summary" in err or "sensitivity" in err or "abstract" in err
+    # No write should have happened.
+    after = (ctx.run_dir / "paper.meta.json").read_text(encoding="utf-8")
+    assert before == after
+
+
+async def test_surgical_edit_duplicate_with_replace_all_replaces_everything(
+    tmp_path: Path,
+) -> None:
+    ctx = _make_ctx(tmp_path)
+    # Count K_R occurrences before.
+    rendered_before = (
+        ctx.paper_meta["abstract"]
+        + " ".join(s["body_markdown"] for s in ctx.paper_meta["sections"])
+    )
+    occurrences = rendered_before.count("K_R")
+    assert occurrences > 1  # sanity: ambiguous before replace_all
+    result = await SurgicalEditTool().execute(
+        {"old_text": "K_R", "new_text": "K_recruit", "replace_all": True}, ctx
+    )
+    assert result.ok, result.error
+    # No K_R should remain.
+    rendered_after = (
+        ctx.paper_meta["abstract"]
+        + " ".join(s["body_markdown"] for s in ctx.paper_meta["sections"])
+    )
+    assert "K_R" not in rendered_after
+    assert rendered_after.count("K_recruit") == occurrences
+    # paper.md mirrors paper.meta.json
+    md = (ctx.run_dir / "paper.md").read_text(encoding="utf-8")
+    assert "K_recruit" in md
+    assert "K_R" not in md
+
+
+# -------------------------------------------------------------- section_title scoping
+
+
+async def test_surgical_edit_section_title_narrows_scope(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    # "K_R" is ambiguous globally, but inside Strengths and Weaknesses it
+    # doesn't appear at all — so a Summary-scoped edit should be possible
+    # if the anchor is unique within Summary.
+    # The phrase "Reducing K_R by 20%" is unique to Summary.
+    result = await SurgicalEditTool().execute(
+        {
+            "old_text": "Reducing K_R by 20%",
+            "new_text": "Lowering K_R by one fifth",
+            "section_title": "Summary",
+        },
+        ctx,
+    )
+    assert result.ok, result.error
+    summary_sec = next(s for s in ctx.paper_meta["sections"] if s["title"] == "Summary")
+    assert "Lowering K_R by one fifth" in summary_sec["body_markdown"]
+
+
+async def test_surgical_edit_unknown_section_title_errors(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    result = await SurgicalEditTool().execute(
+        {
+            "old_text": "K_R",
+            "new_text": "K_recruit",
+            "section_title": "Made Up Section",
+        },
+        ctx,
+    )
+    assert not result.ok
+    assert "Made Up Section" in (result.error or "")
+
+
+# ------------------------------------------------------------------- validation
+
+
+async def test_surgical_edit_empty_old_text_errors(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    result = await SurgicalEditTool().execute(
+        {"old_text": "", "new_text": "anything"}, ctx
+    )
+    assert not result.ok
+    assert "old_text" in (result.error or "").lower()
+
+
+async def test_surgical_edit_missing_new_text_errors(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    result = await SurgicalEditTool().execute({"old_text": "parsimonious"}, ctx)
+    assert not result.ok
+    assert "new_text" in (result.error or "").lower()
+
+
+async def test_surgical_edit_noop_when_old_equals_new(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    result = await SurgicalEditTool().execute(
+        {"old_text": "parsimonious", "new_text": "parsimonious"}, ctx
+    )
+    assert not result.ok
+    assert "noop" in (result.summary or "").lower() or "equals" in (
+        result.error or ""
+    ).lower()
+
+
+# ----------------------------------------------------- agent-loop event emission
+
+
+class _FakeEmitter:
+    def __init__(self) -> None:
+        self.run_id = uuid4()
+        self.events: list[tuple[str, dict[str, Any], str | None]] = []
+
+    async def emit(
+        self,
+        kind: str,
+        payload: dict[str, Any] | None = None,
+        agent: str | None = None,
+    ) -> None:
+        self.events.append((kind, payload or {}, agent))
+
+
+class _FakeGateway:
+    def __init__(self, directives: list[str]) -> None:
+        self._directives = directives
+        self.calls = 0
+        self.export_paper = AsyncMock(return_value=b"%PDF-1.7\nfake")
+
+    async def stream_completion(self, **_: object) -> AsyncIterator[str]:
+        idx = self.calls
+        self.calls += 1
+        if idx >= len(self._directives):
+            idx = len(self._directives) - 1
+        yield self._directives[idx]
+
+    async def close(self) -> None:
+        pass
+
+
+def _seed_run_dir_for_agent(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "figures").mkdir()
+    (run_dir / "paper.meta.json").write_text(
+        json.dumps(PAPER_META, ensure_ascii=False), encoding="utf-8"
+    )
+    (run_dir / "paper.md").write_text(
+        "# title\n\n## Abstract\n\n...\n", encoding="utf-8"
+    )
+    (run_dir / "notebook.ipynb").write_text(
+        json.dumps(
+            {"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+        ),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+@pytest.fixture
+def kernel_mock() -> AsyncMock:
+    kernel = AsyncMock()
+    kernel.execute.return_value = type(
+        "R", (), {"error": None, "stdout": ""}
+    )()
+    return kernel
+
+
+async def test_agent_dispatches_surgical_edit_and_emits_events(
+    tmp_path: Path, kernel_mock: AsyncMock
+) -> None:
+    run_dir = _seed_run_dir_for_agent(tmp_path)
+    directives = [
+        json.dumps(
+            {
+                "reasoning": "fix typo with a surgical edit",
+                "tool": "surgical_edit",
+                "args": {
+                    "old_text": "parsimonious",
+                    "new_text": "minimal",
+                },
+                "done": True,
+                "summary": "Replaced 'parsimonious' with 'minimal'.",
+            }
+        )
+    ]
+    gateway = _FakeGateway(directives)
+    emitter = _FakeEmitter()
+    agent = PaperEditorAgent(
+        gateway=gateway,  # type: ignore[arg-type]
+        emitter=emitter,  # type: ignore[arg-type]
+        kernel=kernel_mock,
+        run_dir=run_dir,
+    )
+    summary = await agent.fine_tune(
+        "Replace 'parsimonious' with 'minimal'.", run_dir, max_iterations=4
+    )
+    assert "minimal" in summary.lower() or "parsimonious" in summary
+
+    kinds = [e[0] for e in emitter.events]
+    assert "finetune.tool_call" in kinds
+    assert "finetune.tool_result" in kinds
+
+    tool_call = next(e for e in emitter.events if e[0] == "finetune.tool_call")
+    assert tool_call[1]["tool"] == "surgical_edit"
+    assert tool_call[1]["args"]["old_text"] == "parsimonious"
+
+    tool_result = next(e for e in emitter.events if e[0] == "finetune.tool_result")
+    assert tool_result[1]["tool"] == "surgical_edit"
+    assert tool_result[1]["ok"] is True
+
+    # Verify the on-disk paper actually got the edit.
+    on_disk = json.loads((run_dir / "paper.meta.json").read_text(encoding="utf-8"))
+    strengths = next(
+        s for s in on_disk["sections"] if s["title"] == "Strengths and Weaknesses"
+    )
+    assert "minimal" in strengths["body_markdown"]
+    assert "parsimonious" not in strengths["body_markdown"]

--- a/apps/agent-worker/tests/test_skill_tool.py
+++ b/apps/agent-worker/tests/test_skill_tool.py
@@ -1,0 +1,508 @@
+"""Tests for the on-demand skill loading tool (`get_skill`).
+
+Covers:
+- `SkillTool.handle` returns the body for a valid name.
+- `SkillTool.handle` returns a structured error for unknown / blank names.
+- `SkillRegistry.render_menu` produces frontmatter-only output.
+- BaseAgent system prompt assembly: bodies are omitted when
+  ``use_skill_tool=True`` and included by default otherwise.
+- CoderAgent prompt assembly: bodies are omitted when the skill tool
+  is enabled, included via menu only.
+- Integration: a mocked Coder turn requests a skill, receives the body,
+  and proceeds to execute code on the next turn.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from agent_worker.agents import CoderAgent
+from agent_worker.kernel import KernelSession
+from agent_worker.skills import (
+    Skill,
+    SkillRegistry,
+    SkillTool,
+    SkillToolResult,
+    build_get_skill_tool_spec,
+    render_skill_menu,
+)
+from mm_contracts import (
+    AnalyzerOutput,
+    ApproachSketch,
+    ModelSpec,
+    ProblemInput,
+)
+
+# ---------------------------------------------------------- registry helpers
+
+
+def _make_registry() -> SkillRegistry:
+    """Two-entry registry with body markers that do NOT collide with Coder prompt.
+
+    The Coder system prompt itself mentions octave + matplotlib, so we
+    use distinctive sentinel strings inside the body that we can grep
+    for without false positives.
+    """
+    return SkillRegistry(
+        [
+            Skill(
+                name="matlab_x",
+                description="MATLAB cell execution patterns for Coder.",
+                when_to_use=[
+                    "Coder picks language='matlab'",
+                    "ODE solving",
+                ],
+                body="# MATLAB skill body\n\nSENTINEL-BODY-MATLAB-XYZ123\n",
+            ),
+            Skill(
+                name="figures_x",
+                description="Figure-saving conventions: savefig.",
+                when_to_use=["any figure"],
+                body="# Figures body\n\nSENTINEL-BODY-FIGURES-XYZ456\n",
+            ),
+        ]
+    )
+
+
+# ---------------------------------------------------------- SkillTool basics
+
+
+def test_get_skill_returns_body_for_valid_name() -> None:
+    reg = _make_registry()
+    tool = SkillTool(reg)
+
+    result = tool.handle({"name": "matlab_x"})
+
+    assert isinstance(result, SkillToolResult)
+    assert result.ok is True
+    assert result.name == "matlab_x"
+    assert "MATLAB skill body" in result.content
+    assert "SENTINEL-BODY-MATLAB-XYZ123" in result.content
+
+
+def test_get_skill_returns_error_for_unknown_name() -> None:
+    reg = _make_registry()
+    tool = SkillTool(reg)
+
+    result = tool.handle({"name": "does_not_exist"})
+
+    assert result.ok is False
+    assert result.name == "does_not_exist"
+    # Error message must mention what the name was and what is available
+    # so the model can retry with a corrected name.
+    assert "does_not_exist" in result.content
+    assert "matlab_x" in result.content
+    assert "figures_x" in result.content
+    assert "Error" in result.content
+
+
+def test_get_skill_handles_missing_or_blank_args() -> None:
+    reg = _make_registry()
+    tool = SkillTool(reg)
+
+    # None args.
+    res_none = tool.handle(None)
+    assert res_none.ok is False
+    assert "non-empty" in res_none.content or "required" in res_none.content.lower()
+
+    # Missing key.
+    res_missing = tool.handle({})
+    assert res_missing.ok is False
+
+    # Blank string.
+    res_blank = tool.handle({"name": "   "})
+    assert res_blank.ok is False
+
+    # Wrong type.
+    res_int = tool.handle({"name": 42})
+    assert res_int.ok is False
+
+
+def test_get_skill_tool_spec_shape() -> None:
+    spec = build_get_skill_tool_spec()
+    assert spec["type"] == "function"
+    assert spec["function"]["name"] == "get_skill"
+    params = spec["function"]["parameters"]
+    assert params["type"] == "object"
+    assert "name" in params["properties"]
+    assert params["required"] == ["name"]
+    assert params["additionalProperties"] is False
+
+
+def test_skill_tool_name_property() -> None:
+    reg = _make_registry()
+    tool = SkillTool(reg)
+    assert tool.name == "get_skill"
+    # tool_spec returns a fresh dict each call (model providers complain
+    # about shared mutable dicts in request bodies).
+    assert tool.tool_spec() is not tool.tool_spec()
+
+
+# --------------------------------------------------------- render_menu / registry
+
+
+def test_render_menu_produces_frontmatter_only_output() -> None:
+    reg = _make_registry()
+    menu = render_skill_menu(reg)
+
+    # Menu has headers + descriptions + when_to_use, but NO body content.
+    assert "Available skills" in menu
+    assert "### matlab_x" in menu
+    assert "### figures_x" in menu
+    assert "MATLAB cell execution patterns" in menu
+    assert "Coder picks language='matlab'" in menu
+
+    # Critical: bodies must NOT appear in the menu — that's the whole
+    # point of the on-demand tool path.
+    assert "SENTINEL-BODY-MATLAB-XYZ123" not in menu
+    assert "SENTINEL-BODY-FIGURES-XYZ456" not in menu
+
+
+def test_render_menu_via_registry_method() -> None:
+    reg = _make_registry()
+    direct = render_skill_menu(reg)
+    via_method = reg.render_menu()
+    assert direct == via_method
+
+
+def test_render_menu_empty_registry_returns_empty_string() -> None:
+    reg = SkillRegistry([])
+    assert render_skill_menu(reg) == ""
+    assert reg.render_menu() == ""
+
+
+def test_render_menu_zh_language() -> None:
+    reg = _make_registry()
+    menu = reg.render_menu(language="zh")
+    assert "可用技能" in menu
+    # Body still absent regardless of language.
+    assert "SENTINEL-BODY-MATLAB-XYZ123" not in menu
+
+
+# --------------------------------------------------------- BaseAgent assembly
+
+
+def test_base_agent_skill_tool_flag_off_omits_menu(tmp_path: Path) -> None:
+    """When the flag is off, the system prompt is unchanged."""
+    from agent_worker.agents import AnalyzerAgent
+
+    # Construct without any of the LLM machinery — we only inspect prompt
+    # assembly, never call run().
+    agent = AnalyzerAgent(
+        gateway=None,  # type: ignore[arg-type]
+        emitter=None,  # type: ignore[arg-type]
+        skill_registry=_make_registry(),
+        use_skill_tool=False,  # explicit
+    )
+    assembled = agent._system_prompt_text()
+    assert "Available skills" not in assembled
+    # And the original system prompt is intact.
+    assert assembled == agent.prompt.system["text"]
+    assert agent.skill_tool is None
+
+
+def test_base_agent_skill_tool_flag_on_appends_menu_omits_body(tmp_path: Path) -> None:
+    """When the flag is on AND a registry is provided, the menu is appended."""
+    from agent_worker.agents import AnalyzerAgent
+
+    agent = AnalyzerAgent(
+        gateway=None,  # type: ignore[arg-type]
+        emitter=None,  # type: ignore[arg-type]
+        skill_registry=_make_registry(),
+        use_skill_tool=True,
+    )
+    assembled = agent._system_prompt_text()
+    assert "Available skills" in assembled
+    assert "### matlab_x" in assembled
+    # Critical: bodies must not appear in the system prompt.
+    assert "SENTINEL-BODY-MATLAB-XYZ123" not in assembled
+    assert "SENTINEL-BODY-FIGURES-XYZ456" not in assembled
+    assert agent.skill_tool is not None
+
+
+def test_base_agent_skill_tool_on_but_empty_registry_no_op(tmp_path: Path) -> None:
+    """Empty registry + flag-on must not append a dangling header."""
+    from agent_worker.agents import AnalyzerAgent
+
+    agent = AnalyzerAgent(
+        gateway=None,  # type: ignore[arg-type]
+        emitter=None,  # type: ignore[arg-type]
+        skill_registry=SkillRegistry([]),
+        use_skill_tool=True,
+    )
+    assembled = agent._system_prompt_text()
+    assert "Available skills" not in assembled
+    assert assembled == agent.prompt.system["text"]
+    assert agent.skill_tool is None
+
+
+def test_base_agent_skill_tool_default_off() -> None:
+    """No-arg construction inherits the safe default: tool disabled."""
+    from agent_worker.agents import AnalyzerAgent
+
+    agent = AnalyzerAgent(
+        gateway=None,  # type: ignore[arg-type]
+        emitter=None,  # type: ignore[arg-type]
+    )
+    assert agent.skill_tool is None
+    assert agent._system_prompt_text() == agent.prompt.system["text"]
+
+
+# --------------------------------------------------------- Coder prompt assembly
+
+
+def test_coder_prompt_assembly_omits_skill_bodies_when_flag_on(tmp_path: Path) -> None:
+    """Coder's system prompt carries the menu, never the bodies."""
+    kernel = KernelSession(uuid4(), tmp_path)
+
+    agent = CoderAgent(
+        gateway=None,  # type: ignore[arg-type]
+        emitter=None,  # type: ignore[arg-type]
+        kernel=kernel,
+        skill_registry=_make_registry(),
+        use_skill_tool=True,
+    )
+    assembled = agent._system_prompt_text()
+    assert "Available skills" in assembled
+    assert "### matlab_x" in assembled
+    # No bodies leaked.
+    assert "SENTINEL-BODY-MATLAB-XYZ123" not in assembled
+    assert "SENTINEL-BODY-FIGURES-XYZ456" not in assembled
+
+
+def test_coder_prompt_assembly_eager_baseline_when_flag_off(tmp_path: Path) -> None:
+    """With the flag off, Coder system prompt is unchanged."""
+    kernel = KernelSession(uuid4(), tmp_path)
+
+    agent = CoderAgent(
+        gateway=None,  # type: ignore[arg-type]
+        emitter=None,  # type: ignore[arg-type]
+        kernel=kernel,
+        skill_registry=_make_registry(),
+        use_skill_tool=False,
+    )
+    assembled = agent._system_prompt_text()
+    assert "Available skills" not in assembled
+    assert assembled == agent.prompt.system["text"]
+    assert agent.skill_tool is None
+
+
+def test_coder_skill_tool_enabled_by_default_when_registry_passed(
+    tmp_path: Path,
+) -> None:
+    """Coder is the first agent to opt in — default ``use_skill_tool=True``."""
+    kernel = KernelSession(uuid4(), tmp_path)
+
+    agent = CoderAgent(
+        gateway=None,  # type: ignore[arg-type]
+        emitter=None,  # type: ignore[arg-type]
+        kernel=kernel,
+        skill_registry=_make_registry(),
+    )
+    assert agent.skill_tool is not None
+    assert "Available skills" in agent._system_prompt_text()
+
+
+def test_coder_without_registry_runs_identically_to_baseline(tmp_path: Path) -> None:
+    """No registry → tool stays None, prompt unchanged."""
+    kernel = KernelSession(uuid4(), tmp_path)
+
+    agent = CoderAgent(
+        gateway=None,  # type: ignore[arg-type]
+        emitter=None,  # type: ignore[arg-type]
+        kernel=kernel,
+    )
+    assert agent.skill_tool is None
+    assert agent._system_prompt_text() == agent.prompt.system["text"]
+
+
+# --------------------------------------------------------- Coder integration
+
+
+class _FakeEmitter:
+    """Same shape as the test_coder_agent harness."""
+
+    def __init__(self) -> None:
+        self.run_id = uuid4()
+        self.events: list[tuple[str, dict, str | None]] = []
+
+    async def emit(
+        self, kind: str, payload: dict | None = None, agent: str | None = None
+    ) -> None:
+        self.events.append((kind, payload or {}, agent))
+
+
+class _ScriptedGateway:
+    """Yields a queued list of JSON strings, one per stream_completion() call."""
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+        self.calls: list[list[dict[str, Any]]] = []
+
+    async def stream_completion(
+        self, *, messages: list[dict[str, Any]], **_: object
+    ) -> AsyncIterator[str]:
+        self.calls.append(messages)
+        if not self._responses:
+            raise AssertionError("gateway out of scripted responses")
+        chunk = self._responses.pop(0)
+        for ch in [chunk]:
+            yield ch
+
+    async def close(self) -> None:
+        pass
+
+
+@pytest.fixture
+def problem() -> ProblemInput:
+    return ProblemInput(problem_text="Compute 1+2 and print the answer.")
+
+
+@pytest.fixture
+def analysis() -> AnalyzerOutput:
+    return AnalyzerOutput(
+        restated_problem="Print the integer seven using Python.",
+        sub_questions=["what is the answer"],
+        proposed_approaches=[
+            ApproachSketch(
+                name="direct",
+                rationale="trivial arithmetic",
+                methods=["arithmetic"],
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def spec() -> ModelSpec:
+    return ModelSpec(
+        chosen_approach="direct arithmetic in Python",
+        rationale="trivial problem with one operation",
+        algorithm_outline=["compute the value", "print result"],
+        validation_strategy="visual inspection of output",
+    )
+
+
+async def test_coder_skill_tool_roundtrip(
+    tmp_path: Path,
+    problem: ProblemInput,
+    analysis: AnalyzerOutput,
+    spec: ModelSpec,
+) -> None:
+    """Mocked Coder turn calls get_skill, receives body, then executes code.
+
+    Sequence:
+    1. Turn 1: directive sets ``skill_request="matlab_x"`` — no code yet.
+       Loop dispatches SkillTool, splices body into messages, re-asks
+       WITHOUT advancing the iteration counter.
+    2. Turn 2: directive with ``skill_request=null`` and ``done=true``,
+       real code that prints 7.
+    3. Output has exactly one executed cell; the messages transcript
+       contains the skill body verbatim (proof it landed in context).
+    """
+    reg = _make_registry()
+    gateway = _ScriptedGateway(
+        [
+            # First call: ask for the matlab skill body.
+            (
+                '{"reasoning":"need matlab patterns",'
+                '"code":"",'
+                '"done":false,'
+                '"summary":null,'
+                '"skill_request":"matlab_x"}'
+            ),
+            # Second call: now armed with the body, execute the real code.
+            (
+                '{"reasoning":"got the skill, run the code",'
+                '"code":"print(7)",'
+                '"done":true,'
+                '"summary":"Printed 7."}'
+            ),
+        ]
+    )
+    emitter = _FakeEmitter()
+    kernel = KernelSession(uuid4(), tmp_path)
+
+    agent = CoderAgent(
+        gateway,  # type: ignore[arg-type]
+        emitter,  # type: ignore[arg-type]
+        kernel,
+        skill_registry=reg,
+    )
+    output = await agent.run(problem, analysis, spec)
+
+    # Real iteration count was 1 — the skill lookup must NOT have burned an iteration.
+    assert len(gateway.calls) == 2, "expected two LLM calls (one lookup, one exec)"
+    assert len(output.cells) == 1
+    assert "7" in output.cells[0].stdout
+    assert output.final_summary == "Printed 7."
+
+    # The skill body was spliced into the message transcript before turn 2.
+    second_call_messages = gateway.calls[1]
+    transcript = "\n".join(
+        m.get("content", "") for m in second_call_messages if isinstance(m, dict)
+    )
+    assert "SENTINEL-BODY-MATLAB-XYZ123" in transcript, (
+        "skill body must appear in transcript so subsequent turns see it"
+    )
+
+    # A `log` event records the skill_tool dispatch.
+    log_events = [e for e in emitter.events if e[0] == "log"]
+    skill_logs = [
+        e for e in log_events if "skill_tool" in e[1].get("message", "")
+    ]
+    assert skill_logs, "expected at least one skill_tool log event"
+    assert "matlab_x" in skill_logs[0][1]["message"]
+
+
+async def test_coder_skill_tool_unknown_name_error_recovery(
+    tmp_path: Path,
+    problem: ProblemInput,
+    analysis: AnalyzerOutput,
+    spec: ModelSpec,
+) -> None:
+    """Unknown skill name produces a structured error and the loop continues."""
+    reg = _make_registry()
+    gateway = _ScriptedGateway(
+        [
+            # Ask for a nonexistent skill.
+            (
+                '{"reasoning":"oops typo",'
+                '"code":"",'
+                '"done":false,'
+                '"summary":null,'
+                '"skill_request":"matlab_z"}'
+            ),
+            # Recover and execute.
+            (
+                '{"reasoning":"recovered",'
+                '"code":"print(\\"ok\\")",'
+                '"done":true,'
+                '"summary":"recovered"}'
+            ),
+        ]
+    )
+    emitter = _FakeEmitter()
+    kernel = KernelSession(uuid4(), tmp_path)
+    agent = CoderAgent(
+        gateway,  # type: ignore[arg-type]
+        emitter,  # type: ignore[arg-type]
+        kernel,
+        skill_registry=reg,
+    )
+    output = await agent.run(problem, analysis, spec)
+
+    assert len(output.cells) == 1
+    assert output.final_summary == "recovered"
+    # Error message landed in transcript so the model knew to retry.
+    transcript = "\n".join(
+        m.get("content", "")
+        for m in gateway.calls[1]
+        if isinstance(m, dict)
+    )
+    assert "matlab_z" in transcript
+    assert "Available skills" in transcript or "Error" in transcript

--- a/apps/web/src/components/AppBar.vue
+++ b/apps/web/src/components/AppBar.vue
@@ -29,18 +29,21 @@ const route = useRoute();
         <RouterLink
           :to="{ name: 'showcase' }"
           :class="{ on: route.name === 'showcase' }"
+          :aria-current="route.name === 'showcase' ? 'page' : undefined"
         >
           <T en="Overview" zh="概览" />
         </RouterLink>
         <RouterLink
           :to="{ name: 'dashboard' }"
           :class="{ on: route.name === 'dashboard' }"
+          :aria-current="route.name === 'dashboard' ? 'page' : undefined"
         >
           <T en="Dashboard" zh="仪表盘" />
         </RouterLink>
         <RouterLink
           :to="{ name: 'workbench' }"
           :class="{ on: route.name === 'workbench' }"
+          :aria-current="route.name === 'workbench' ? 'page' : undefined"
         >
           <T en="Workbench" zh="工作台" />
         </RouterLink>

--- a/apps/web/src/components/EventLog.vue
+++ b/apps/web/src/components/EventLog.vue
@@ -13,6 +13,11 @@ import type { AgentEvent } from "@mathodology/contracts";
 import { useRunStore } from "@/stores/run";
 import { useI18n } from "@/composables/useI18n";
 import { useCountUp } from "@/composables/useCountUp";
+import {
+  formatCurrency,
+  formatTimeHMS,
+  formatTokenCount,
+} from "@/utils/format";
 import T from "./T.vue";
 
 const props = defineProps<{ runId: string; now: number }>();
@@ -39,9 +44,7 @@ interface Line {
 }
 
 function fmtTime(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "--:--:--";
-  return d.toLocaleTimeString("en-GB", { hour12: false });
+  return formatTimeHMS(iso, i18n.lang);
 }
 
 function agentLabel(ev: AgentEvent): string {
@@ -77,7 +80,9 @@ function lineFor(ev: AgentEvent): Line | null {
       const dur =
         typeof p.duration_ms === "number" ? (p.duration_ms / 1000).toFixed(1) + "s" : null;
       const cost =
-        typeof p.cost_rmb === "number" ? `¥${p.cost_rmb.toFixed(3)}` : null;
+        typeof p.cost_rmb === "number"
+          ? formatCurrency(p.cost_rmb, i18n.lang, 3)
+          : null;
       const parts = ["✓", dur, cost].filter((x): x is string => typeof x === "string");
       msg = parts.join(" · ");
       break;
@@ -97,7 +102,9 @@ function lineFor(ev: AgentEvent): Line | null {
       const p = ev.payload as { model?: unknown; delta_rmb?: unknown };
       const model = typeof p.model === "string" ? p.model : "—";
       const delta =
-        typeof p.delta_rmb === "number" ? `¥${p.delta_rmb.toFixed(3)}` : "";
+        typeof p.delta_rmb === "number"
+          ? formatCurrency(p.delta_rmb, i18n.lang, 3)
+          : "";
       cls = "lv-info";
       msg = `${escapeHtml(model)} · ${delta}`;
       break;
@@ -113,7 +120,9 @@ function lineFor(ev: AgentEvent): Line | null {
       const p = ev.payload as { status?: unknown; cost_rmb?: unknown };
       const status = typeof p.status === "string" ? p.status : "done";
       const cost =
-        typeof p.cost_rmb === "number" ? ` · ¥${p.cost_rmb.toFixed(3)}` : "";
+        typeof p.cost_rmb === "number"
+          ? ` · ${formatCurrency(p.cost_rmb, i18n.lang, 3)}`
+          : "";
       msg = `run ${escapeHtml(status)}${cost}`;
       agentCls = "lv-info";
       break;
@@ -241,7 +250,13 @@ const elapsedMs = computed(() => {
 // `—`; once it's done we freeze the value at the final elapsed time so the
 // viewer sees the actual total.
 const estTotalMs = computed<number | null>(() => {
-  if (run.status === "done" || run.status === "failed") return elapsedMs.value;
+  if (
+    run.status === "done" ||
+    run.status === "failed" ||
+    run.status === "cancelled"
+  ) {
+    return elapsedMs.value;
+  }
   return null;
 });
 
@@ -255,8 +270,7 @@ function fmtMs(ms: number | null): string {
 }
 
 function fmtK(n: number): string {
-  if (n < 1000) return String(n);
-  return `${(n / 1000).toFixed(1)}k`;
+  return formatTokenCount(n, i18n.lang);
 }
 
 // --- motion: smooth count-up for cost + token totals in the footer --------

--- a/apps/web/src/components/FinetuneChat.vue
+++ b/apps/web/src/components/FinetuneChat.vue
@@ -14,7 +14,10 @@ import { computed, nextTick, ref, watch } from "vue";
 import { Marked } from "marked";
 import { useFinetuneStore } from "@/stores/finetune";
 import type { Message, ToolCall } from "@/stores/finetune";
+import { useI18n } from "@/composables/useI18n";
 import T from "./T.vue";
+
+const i18n = useI18n();
 
 const props = defineProps<{ runId: string }>();
 const emit = defineEmits<{
@@ -260,7 +263,10 @@ const messages = computed<Message[]>(() => store.messages);
                 class="ft-reasoning"
                 :open="expandedReasoning.has(m.id)"
               >
-                <summary @click.prevent="toggleReasoning(m.id)">
+                <summary
+                  :aria-expanded="expandedReasoning.has(m.id)"
+                  @click.prevent="toggleReasoning(m.id)"
+                >
                   <span class="mono ft-reasoning-toggle">
                     {{ expandedReasoning.has(m.id) ? "▾" : "▸" }}
                     <T en="reasoning" zh="推理" />
@@ -302,6 +308,12 @@ const messages = computed<Message[]>(() => store.messages);
                       v-if="entry.truncated"
                       type="button"
                       class="ft-arg-toggle mono"
+                      :aria-expanded="expandedToolArgs.has(tc.id)"
+                      :aria-label="
+                        expandedToolArgs.has(tc.id)
+                          ? i18n.t('Collapse tool args', '收起参数')
+                          : i18n.t('Expand tool args', '展开参数')
+                      "
                       @click="toggleToolArgs(tc.id)"
                     >
                       {{ expandedToolArgs.has(tc.id) ? "−" : "+" }}

--- a/apps/web/src/components/LangToggle.vue
+++ b/apps/web/src/components/LangToggle.vue
@@ -9,6 +9,7 @@ const i18n = useI18n();
     <button
       type="button"
       :class="{ on: i18n.lang === 'en' }"
+      :aria-pressed="i18n.lang === 'en'"
       @click="i18n.toggle('en')"
     >
       EN
@@ -16,6 +17,7 @@ const i18n = useI18n();
     <button
       type="button"
       :class="{ on: i18n.lang === 'zh' }"
+      :aria-pressed="i18n.lang === 'zh'"
       @click="i18n.toggle('zh')"
     >
       中文

--- a/apps/web/src/components/ProblemCard.vue
+++ b/apps/web/src/components/ProblemCard.vue
@@ -79,6 +79,7 @@ function submit() {
             type="button"
             :disabled="disabled || mode === 'active'"
             :class="{ on: (mode === 'active' ? (competition ?? '').toLowerCase() === c.id : settings.competition === c.id) }"
+            :aria-pressed="(mode === 'active' ? (competition ?? '').toLowerCase() === c.id : settings.competition === c.id)"
             @click="pickCompetition(c.id)"
           >
             {{ i18n.t(c.en, c.zh) }}

--- a/apps/web/src/components/SearchConfigPanel.vue
+++ b/apps/web/src/components/SearchConfigPanel.vue
@@ -308,6 +308,7 @@ const tavilyDepthDisabled = computed(() => store.effectivePrimary !== "tavily");
             :key="d.id"
             type="button"
             :class="{ on: store.tavily_depth === d.id }"
+            :aria-pressed="store.tavily_depth === d.id"
             :disabled="readonly || tavilyDepthDisabled"
             @click="onDepth(d.id)"
           >

--- a/apps/web/src/components/SettingsPanel.vue
+++ b/apps/web/src/components/SettingsPanel.vue
@@ -143,6 +143,7 @@ const isReasoningModel = computed(() => REASONING_MODEL_RE.test(settings.model))
             :key="e.id"
             type="button"
             :class="{ on: settings.reasoningEffort === e.id }"
+            :aria-pressed="settings.reasoningEffort === e.id"
             :disabled="readonly"
             @click="settings.setReasoningEffort(e.id)"
           >
@@ -165,6 +166,7 @@ const isReasoningModel = computed(() => REASONING_MODEL_RE.test(settings.model))
           <button
             type="button"
             :class="{ on: !settings.longContext }"
+            :aria-pressed="!settings.longContext"
             :disabled="readonly"
             @click="settings.setLongContext(false)"
           >
@@ -173,6 +175,7 @@ const isReasoningModel = computed(() => REASONING_MODEL_RE.test(settings.model))
           <button
             type="button"
             :class="{ on: settings.longContext }"
+            :aria-pressed="settings.longContext"
             :disabled="readonly"
             @click="settings.setLongContext(true)"
           >
@@ -195,6 +198,7 @@ const isReasoningModel = computed(() => REASONING_MODEL_RE.test(settings.model))
             :key="r.id"
             type="button"
             :class="{ on: settings.routing === r.id }"
+            :aria-pressed="settings.routing === r.id"
             :disabled="readonly"
             @click="settings.setRouting(r.id)"
           >
@@ -211,6 +215,7 @@ const isReasoningModel = computed(() => REASONING_MODEL_RE.test(settings.model))
             :key="n"
             type="button"
             :class="{ on: settings.retry === n }"
+            :aria-pressed="settings.retry === n"
             :disabled="readonly"
             @click="settings.setRetry(n)"
           >
@@ -225,6 +230,7 @@ const isReasoningModel = computed(() => REASONING_MODEL_RE.test(settings.model))
           <button
             type="button"
             :class="{ on: !settings.hmml }"
+            :aria-pressed="!settings.hmml"
             :disabled="readonly"
             @click="settings.setHmml(false)"
           >
@@ -233,6 +239,7 @@ const isReasoningModel = computed(() => REASONING_MODEL_RE.test(settings.model))
           <button
             type="button"
             :class="{ on: settings.hmml }"
+            :aria-pressed="settings.hmml"
             :disabled="readonly"
             @click="settings.setHmml(true)"
           >

--- a/apps/web/src/components/StagePills.vue
+++ b/apps/web/src/components/StagePills.vue
@@ -11,6 +11,7 @@ import { computed, ref, watch } from "vue";
 import type { AgentEvent, AgentName } from "@mathodology/contracts";
 import { useRunStore } from "@/stores/run";
 import { useI18n } from "@/composables/useI18n";
+import { formatCurrency } from "@/utils/format";
 
 const props = defineProps<{ now: number }>();
 
@@ -101,7 +102,7 @@ function fmtDuration(ms: number | null): string {
 function detail(p: Pill): string {
   if (p.state === "q") return i18n.t("queued", "排队中");
   const dur = fmtDuration(p.durationMs);
-  if (p.costRmb > 0) return `${dur} · ¥${p.costRmb.toFixed(3)}`;
+  if (p.costRmb > 0) return `${dur} · ${formatCurrency(p.costRmb, i18n.lang, 3)}`;
   return dur;
 }
 

--- a/apps/web/src/stores/run.ts
+++ b/apps/web/src/stores/run.ts
@@ -4,7 +4,13 @@ import { http, devAuthToken } from "@/api/http";
 import { RunWsClient } from "@/api/ws";
 import { useFinetuneStore, isFinetuneKind } from "@/stores/finetune";
 
-export type RunStatus = "idle" | "queued" | "running" | "done" | "failed";
+export type RunStatus =
+  | "idle"
+  | "queued"
+  | "running"
+  | "done"
+  | "failed"
+  | "cancelled";
 
 interface RunCreated {
   run_id: string;
@@ -56,6 +62,9 @@ interface State {
   error: string | null;
   costRmb: number;
   wsConnected: boolean;
+  // True while the WS client is between attempts (closed but going to retry).
+  // Distinct from `!wsConnected` which can also mean "terminal / never opened".
+  wsReconnecting: boolean;
   tokens: Record<string, AgentStream>;
   usage: Record<string, AgentUsage>;
   outputs: Record<string, AgentOutput>;
@@ -106,6 +115,7 @@ export const useRunStore = defineStore("run", {
     error: null,
     costRmb: 0,
     wsConnected: false,
+    wsReconnecting: false,
     tokens: {},
     usage: {},
     outputs: {},
@@ -141,6 +151,7 @@ export const useRunStore = defineStore("run", {
       this.error = null;
       this.costRmb = 0;
       this.wsConnected = false;
+      this.wsReconnecting = false;
       this.tokens = {};
       this.usage = {};
       this.outputs = {};
@@ -197,10 +208,22 @@ export const useRunStore = defineStore("run", {
         handlers: {
           onOpen: () => {
             this.wsConnected = true;
+            this.wsReconnecting = false;
             if (this.status === "queued") this.status = "running";
           },
-          onClose: () => {
+          onClose: (ev) => {
             this.wsConnected = false;
+            // The RunWsClient already decides whether to attempt a reconnect
+            // (closedByUser, terminal, code 1000 → no retry). We mirror its
+            // rule here so the UI only shows "reconnecting" when one is
+            // actually scheduled. The terminal `done` event flips status
+            // and clears this on the next tick.
+            const willRetry =
+              ev.code !== 1000 &&
+              this.status !== "done" &&
+              this.status !== "failed" &&
+              this.status !== "cancelled";
+            this.wsReconnecting = willRetry;
           },
           onError: () => {
             this.wsConnected = false;
@@ -412,7 +435,16 @@ export const useRunStore = defineStore("run", {
             this.kernelCells[idx] = { ...existing, doneTs: ev.ts };
           }
         }
-        this.status = p.status === "failed" ? "failed" : "done";
+        // Three distinct terminal statuses. `cancelled` was added in round 7
+        // (gateway-signalled mid-run cancel). Treat anything unrecognized as
+        // `done` to stay forward-compatible with any future success label.
+        this.status =
+          p.status === "failed"
+            ? "failed"
+            : p.status === "cancelled"
+              ? "cancelled"
+              : "done";
+        this.wsReconnecting = false;
         return;
       }
     },

--- a/apps/web/src/utils/format.ts
+++ b/apps/web/src/utils/format.ts
@@ -1,0 +1,113 @@
+// Centralised i18n-aware formatters. Use these instead of ad-hoc
+// `toLocaleTimeString("en-GB", ...)` or `n.toFixed(2)` so the en/zh
+// switch in the top-right toggle actually propagates to the numbers and
+// dates the user sees in the header, dashboard, and feed.
+//
+// Lang argument is passed explicitly rather than read from the i18n
+// store so these stay usable from plain functions (no need to be a
+// composable). Callers pass `i18n.lang`.
+
+import type { Lang } from "@/composables/useI18n";
+
+const BCP47: Record<Lang, string> = {
+  en: "en-GB",
+  zh: "zh-CN",
+};
+
+// HH:mm:ss in 24-hour form. The original EventLog used a hardcoded
+// "en-GB" — same shape regardless of UI lang. We keep the 24-hour
+// convention (engineers expect logs in 24h regardless of locale) but
+// route through Intl so the digit script follows the active locale.
+const TIME_HMS_FMT = new Map<Lang, Intl.DateTimeFormat>();
+export function formatTimeHMS(iso: string, lang: Lang): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "--:--:--";
+  let f = TIME_HMS_FMT.get(lang);
+  if (!f) {
+    f = new Intl.DateTimeFormat(BCP47[lang], {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+    TIME_HMS_FMT.set(lang, f);
+  }
+  return f.format(d);
+}
+
+// HH:mm only. Used as the "started at" label in the run header.
+const TIME_HM_FMT = new Map<Lang, Intl.DateTimeFormat>();
+export function formatTimeHM(iso: string, lang: Lang): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "--:--";
+  let f = TIME_HM_FMT.get(lang);
+  if (!f) {
+    f = new Intl.DateTimeFormat(BCP47[lang], {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    TIME_HM_FMT.set(lang, f);
+  }
+  return f.format(d);
+}
+
+// "¥1,234.56" style. Numbers below 1000 don't show separators (Intl
+// handles that). Fraction digits are explicit so callers control
+// precision (header wants 3, dashboard wants 2).
+const CURRENCY_FMT = new Map<string, Intl.NumberFormat>();
+export function formatCurrency(
+  n: number,
+  lang: Lang,
+  fractionDigits: number = 2,
+): string {
+  if (typeof n !== "number" || Number.isNaN(n)) return "¥—";
+  const key = `${lang}:${fractionDigits}`;
+  let f = CURRENCY_FMT.get(key);
+  if (!f) {
+    f = new Intl.NumberFormat(BCP47[lang], {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    });
+    CURRENCY_FMT.set(key, f);
+  }
+  return `¥${f.format(n)}`;
+}
+
+// Percent display. We format the raw number (e.g. 87.5) and append %
+// rather than using Intl's percent style (which expects 0..1).
+const PERCENT_FMT = new Map<string, Intl.NumberFormat>();
+export function formatPercent(
+  n: number,
+  lang: Lang,
+  fractionDigits: number = 1,
+): string {
+  if (typeof n !== "number" || Number.isNaN(n)) return "—";
+  const key = `${lang}:${fractionDigits}`;
+  let f = PERCENT_FMT.get(key);
+  if (!f) {
+    f = new Intl.NumberFormat(BCP47[lang], {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    });
+    PERCENT_FMT.set(key, f);
+  }
+  return `${f.format(n)}%`;
+}
+
+// Compact token-count display: "1.2k" past a thousand, raw integer
+// below. Used in the per-agent usage chips.
+const TOKEN_FMT = new Map<Lang, Intl.NumberFormat>();
+export function formatTokenCount(n: number, lang: Lang): string {
+  if (typeof n !== "number" || Number.isNaN(n)) return "—";
+  let f = TOKEN_FMT.get(lang);
+  if (!f) {
+    f = new Intl.NumberFormat(BCP47[lang], {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
+    TOKEN_FMT.set(lang, f);
+  }
+  if (n < 1000) return n.toString();
+  return `${f.format(n / 1000)}k`;
+}

--- a/apps/web/src/views/Dashboard.vue
+++ b/apps/web/src/views/Dashboard.vue
@@ -17,6 +17,7 @@ import { http } from "@/api/http";
 import T from "@/components/T.vue";
 import { useI18n } from "@/composables/useI18n";
 import { useCountUp } from "@/composables/useCountUp";
+import { formatCurrency, formatPercent } from "@/utils/format";
 import {
   fetchSummary,
   fetchProviderShare,
@@ -200,7 +201,7 @@ function costTag(r: RunSummary): string {
   if (r.status === "queued") return "—";
   const c = r.cost_rmb;
   if (typeof c !== "number" || Number.isNaN(c)) return "—";
-  return `¥${c.toFixed(2)}`;
+  return formatCurrency(c, i18n.lang, 2);
 }
 
 // --- 7-day activity ---------------------------------------------------------
@@ -291,13 +292,13 @@ function barHeight(count: number): string {
         </div>
         <div class="stat">
           <div class="k"><T en="Success" zh="成功率" /></div>
-          <div class="v" v-if="hasRuns24h">{{ successDisplay.toFixed(1) }}%</div>
+          <div class="v" v-if="hasRuns24h">{{ formatPercent(successDisplay, i18n.lang, 1) }}</div>
           <div class="v" v-else-if="summaryLoaded">—</div>
           <div class="v dim-inline" v-else>…</div>
         </div>
         <div class="stat">
           <div class="k"><T en="Median cost" zh="成本中位" /></div>
-          <div class="v" v-if="costCellRender">¥ {{ costDisplay.toFixed(2) }}</div>
+          <div class="v" v-if="costCellRender">{{ formatCurrency(costDisplay, i18n.lang, 2) }}</div>
           <div class="v" v-else-if="summaryLoaded">—</div>
           <div class="v dim-inline" v-else>…</div>
         </div>
@@ -413,7 +414,7 @@ function barHeight(count: number): string {
                 class="mono"
                 style="font-size:11px; color:var(--ink-3);"
               >
-                ¥ {{ providers.total_cost_rmb.toFixed(2) }} · 7d
+                {{ formatCurrency(providers.total_cost_rmb, i18n.lang, 2) }} · 7d
               </span>
             </div>
             <div class="panel-b">
@@ -447,7 +448,7 @@ function barHeight(count: number): string {
                       ></span>
                     </div>
                   </div>
-                  <div class="pct">{{ p.share_pct.toFixed(1) }}%</div>
+                  <div class="pct">{{ formatPercent(p.share_pct, i18n.lang, 1) }}</div>
                 </div>
               </div>
             </div>

--- a/apps/web/src/views/Showcase.vue
+++ b/apps/web/src/views/Showcase.vue
@@ -10,6 +10,10 @@ import T from "@/components/T.vue";
 import { useCountUp } from "@/composables/useCountUp";
 import { useInView } from "@/composables/useInView";
 import { fetchSummary, type StatsSummary } from "@/api/stats";
+import { useI18n } from "@/composables/useI18n";
+import { formatCurrency, formatPercent } from "@/utils/format";
+
+const i18n = useI18n();
 
 const summary = ref<StatsSummary | null>(null);
 const loaded = ref(false);
@@ -296,7 +300,7 @@ const p95Cell = computed<StatCell>(() => ({
               <div class="stat-row" ref="statsStrip">
                 <div>
                   <div class="n" v-if="successCell.render">
-                    {{ successDisplay.toFixed(1) }}%
+                    {{ formatPercent(successDisplay, i18n.lang, 1) }}
                   </div>
                   <div class="n" v-else>—</div>
                   <div class="l">
@@ -308,7 +312,7 @@ const p95Cell = computed<StatCell>(() => ({
                 </div>
                 <div>
                   <div class="n" v-if="costCell.render">
-                    ¥ {{ costDisplay.toFixed(2) }}
+                    {{ formatCurrency(costDisplay, i18n.lang, 2) }}
                   </div>
                   <div class="n" v-else>—</div>
                   <div class="l">

--- a/apps/web/src/views/Workbench.vue
+++ b/apps/web/src/views/Workbench.vue
@@ -12,6 +12,7 @@ import { http } from "@/api/http";
 import { useRunStore } from "@/stores/run";
 import { useI18n } from "@/composables/useI18n";
 import { useCountUp } from "@/composables/useCountUp";
+import { formatCurrency, formatTimeHM } from "@/utils/format";
 import StagePills from "@/components/StagePills.vue";
 import ProblemCard from "@/components/ProblemCard.vue";
 import SettingsPanel from "@/components/SettingsPanel.vue";
@@ -101,13 +102,17 @@ async function cancelRun(): Promise<void> {
 }
 
 // Cancel button is only useful while the pipeline is still in flight.
-// Treat "queued" + "running" as in-flight; anything else (done / failed /
-// future "cancelled") hides the button. Store's RunStatus doesn't yet
-// model "cancelled" — that's a follow-up; the gateway emits done.status =
-// "cancelled" and the audit task persists it to runs.status.
+// "cancelled" is a terminal status (round 7) — once it lands the button
+// disappears alongside done/failed.
 const isInFlight = computed<boolean>(() =>
   run.status === "running" || run.status === "queued"
 );
+
+// "Reconnecting…" chip lives in the header next to the cost. We show it
+// whenever the WS client is between attempts but the run hasn't reached
+// a terminal state. The store mirrors RunWsClient's reconnect decision so
+// this flag is accurate without a separate timer.
+const showReconnect = computed<boolean>(() => run.wsReconnecting);
 
 watch(
   routeRunId,
@@ -151,9 +156,13 @@ async function onPaperUpdated(): Promise<void> {
 
 // --- start a new run from the empty-state form ------------------------------
 async function onStart(payload: { problemText: string }) {
-  // Reset any leftover error / done state from a prior attempt so the guard
-  // in startRun doesn't swallow the new submission.
-  if (run.status === "failed" || run.status === "done") {
+  // Reset any leftover terminal state so the guard in startRun doesn't
+  // swallow the new submission. "cancelled" was added in round 7.
+  if (
+    run.status === "failed" ||
+    run.status === "done" ||
+    run.status === "cancelled"
+  ) {
     run.reset();
   }
   await run.startRun(payload.problemText, {
@@ -190,9 +199,7 @@ const firstLine = computed<string>(() => {
 const startLabel = computed<string>(() => {
   const iso = runRecord.value?.created_at;
   if (!iso) return "—";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "—";
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return formatTimeHM(iso, i18n.lang);
 });
 
 // Tween the header cost so live ¥ updates feel continuous, matching the
@@ -375,7 +382,23 @@ function agentTitle(agent: string): { en: string; zh: string; num: string } {
                 <T en="started" zh="开始于" /> {{ startLabel }}
               </span>
               <span>·</span>
-              <span>¥ {{ costDisplay.toFixed(3) }}</span>
+              <span>{{ formatCurrency(costDisplay, i18n.lang, 3) }}</span>
+              <span
+                v-if="showReconnect"
+                class="reconnect-pill"
+                role="status"
+                aria-live="polite"
+              >
+                <span class="reconnect-dot" aria-hidden="true"></span>
+                <T en="reconnecting…" zh="正在重连…" />
+              </span>
+              <span
+                v-else-if="run.status === 'cancelled'"
+                class="cancelled-pill"
+                role="status"
+              >
+                <T en="cancelled" zh="已取消" />
+              </span>
             </div>
           </div>
           <div style="display:flex; gap:8px;">
@@ -385,11 +408,27 @@ function agentTitle(agent: string): { en: string; zh: string; num: string } {
             <button
               v-if="isInFlight"
               class="btn ghost"
+              type="button"
               :disabled="cancelInFlight"
+              :aria-busy="cancelInFlight || undefined"
+              :aria-label="
+                cancelInFlight
+                  ? i18n.t('Cancelling run…', '正在取消运行…')
+                  : i18n.t('Cancel this run', '取消本次运行')
+              "
               @click="cancelRun"
             >
               <span aria-hidden="true">■</span>
-              <T en="Cancel" zh="取消" />
+              <T
+                v-if="!cancelInFlight"
+                en="Cancel"
+                zh="取消"
+              />
+              <T
+                v-else
+                en="Cancelling…"
+                zh="取消中…"
+              />
             </button>
             <RouterLink class="btn hi" :to="{ name: 'workbench' }">
               <span aria-hidden="true">▶</span> <T en="New run" zh="新建运行" />
@@ -536,5 +575,37 @@ function agentTitle(agent: string): { en: string; zh: string; num: string } {
   font-family: 'Inter', sans-serif;
   font-weight: 600;
   font-size: 12.5px;
+}
+.reconnect-pill,
+.cancelled-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 1px 7px;
+  border-radius: 2px;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  font-family: 'JetBrains Mono', monospace;
+}
+.reconnect-pill {
+  border: 1px solid var(--warn, #C77B40);
+  color: #6B3A14;
+  background: #FBEAD6;
+}
+.cancelled-pill {
+  border: 1px solid var(--rule-soft, #D7D2C8);
+  color: var(--ink-3, #5C544A);
+  background: transparent;
+}
+.reconnect-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--warn, #C77B40);
+  animation: reconnect-pulse 1.1s ease-in-out infinite;
+}
+@keyframes reconnect-pulse {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 1; }
 }
 </style>

--- a/crates/gateway/src/routes/runs.rs
+++ b/crates/gateway/src/routes/runs.rs
@@ -185,6 +185,11 @@ pub async fn finetune_run(
 pub struct CancelAccepted {
     pub run_id: Uuid,
     pub status: &'static str,
+    /// True when this POST flipped the cancel flag; false when the flag
+    /// was already set by an earlier click (idempotent). Lets the UI
+    /// distinguish "cancel sent" from "already cancelling" without
+    /// needing a second round-trip.
+    pub already_signalled: bool,
 }
 
 /// `POST /runs/:run_id/cancel` — signal the worker to halt the run.
@@ -215,6 +220,7 @@ pub async fn cancel_run(
         Json(CancelAccepted {
             run_id,
             status: "cancel_signalled",
+            already_signalled: !newly_set,
         }),
     ))
 }


### PR DESCRIPTION
## Summary
Round-8 bundles four independent improvement tracks against fine-tune ergonomics, Coder prompt economics, and frontend a11y/i18n.

- **Worker — Surgical edit tool for PaperEditor.** Anthropic-Edit-style exact-string find/replace with uniqueness check, optional `section_title` scoping, and `replace_all` override. Coexists with the full-rewrite `edit_section` (model picks based on edit footprint, ~30% threshold). Mutates `paper.meta.json` and re-renders `paper.md` so the two never drift. +11 tests.

- **Worker — SkillTool on-demand body loading.** `SkillRegistry.render_menu()` puts the frontmatter-only menu in the agent's system prompt; `get_skill(name)` loads a single body only when the model decides it needs one. CoderAgent defaults `use_skill_tool=True` with a 6-lookup budget that doesn't consume code iterations. Other agents accept the kwargs but stay on eager-load until proven safe. `pipeline.py` now wires `skill_registry=...` into CoderAgent so the optimization actually fires. +19 tests.

- **Gateway — Cancel endpoint idempotency hint.** `CancelAccepted` response gains `already_signalled: bool`, surfacing the existing `signal_cancel` `SET NX` return so the UI can distinguish a fresh cancel from a no-op retry without a second round-trip.

- **Frontend — i18n formatting + a11y polish.**
  - `apps/web/src/utils/format.ts`: Intl-cached helpers (`formatTimeHMS`, `formatTimeHM`, `formatCurrency`, `formatPercent`, `formatTokenCount`) replace hardcoded `en-GB` and ad-hoc `¥${n.toFixed(2)}` / `X.toFixed(1)%` across EventLog, Workbench, StagePills, Dashboard, Showcase. The en/zh toggle now propagates digit script and number conventions consistently.
  - `aria-pressed` on all segmented-control toggles (LangToggle, SettingsPanel × 5 groups, SearchConfigPanel depth, ProblemCard competition).
  - `aria-current="page"` on the three AppBar route links.
  - `aria-busy` + `aria-label` + visible "Cancelling…" label on the Workbench Cancel button during in-flight POST.
  - `aria-expanded` on FinetuneChat reasoning `<summary>` and tool-args +/− button.
  - WebSocket reconnect indicator: store mirrors `RunWsClient`'s reconnect decision into `wsReconnecting`; Workbench header shows a pulsing "reconnecting…" pill (`role=status`, `aria-live=polite`). Dedicated "cancelled" pill replaces the generic "done" treatment.
  - `RunStatus` extended with `cancelled`; reset-on-start + elapsed-time freeze updated in Workbench and EventLog.

## Concurrent-Critic audit (negative result)
Investigated overlapping Critic review of stage N with prep work for stage N+1. Verdict: ~3-5s realistic savings on a 90-min run because all heavy prep (HMML index, few-shot library, prompt templates) is already process-singleton-cached. **Not implementing.** Real lever surfaced: switch Critic to `gpt-5.4-mini` (it produces small JSON verdicts, not prose) — filed as a follow-up task for a future round.

## Test plan
- [x] `pytest -q` — 484 passing (was 454; +30 across surgical-edit + SkillTool suites).
- [x] `ruff check` clean.
- [x] `cargo check -p gateway` clean.
- [x] `pnpm typecheck` in `apps/web/` clean.
- [ ] End-to-end fine-tune smoke: dispatch a real run, ask PaperEditor to "fix the typo in section 3 paragraph 2", verify it uses `surgical_edit` not `edit_section`.
- [ ] End-to-end coder run: verify `get_skill` is called for MATLAB-tagged problems and the body lands in the conversation only after the model requests it.
- [ ] Spot-check WebSocket reconnect chip by killing the gateway mid-run.