### PR TITLE
feat: one-click competition submission bundle (mcm/cumcm/huashu)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +49,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -441,6 +456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +564,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +590,17 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -603,7 +649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -650,6 +696,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -799,6 +855,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "md-5",
  "redis",
  "reqwest",
  "serde",
@@ -817,6 +874,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wiremock",
+ "zip",
 ]
 
 [[package]]
@@ -1388,6 +1446,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,7 +1499,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2243,6 +2311,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -3253,7 +3327,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3549,7 +3623,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,17 @@ eventsource-stream = "0.2"
 hex = "0.4"
 wiremock = "=0.6.2"
 tempfile = "=3.14"
+# `zip` 2.x — pure-Rust zip writer used by the submission-bundle endpoint.
+# Default features pull in bzip2/zstd C bindings we don't need; deflate alone
+# is plenty for paper+code archives, and dropping the C deps keeps the
+# cargo-deb / Linux CI build hermetic.
+zip = { version = "2", default-features = false, features = ["deflate"] }
+# md-5: pure-Rust MD5 used by the submission-bundle MD5.txt manifest.
+# CUMCM's submission protocol explicitly asks for MD5 codes (cnki.net uses
+# them as integrity checks against the uploaded files), so SHA-256 isn't a
+# substitute. Cryptographic weakness is acceptable here — this is integrity,
+# not authentication.
+md-5 = "0.10"
 
 [profile.dev]
 opt-level = 0

--- a/apps/agent-worker/src/agent_worker/gateway_client.py
+++ b/apps/agent-worker/src/agent_worker/gateway_client.py
@@ -65,6 +65,40 @@ class GatewayClient:
         resp.raise_for_status()
         return resp.content
 
+    async def export_submission(
+        self,
+        *,
+        run_id: UUID,
+        template: str | None = None,
+        compile_timeout_s: float = 600.0,
+    ) -> bytes:
+        """Fetch the competition-specific submission bundle as a ZIP.
+
+        Hits GET /runs/<id>/submission?template=<t>. The gateway:
+          * renders the main paper PDF (with appropriate cover letter /
+            AI-use report per the chosen competition),
+          * for CUMCM, also renders an anonymous-variant PDF + the
+            支撑材料.zip sub-archive,
+          * packs everything into a single ZIP whose layout matches the
+            target competition's upload spec.
+
+        Returns the raw ZIP bytes. Cumcm/Huashu rendering does two
+        tectonic compiles + a pandoc docx pass, so the timeout is
+        deliberately generous.
+        """
+        url = f"{self._base}/runs/{run_id}/submission"
+        params: dict[str, str] = {}
+        if template:
+            params["template"] = template
+        resp = await self._client.get(
+            url,
+            headers=self._headers,
+            params=params or None,
+            timeout=httpx.Timeout(compile_timeout_s, connect=5.0, read=compile_timeout_s),
+        )
+        resp.raise_for_status()
+        return resp.content
+
     def _build_headers(self, run_id: UUID, agent: str) -> dict[str, str]:
         return {
             **self._headers,

--- a/apps/web/src/api/export.ts
+++ b/apps/web/src/api/export.ts
@@ -90,3 +90,50 @@ export async function exportPaper(params: ExportParams): Promise<void> {
   // revoked synchronously.
   setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
 }
+
+/**
+ * Fetch the competition-specific submission bundle ZIP and trigger
+ * download. The gateway packs cover-letter / 编号专用页 / 支撑材料 /
+ * MD5 manifest / AI-use report per the chosen template so the file
+ * downloaded here is the exact payload the team uploads to the contest
+ * platform (modulo COMAP's rename-to-control-number step, noted in the
+ * bundled README.txt).
+ */
+export async function downloadSubmissionBundle(params: {
+  runId: string;
+  template: ExportTemplate;
+}): Promise<void> {
+  const url =
+    `${BASE}/runs/${params.runId}/submission?template=` +
+    encodeURIComponent(params.template);
+  const headers = new Headers({ accept: "application/zip" });
+  if (TOKEN) headers.set("authorization", `Bearer ${TOKEN}`);
+
+  const res = await fetch(url, { method: "GET", headers });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    const err = new Error(
+      `HTTP ${res.status} ${res.statusText} for ${url}`,
+    ) as ExportError;
+    err.status = res.status;
+    if (text) err.detail = text.slice(0, 200);
+    throw err;
+  }
+
+  const blob = await res.blob();
+  const cd = res.headers.get("content-disposition") ?? "";
+  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(cd);
+  const fallback = `submission-${params.template}-${params.runId.slice(0, 8)}.zip`;
+  const filename = match?.[1] ? decodeURIComponent(match[1]) : fallback;
+
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = objectUrl;
+  a.download = filename;
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+}

--- a/apps/web/src/components/ExportPanel.vue
+++ b/apps/web/src/components/ExportPanel.vue
@@ -13,6 +13,7 @@ import T from "./T.vue";
 import { useI18n } from "@/composables/useI18n";
 import {
   exportPaper,
+  downloadSubmissionBundle,
   type ExportFormat,
   type ExportTemplate,
   type ExportError,
@@ -159,6 +160,28 @@ async function onExport(spec: FormatSpec) {
     busy.value = { ...busy.value, [spec.id]: false };
   }
 }
+
+// Submission-bundle button has its own loading flag separate from per-
+// format ones so a long bundle render doesn't grey-out the per-format
+// buttons (a CUMCM bundle does two tectonic compiles + a pandoc pass,
+// expect ~30-90s on a warm cache).
+const bundleBusy = ref(false);
+async function onDownloadBundle() {
+  if (bundleBusy.value || !props.paperReady) return;
+  lastError.value = null;
+  bundleBusy.value = true;
+  try {
+    await downloadSubmissionBundle({
+      runId: props.runId,
+      template: template.value,
+    });
+  } catch (err) {
+    console.error("[ExportPanel] submission bundle failed", err);
+    lastError.value = messageForError(err);
+  } finally {
+    bundleBusy.value = false;
+  }
+}
 </script>
 
 <template>
@@ -220,6 +243,44 @@ async function onExport(spec: FormatSpec) {
         </div>
       </div>
 
+      <div class="field bundle-field">
+        <label>
+          <T en="Competition Submission Bundle" zh="竞赛提交压缩包" />
+        </label>
+        <button
+          type="button"
+          class="btn hi bundle-btn"
+          :disabled="!paperReady || bundleBusy || anyBusy"
+          :title="
+            !paperReady
+              ? i18n.t('Paper not ready', '论文未就绪')
+              : i18n.t(
+                  'Download competition-ready ZIP (paper + cover letter + supporting materials + MD5)',
+                  '下载竞赛级提交压缩包（论文 + 承诺书 + 支撑材料 + MD5）',
+                )
+          "
+          @click="onDownloadBundle"
+        >
+          <template v-if="bundleBusy">
+            <span class="spinner" aria-hidden="true">○</span>
+            <T en="…packaging" zh="打包中…" />
+          </template>
+          <template v-else>
+            <span class="fmt-icon mono" aria-hidden="true">ZIP</span>
+            <T
+              en="Submission Bundle (.zip)"
+              zh="提交压缩包 (.zip)"
+            />
+          </template>
+        </button>
+        <p class="bundle-hint">
+          <T
+            en="One-click pack: paper PDF + (per template) cover letter / supporting materials / AI-use report / MD5 manifest. Layout matches the upload spec for the selected competition."
+            zh="一键打包：论文 PDF + 按所选竞赛附带承诺书 / 支撑材料 / AI 使用报告 / MD5 校验码,目录结构与官方上传要求一致。"
+          />
+        </p>
+      </div>
+
       <div
         v-if="lastError"
         class="export-error"
@@ -275,6 +336,23 @@ async function onExport(spec: FormatSpec) {
   line-height: 1.5;
   color: #6B1F0C;
   word-break: break-word;
+}
+
+.bundle-field {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--rule);
+}
+.bundle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.bundle-hint {
+  margin: 8px 0 0 0;
+  font-size: 10.5px;
+  line-height: 1.5;
+  color: var(--ink-3);
 }
 
 @media (max-width: 560px) {

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -44,6 +44,8 @@ config = { workspace = true }
 toml = { workspace = true }
 tera = "=1.19"
 tempfile = { workspace = true }
+zip = { workspace = true }
+md-5 = { workspace = true }
 
 [dev-dependencies]
 wiremock = { workspace = true }

--- a/crates/gateway/src/app.rs
+++ b/crates/gateway/src/app.rs
@@ -4,7 +4,7 @@ use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 
 use crate::auth::require_dev_token;
-use crate::routes::{export, figures, health, llm, runs, search, stats, ws_run};
+use crate::routes::{export, figures, health, llm, runs, search, stats, submission, ws_run};
 use crate::state::AppState;
 
 pub fn build_router(state: AppState) -> Router {
@@ -19,6 +19,10 @@ pub fn build_router(state: AppState) -> Router {
         .route("/runs/:run_id/notebook", get(figures::serve_notebook))
         .route("/runs/:run_id/paper", get(figures::serve_paper))
         .route("/runs/:run_id/export/:format", get(export::export_paper))
+        .route(
+            "/runs/:run_id/submission",
+            get(submission::export_submission),
+        )
         .route("/ws/runs/:run_id", get(ws_run::ws_handler))
         .route("/llm/chat/completions", post(llm::chat_completions))
         .route("/stats/summary", get(stats::stats_summary))

--- a/crates/gateway/src/dispatch.rs
+++ b/crates/gateway/src/dispatch.rs
@@ -60,10 +60,7 @@ pub fn cancel_key(run_id: &Uuid) -> String {
 /// SET mm:cancel:<run_id> = "1" with TTL, signalling the worker to halt
 /// the pipeline at its next stage boundary. Returns `true` if newly set,
 /// `false` if it was already set (idempotent).
-pub async fn signal_cancel(
-    redis: &mut ConnectionManager,
-    run_id: &Uuid,
-) -> Result<bool, AppError> {
+pub async fn signal_cancel(redis: &mut ConnectionManager, run_id: &Uuid) -> Result<bool, AppError> {
     let key = cancel_key(run_id);
     // SET key "1" EX <ttl> NX so a second click doesn't reset the TTL.
     let was_set: Option<String> = redis::cmd("SET")

--- a/crates/gateway/src/llm/cost.rs
+++ b/crates/gateway/src/llm/cost.rs
@@ -113,8 +113,7 @@ pub async fn record_completion_cost(
         // delta is fine (no-op net) and we still call it so the key
         // exists eagerly for the run.
         let cost_redis_key = cost_key(&rid);
-        let _: redis::RedisResult<f64> =
-            redis.incr(cost_redis_key, delta).await;
+        let _: redis::RedisResult<f64> = redis.incr(cost_redis_key, delta).await;
 
         // XADD kind=cost event to the run stream. Seq from shared counter.
         let seq = next_seq(redis, &rid).await?;

--- a/crates/gateway/src/llm/cost.rs
+++ b/crates/gateway/src/llm/cost.rs
@@ -5,6 +5,9 @@
 //! Postgres NUMERIC (same trick as M2's GET /runs/:id) so we don't need the
 //! bigdecimal sqlx feature.
 
+use std::io::Write;
+use std::path::Path;
+
 use chrono::Utc;
 use redis::aio::ConnectionManager;
 use redis::AsyncCommands;
@@ -46,6 +49,7 @@ pub async fn record_completion_cost(
     pg: &sqlx::PgPool,
     redis: &mut ConnectionManager,
     prices: &PriceTable,
+    runs_dir: &Path,
     run_id: Option<Uuid>,
     agent: Option<&str>,
     model: &str,
@@ -138,6 +142,56 @@ pub async fn record_completion_cost(
                 &[("payload", payload_str.as_str())],
             )
             .await?;
+
+        // Mirror to <runs_dir>/<run_id>/events.jsonl so the forensic log
+        // (and the submission-bundle AI Use Report aggregator) sees every
+        // cost event. The worker's EventEmitter only persists events it
+        // emits itself; cost events are produced *here*, server-side,
+        // and the worker never sees them. Without this, the on-disk
+        // jsonl is missing every LLM call — verified across 44 real runs
+        // pre-fix (all had 0 cost events on disk despite hundreds of
+        // calls in the Redis stream).
+        //
+        // Best-effort: failures (run dir not yet created, fs full, etc.)
+        // log + continue. The Redis stream remains the authoritative
+        // live source; this disk mirror is for forensics + submission
+        // bundle assembly only.
+        let mut jsonl_line = payload_str;
+        jsonl_line.push('\n');
+        let events_path = runs_dir.join(rid.to_string()).join("events.jsonl");
+        let _ = tokio::task::spawn_blocking(move || {
+            // O_APPEND + single write() under PIPE_BUF (4 KiB) is
+            // atomic against concurrent writers on POSIX — matches the
+            // worker's EventEmitter contract.
+            match std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&events_path)
+            {
+                Ok(mut f) => {
+                    if let Err(e) = f.write_all(jsonl_line.as_bytes()) {
+                        tracing::warn!(
+                            error = %e,
+                            path = %events_path.display(),
+                            "cost event events.jsonl append failed"
+                        );
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Run dir doesn't exist yet (orphan LLM call before
+                    // run row created) — silent skip, this branch is
+                    // already gated on run_id presence above.
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        path = %events_path.display(),
+                        "cost event events.jsonl open failed"
+                    );
+                }
+            }
+        })
+        .await;
     }
 
     Ok(delta)

--- a/crates/gateway/src/llm/providers/openai_compat.rs
+++ b/crates/gateway/src/llm/providers/openai_compat.rs
@@ -62,10 +62,7 @@ impl OpenAICompatAdapter {
                     obj.insert("name".into(), json!(n));
                 }
                 if m.cache_breakpoint {
-                    obj.insert(
-                        "cache_control".into(),
-                        json!({ "type": "ephemeral" }),
-                    );
+                    obj.insert("cache_control".into(), json!({ "type": "ephemeral" }));
                 }
                 Value::Object(obj)
             })
@@ -131,7 +128,8 @@ impl ProviderAdapter for OpenAICompatAdapter {
         // empty-string convention used by the Ollama-local case AND by
         // dead-key providers loaded from a missing env var). The Ollama
         // base URL exception keeps it functional offline.
-        !self.api_key.is_empty() || self.base_url.contains("127.0.0.1")
+        !self.api_key.is_empty()
+            || self.base_url.contains("127.0.0.1")
             || self.base_url.contains("localhost")
     }
 

--- a/crates/gateway/src/llm/router.rs
+++ b/crates/gateway/src/llm/router.rs
@@ -214,7 +214,11 @@ mod tests {
     }
 
     fn router_with(providers: Vec<Arc<dyn ProviderAdapter>>) -> Router {
-        Router::new(providers, "gpt-5.5".to_string(), vec!["gpt-5.4".to_string()])
+        Router::new(
+            providers,
+            "gpt-5.5".to_string(),
+            vec!["gpt-5.4".to_string()],
+        )
     }
 
     #[test]

--- a/crates/gateway/src/routes/export.rs
+++ b/crates/gateway/src/routes/export.rs
@@ -278,13 +278,23 @@ pub async fn export_paper(
     match fmt {
         ExportFormat::Md => unreachable!("handled above"),
         ExportFormat::Tex => {
-            let tex =
-                render_tex(&meta, template, &canonical_run_root, RenderExtras::default()).await?;
+            let tex = render_tex(
+                &meta,
+                template,
+                &canonical_run_root,
+                RenderExtras::default(),
+            )
+            .await?;
             build_binary_response(fmt, run_id, tex.into_bytes())
         }
         ExportFormat::Pdf => {
-            let tex =
-                render_tex(&meta, template, &canonical_run_root, RenderExtras::default()).await?;
+            let tex = render_tex(
+                &meta,
+                template,
+                &canonical_run_root,
+                RenderExtras::default(),
+            )
+            .await?;
             let pdf = compile_pdf(&tex).await?;
             build_binary_response(fmt, run_id, pdf)
         }
@@ -640,7 +650,10 @@ pub(crate) async fn compile_pdf(tex: &str) -> Result<Vec<u8>, AppError> {
         .map_err(|e| AppError::Internal(format!("read compiled pdf: {e}")))
 }
 
-pub(crate) async fn compile_docx(paper_md: &StdPath, run_root: &StdPath) -> Result<Vec<u8>, AppError> {
+pub(crate) async fn compile_docx(
+    paper_md: &StdPath,
+    run_root: &StdPath,
+) -> Result<Vec<u8>, AppError> {
     let tmp = tempfile::TempDir::new().map_err(|e| AppError::Internal(format!("tempdir: {e}")))?;
     let out_path = tmp.path().join("paper.docx");
 
@@ -775,7 +788,10 @@ fn latex_escape_filter(
 // Helpers shared with figures.rs (kept separate to avoid churning that file)
 // ---------------------------------------------------------------------------
 
-pub(crate) async fn resolve_within(prefix: &StdPath, requested: &StdPath) -> Result<PathBuf, AppError> {
+pub(crate) async fn resolve_within(
+    prefix: &StdPath,
+    requested: &StdPath,
+) -> Result<PathBuf, AppError> {
     let canonical_prefix = tokio::fs::canonicalize(prefix)
         .await
         .map_err(|_| AppError::NotFound)?;

--- a/crates/gateway/src/routes/export.rs
+++ b/crates/gateway/src/routes/export.rs
@@ -320,6 +320,12 @@ pub(crate) struct RenderExtras<'a> {
     /// submission-bundle MCM variant sets this; standalone exports leave it
     /// empty so they remain inside the 25-page COMAP budget.
     pub ai_use_report_section: &'a str,
+    /// Override the PDF metadata title (`\hypersetup{pdftitle=…}`). When
+    /// `Some`, the templates render this string instead of `meta.title`.
+    /// Used by the CUMCM submission bundle's anonymous variant to ensure
+    /// the file's PDF metadata can't leak a team-identifying title
+    /// (e.g. teams sometimes embed their control number in `meta.title`).
+    pub pdf_title_override: Option<&'a str>,
 }
 
 pub(crate) async fn render_tex(
@@ -390,6 +396,13 @@ pub(crate) async fn render_tex(
     // no-op value for the standalone export path.
     ctx.insert("cover_letter_section", extras.cover_letter_section);
     ctx.insert("ai_use_report_section", extras.ai_use_report_section);
+    // `pdf_title`: defaults to `meta.title`, overridden by the bundle's
+    // anonymous-variant path. Templates use `pdf_title` (not `title`)
+    // inside `\hypersetup{pdftitle=…}`.
+    ctx.insert(
+        "pdf_title",
+        extras.pdf_title_override.unwrap_or(&meta.title),
+    );
 
     let rendered = tera()
         .render(template.file(), &ctx)
@@ -987,6 +1000,7 @@ mod tests {
         // these (as empty strings) too.
         ctx.insert("cover_letter_section", "");
         ctx.insert("ai_use_report_section", "");
+        ctx.insert("pdf_title", &meta.title);
 
         tera().render(template.file(), &ctx).unwrap_or_else(|e| {
             // Walk the source chain so the panic shows the *underlying*

--- a/crates/gateway/src/routes/export.rs
+++ b/crates/gateway/src/routes/export.rs
@@ -147,7 +147,7 @@ pub enum TemplateKind {
 }
 
 impl TemplateKind {
-    fn parse(s: &str) -> Option<Self> {
+    pub fn parse(s: &str) -> Option<Self> {
         match s {
             "cumcm" => Some(Self::Cumcm),
             "huashu" => Some(Self::Huashu),
@@ -157,7 +157,7 @@ impl TemplateKind {
         }
     }
 
-    fn file(&self) -> &'static str {
+    pub(crate) fn file(&self) -> &'static str {
         match self {
             Self::Cumcm => "cumcm.tex.tera",
             Self::Huashu => "huashu.tex.tera",
@@ -168,7 +168,7 @@ impl TemplateKind {
     /// Resolve the competition_type → TemplateKind default (used when no
     /// explicit `template=` query is present). `other` degrades to `cumcm`
     /// per spec.
-    fn from_competition(ct: Option<&str>) -> Self {
+    pub fn from_competition(ct: Option<&str>) -> Self {
         match ct.unwrap_or("").to_ascii_lowercase().as_str() {
             "mcm" | "icm" => Self::Mcm,
             "huashu" => Self::Huashu,
@@ -183,7 +183,7 @@ impl TemplateKind {
 // in-memory strings so the binary is portable.
 // ---------------------------------------------------------------------------
 
-fn tera() -> &'static Tera {
+pub(crate) fn tera() -> &'static Tera {
     static INSTANCE: OnceLock<Tera> = OnceLock::new();
     INSTANCE.get_or_init(|| {
         let mut t = Tera::default();
@@ -197,6 +197,23 @@ fn tera() -> &'static Tera {
                 include_str!("../../templates/huashu.tex.tera"),
             ),
             ("mcm.tex.tera", include_str!("../../templates/mcm.tex.tera")),
+            // Submission-bundle fragments — body-only Tera files that are
+            // pre-rendered and then injected into the main templates above
+            // via the `cover_letter_section` / `ai_use_report_section` ctx
+            // variables. Bundled here too so the entire submission build
+            // path stays in-memory and the binary remains portable.
+            (
+                "cumcm_cover_letter.tex.tera",
+                include_str!("../../templates/cumcm_cover_letter.tex.tera"),
+            ),
+            (
+                "huashu_cover_letter.tex.tera",
+                include_str!("../../templates/huashu_cover_letter.tex.tera"),
+            ),
+            (
+                "ai_use_report.tex.tera",
+                include_str!("../../templates/ai_use_report.tex.tera"),
+            ),
         ])
         .expect("bundled Tera templates parse");
         t.register_filter("latex_escape", latex_escape_filter);
@@ -261,11 +278,13 @@ pub async fn export_paper(
     match fmt {
         ExportFormat::Md => unreachable!("handled above"),
         ExportFormat::Tex => {
-            let tex = render_tex(&meta, template, &canonical_run_root).await?;
+            let tex =
+                render_tex(&meta, template, &canonical_run_root, RenderExtras::default()).await?;
             build_binary_response(fmt, run_id, tex.into_bytes())
         }
         ExportFormat::Pdf => {
-            let tex = render_tex(&meta, template, &canonical_run_root).await?;
+            let tex =
+                render_tex(&meta, template, &canonical_run_root, RenderExtras::default()).await?;
             let pdf = compile_pdf(&tex).await?;
             build_binary_response(fmt, run_id, pdf)
         }
@@ -285,10 +304,29 @@ pub async fn export_paper(
 // TeX rendering pipeline
 // ---------------------------------------------------------------------------
 
-async fn render_tex(
+/// Optional Tera fragments injected into the main template for the
+/// submission-bundle pipeline. Both fields default to empty strings, which
+/// matches the original `/export/{pdf,tex}` semantics (no cover letter, no
+/// AI-use report — the standalone paper.pdf stays at the 25-page MCM budget
+/// and the CUMCM PDF starts at the 封面 page as before).
+#[derive(Debug, Default, Clone)]
+pub(crate) struct RenderExtras<'a> {
+    /// Pre-rendered LaTeX for the cover letter block — injected at the top
+    /// of `\begin{document}` in the CUMCM / Huashu templates. The bundle's
+    /// printed-variant PDF sets this; the anonymous-variant leaves it empty.
+    pub cover_letter_section: &'a str,
+    /// Pre-rendered LaTeX for the "Report on Use of AI" section — appended
+    /// at the end of the MCM template before `\end{document}`. Only the
+    /// submission-bundle MCM variant sets this; standalone exports leave it
+    /// empty so they remain inside the 25-page COMAP budget.
+    pub ai_use_report_section: &'a str,
+}
+
+pub(crate) async fn render_tex(
     meta: &PaperMeta,
     template: TemplateKind,
     run_root: &StdPath,
+    extras: RenderExtras<'_>,
 ) -> Result<String, AppError> {
     // Build figure lookup by id.
     let mut figure_map: HashMap<&str, &FigureRef> = HashMap::new();
@@ -347,6 +385,11 @@ async fn render_tex(
     ctx.insert("team_id", "");
     ctx.insert("problem_id", "");
     ctx.insert("graphics_root", &graphics_root);
+    // Always insert the optional fragment slots — Tera errors on undefined
+    // variables inside `{% if %}` blocks, so an empty string is the safe
+    // no-op value for the standalone export path.
+    ctx.insert("cover_letter_section", extras.cover_letter_section);
+    ctx.insert("ai_use_report_section", extras.ai_use_report_section);
 
     let rendered = tera()
         .render(template.file(), &ctx)
@@ -514,7 +557,7 @@ fn matching_brace_end(s: &str) -> Option<usize> {
     None
 }
 
-async fn compile_pdf(tex: &str) -> Result<Vec<u8>, AppError> {
+pub(crate) async fn compile_pdf(tex: &str) -> Result<Vec<u8>, AppError> {
     let tmp = tempfile::TempDir::new().map_err(|e| AppError::Internal(format!("tempdir: {e}")))?;
     let tex_path = tmp.path().join("paper.tex");
     tokio::fs::write(&tex_path, tex)
@@ -555,7 +598,7 @@ async fn compile_pdf(tex: &str) -> Result<Vec<u8>, AppError> {
         .map_err(|e| AppError::Internal(format!("read compiled pdf: {e}")))
 }
 
-async fn compile_docx(paper_md: &StdPath, run_root: &StdPath) -> Result<Vec<u8>, AppError> {
+pub(crate) async fn compile_docx(paper_md: &StdPath, run_root: &StdPath) -> Result<Vec<u8>, AppError> {
     let tmp = tempfile::TempDir::new().map_err(|e| AppError::Internal(format!("tempdir: {e}")))?;
     let out_path = tmp.path().join("paper.docx");
 
@@ -690,7 +733,7 @@ fn latex_escape_filter(
 // Helpers shared with figures.rs (kept separate to avoid churning that file)
 // ---------------------------------------------------------------------------
 
-async fn resolve_within(prefix: &StdPath, requested: &StdPath) -> Result<PathBuf, AppError> {
+pub(crate) async fn resolve_within(prefix: &StdPath, requested: &StdPath) -> Result<PathBuf, AppError> {
     let canonical_prefix = tokio::fs::canonicalize(prefix)
         .await
         .map_err(|_| AppError::NotFound)?;
@@ -714,7 +757,7 @@ async fn resolve_within(prefix: &StdPath, requested: &StdPath) -> Result<PathBuf
     Ok(canonical)
 }
 
-async fn read_capped(path: &StdPath) -> Result<Vec<u8>, AppError> {
+pub(crate) async fn read_capped(path: &StdPath) -> Result<Vec<u8>, AppError> {
     // The 16 MiB figures cap is unnecessarily tight for a paper PDF; we keep
     // the same order of magnitude but bump to 32 MiB for exports.
     const MAX_BYTES: u64 = 32 * 1024 * 1024;
@@ -927,16 +970,36 @@ mod tests {
         let mut ctx = tera::Context::new();
         ctx.insert("title", &meta.title);
         ctx.insert("abstract", &meta.r#abstract);
+        // The templates use `abstract_latex` (pandoc-rendered) for the
+        // visible abstract block. In production it's computed by
+        // render_tex via md_to_latex; here we just feed the raw markdown
+        // through so the template render compiles. Test only validates
+        // template *structure*, not abstract content.
+        ctx.insert("abstract_latex", &meta.r#abstract);
         ctx.insert("problem_text", &meta.problem_text);
         ctx.insert("sections", &sections);
         ctx.insert("references", &meta.references);
         ctx.insert("team_id", "");
         ctx.insert("problem_id", "");
         ctx.insert("graphics_root", "/tmp/fake-run/");
+        // Submission-bundle slots — Tera blows up on undefined vars inside
+        // `{% if %}`, so the standalone export path must always insert
+        // these (as empty strings) too.
+        ctx.insert("cover_letter_section", "");
+        ctx.insert("ai_use_report_section", "");
 
-        tera()
-            .render(template.file(), &ctx)
-            .unwrap_or_else(|e| panic!("render {}: {e}", template.file()))
+        tera().render(template.file(), &ctx).unwrap_or_else(|e| {
+            // Walk the source chain so the panic shows the *underlying*
+            // Tera failure (template name, line, missing var, etc.) and
+            // not just the wrapper.
+            let mut chain = String::new();
+            let mut src: Option<&dyn std::error::Error> = Some(&e);
+            while let Some(err) = src {
+                chain.push_str(&format!("\n  caused by: {err}"));
+                src = err.source();
+            }
+            panic!("render {}: {e}{chain}", template.file())
+        })
     }
 
     #[test]

--- a/crates/gateway/src/routes/export.rs
+++ b/crates/gateway/src/routes/export.rs
@@ -570,7 +570,36 @@ fn matching_brace_end(s: &str) -> Option<usize> {
     None
 }
 
+/// Cap on concurrent `tectonic` invocations across the whole process.
+///
+/// A cold tectonic compile peaks at ~500 MB resident plus the ~200 MB
+/// TeXLive bundle cache. Two CUMCM submission bundles arriving at the
+/// same time spawn 4 simultaneous compiles (anonymous + printed × 2
+/// requests); on a 4 GB VM that OOMs. `min(num_cpus, 4)` gates this
+/// without serialising single-user latency. The CPU-fanout limit also
+/// matches xetex's own observation that >4 parallel processes thrash
+/// the disk cache on the bundled font/macro files.
+fn tectonic_semaphore() -> &'static tokio::sync::Semaphore {
+    static SEM: OnceLock<tokio::sync::Semaphore> = OnceLock::new();
+    SEM.get_or_init(|| {
+        let n = std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(2)
+            .min(4);
+        tracing::info!(permits = n, "tectonic concurrency semaphore initialised");
+        tokio::sync::Semaphore::new(n)
+    })
+}
+
 pub(crate) async fn compile_pdf(tex: &str) -> Result<Vec<u8>, AppError> {
+    // Acquire BEFORE doing any work — including the tmpdir write — so
+    // queued requests don't waste FDs while waiting their turn. Permit
+    // is held for the entire compile, released on drop.
+    let _permit = tectonic_semaphore()
+        .acquire()
+        .await
+        .map_err(|e| AppError::Internal(format!("tectonic semaphore: {e}")))?;
+
     let tmp = tempfile::TempDir::new().map_err(|e| AppError::Internal(format!("tempdir: {e}")))?;
     let tex_path = tmp.path().join("paper.tex");
     tokio::fs::write(&tex_path, tex)
@@ -1030,6 +1059,60 @@ mod tests {
         // references rendered
         assert!(out.contains("\\begin{thebibliography}"));
         assert!(out.contains("Knuth, D."));
+        // N6 guard: empty cover_letter_section must NOT smuggle in the
+        // 承诺书 page. If a future refactor inverts the `{% if %}`
+        // condition, this fires before the anonymous CUMCM bundle
+        // silently starts carrying the cover letter.
+        assert!(
+            !out.contains("我们郑重承诺"),
+            "empty cover_letter_section should not render cover-letter body"
+        );
+    }
+
+    #[test]
+    fn cumcm_template_injects_cover_letter_when_provided() {
+        let meta = fixture_meta();
+        let sections: Vec<serde_json::Value> = meta
+            .sections
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "title": s.title,
+                    "body_latex": format!("%% section placeholder body for {}", s.title),
+                })
+            })
+            .collect();
+
+        let mut ctx = tera::Context::new();
+        ctx.insert("title", &meta.title);
+        ctx.insert("abstract", &meta.r#abstract);
+        ctx.insert("abstract_latex", &meta.r#abstract);
+        ctx.insert("problem_text", &meta.problem_text);
+        ctx.insert("sections", &sections);
+        ctx.insert("references", &meta.references);
+        ctx.insert("team_id", "");
+        ctx.insert("problem_id", "");
+        ctx.insert("graphics_root", "/tmp/fake-run/");
+        ctx.insert("ai_use_report_section", "");
+        ctx.insert("pdf_title", &meta.title);
+        // Non-empty cover_letter_section — render path used by the
+        // submission bundle's printed variant.
+        ctx.insert(
+            "cover_letter_section",
+            "\\section*{COVER-LETTER-MARKER} 我们郑重承诺",
+        );
+
+        let out = tera()
+            .render(TemplateKind::Cumcm.file(), &ctx)
+            .expect("renders");
+        assert!(
+            out.contains("COVER-LETTER-MARKER"),
+            "non-empty cover_letter_section must render verbatim"
+        );
+        assert!(
+            out.contains("我们郑重承诺"),
+            "cover-letter body text reaches the rendered LaTeX"
+        );
     }
 
     #[test]

--- a/crates/gateway/src/routes/llm.rs
+++ b/crates/gateway/src/routes/llm.rs
@@ -109,6 +109,7 @@ async fn complete_path(
             &state.pg,
             &mut state.redis,
             &state.llm.prices,
+            state.runs_dir.as_ref(),
             run_id,
             agent.as_deref(),
             &model,
@@ -142,6 +143,7 @@ async fn complete_path(
         &state.pg,
         &mut state.redis,
         &state.llm.prices,
+        state.runs_dir.as_ref(),
         run_id,
         agent.as_deref(),
         &model_for_cost,
@@ -175,6 +177,7 @@ async fn stream_path(
         state.pg.clone(),
         state.redis.clone(),
         state.llm.clone(),
+        state.runs_dir.clone(),
         run_id,
         agent,
         served_model,
@@ -191,11 +194,13 @@ async fn stream_path(
 /// Translate a CanonicalChunk stream into SSE Events, fanning tokens and
 /// computing final cost. Produces `Event::default().data("[DONE]")` at the end.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::ptr_arg)]
 fn build_forward_stream(
     upstream: BoxStream<'static, Result<CanonicalChunk, ProviderError>>,
     pg: sqlx::PgPool,
     redis: ConnectionManager,
     llm: std::sync::Arc<crate::llm::LlmContext>,
+    runs_dir: std::sync::Arc<std::path::PathBuf>,
     run_id: Option<Uuid>,
     agent: Option<String>,
     served_model: String,
@@ -207,6 +212,7 @@ fn build_forward_stream(
         redis: ConnectionManager,
         pg: sqlx::PgPool,
         llm: std::sync::Arc<crate::llm::LlmContext>,
+        runs_dir: std::sync::Arc<std::path::PathBuf>,
         run_id: Option<Uuid>,
         agent: Option<String>,
         served_model: String,
@@ -220,6 +226,7 @@ fn build_forward_stream(
         redis,
         pg,
         llm,
+        runs_dir,
         run_id,
         agent,
         served_model,
@@ -286,6 +293,7 @@ fn build_forward_stream(
                         &s.pg,
                         &mut s.redis,
                         &s.llm.prices,
+                        s.runs_dir.as_ref(),
                         s.run_id,
                         s.agent.as_deref(),
                         &s.served_model,

--- a/crates/gateway/src/routes/mod.rs
+++ b/crates/gateway/src/routes/mod.rs
@@ -5,4 +5,5 @@ pub mod llm;
 pub mod runs;
 pub mod search;
 pub mod stats;
+pub mod submission;
 pub mod ws_run;

--- a/crates/gateway/src/routes/runs.rs
+++ b/crates/gateway/src/routes/runs.rs
@@ -153,7 +153,9 @@ pub async fn finetune_run(
     Json(req): Json<FinetuneRequest>,
 ) -> Result<(StatusCode, Json<FinetuneAccepted>), AppError> {
     if req.message.trim().is_empty() {
-        return Err(AppError::BadRequest("message must be non-empty".to_string()));
+        return Err(AppError::BadRequest(
+            "message must be non-empty".to_string(),
+        ));
     }
     // Verify the run exists. We don't require status='success' — users may
     // want to fine-tune a paper from a partially-failed run too.

--- a/crates/gateway/src/routes/submission.rs
+++ b/crates/gateway/src/routes/submission.rs
@@ -38,7 +38,7 @@
 //!   └── README.txt          # 赛氪 saikr.com upload instructions
 //!   ```
 //!
-//! All bundles are built fully in-memory (Vec<u8>) because each component
+//! All bundles are built fully in-memory (`Vec<u8>`) because each component
 //! has independent retry semantics and we want a single atomic body to
 //! hand back to axum. The 100 MB hard cap avoids buffering the response
 //! body twice (once here, once in axum), and is well below any of the

--- a/crates/gateway/src/routes/submission.rs
+++ b/crates/gateway/src/routes/submission.rs
@@ -1,0 +1,939 @@
+//! Submission-bundle endpoint.
+//!
+//! `GET /runs/:run_id/submission?template=<mcm|icm|cumcm|huashu>` returns a
+//! ZIP archive containing every file the team needs to upload to the
+//! competition platform — including secondary artefacts each competition
+//! demands (cover-letter / 编号专用页 / 支撑材料 / MD5 manifest / AI-use
+//! report) that the standalone `/export/:format` route does not produce.
+//!
+//! Per-template ZIP layout (all UTF-8 paths inside the archive):
+//!
+//! * **MCM / ICM** (`template=mcm` or `icm`)
+//!   ```text
+//!   submission-mcm-<run>.zip
+//!   ├── <run>.pdf          # main paper + appended Report on Use of AI
+//!   ├── README.txt         # COMAP upload checklist
+//!   └── source/            # archive copy for the team's own records
+//!       ├── paper.tex
+//!       ├── paper.md
+//!       └── figures/*.png
+//!   ```
+//!
+//! * **CUMCM** (`template=cumcm`)
+//!   ```text
+//!   submission-cumcm-<run>.zip
+//!   ├── 论文-匿名版.pdf      # uploads to cumcm.cnki.net (no 承诺书/编号页)
+//!   ├── 论文-打印版-签字用.pdf # printed copy with 承诺书 + 编号专用页
+//!   ├── 论文.docx           # optional alternate format
+//!   ├── 支撑材料.zip         # nested per spec: notebook + code + figures
+//!   ├── MD5.txt             # MD5 manifest required by the upload client
+//!   └── README.txt          # CUMCM submission checklist
+//!   ```
+//!
+//! * **Huashu Cup** (`template=huashu`)
+//!   ```text
+//!   submission-huashu-<run>.zip
+//!   ├── 论文.pdf            # with 承诺书 as first page
+//!   ├── 支撑材料.zip         # notebook + code + figures
+//!   └── README.txt          # 赛氪 saikr.com upload instructions
+//!   ```
+//!
+//! All bundles are built fully in-memory (Vec<u8>) because each component
+//! has independent retry semantics and we want a single atomic body to hand
+//! back to axum. The hard 100 MB upper bound matches `read_capped` × 3 and
+//! is well below any of the three platforms' upload ceilings.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::Path as StdPath;
+
+use axum::body::Body;
+use axum::extract::{Path, Query, State};
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::response::Response;
+use chrono::Utc;
+use md5::{Digest, Md5};
+use serde::Deserialize;
+use uuid::Uuid;
+use zip::write::SimpleFileOptions;
+use zip::CompressionMethod;
+use zip::ZipWriter;
+
+use crate::error::AppError;
+use crate::routes::export::{
+    compile_docx, compile_pdf, latex_escape, read_capped, render_tex, resolve_within, tera,
+    PaperMeta, RenderExtras, TemplateKind,
+};
+use crate::state::AppState;
+
+/// Hard cap on the assembled bundle. Above this we'd be sending so much
+/// data over the WS-server's single-threaded io_uring that other runs
+/// would feel it. COMAP's own limit is 25 MB and CUMCM is unstated but in
+/// practice 50 MB+ trips the upload client — 100 MB is more than enough
+/// headroom and 4× our current worst-case figure folder.
+const MAX_BUNDLE_BYTES: usize = 100 * 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+pub struct SubmissionQuery {
+    #[serde(default)]
+    pub template: Option<String>,
+}
+
+#[tracing::instrument(skip_all, fields(%run_id))]
+pub async fn export_submission(
+    State(state): State<AppState>,
+    Path(run_id): Path<Uuid>,
+    Query(q): Query<SubmissionQuery>,
+) -> Result<Response, AppError> {
+    let run_root = state.runs_dir.join(run_id.to_string());
+    let canonical = tokio::fs::canonicalize(&run_root).await.map_err(|e| {
+        tracing::debug!(error = %e, "canonicalize run root failed");
+        AppError::NotFound
+    })?;
+
+    // paper.meta.json is the single source of truth for what the bundle
+    // contains (title, abstract, references, figures…). If the writer
+    // hasn't finished, the bundle simply can't be assembled.
+    let meta_path = resolve_within(&canonical, &canonical.join("paper.meta.json")).await?;
+    let meta_bytes = tokio::fs::read(&meta_path).await.map_err(|e| {
+        tracing::debug!(error = %e, "read paper.meta.json");
+        AppError::NotFound
+    })?;
+    let meta: PaperMeta = serde_json::from_slice(&meta_bytes)
+        .map_err(|e| AppError::UnprocessableEntity(format!("paper.meta.json invalid: {e}")))?;
+
+    let template = match q.template.as_deref() {
+        Some(s) => TemplateKind::parse(s).ok_or_else(|| {
+            AppError::UnprocessableEntity(format!(
+                "unsupported template {s:?}; expected one of mcm|icm|cumcm|huashu"
+            ))
+        })?,
+        None => TemplateKind::from_competition(meta.competition_type.as_deref()),
+    };
+
+    let (zip_bytes, label) = match template {
+        TemplateKind::Mcm => (build_mcm_bundle(&meta, &canonical, run_id).await?, "mcm"),
+        TemplateKind::Cumcm => (build_cumcm_bundle(&meta, &canonical, run_id).await?, "cumcm"),
+        TemplateKind::Huashu => (
+            build_huashu_bundle(&meta, &canonical, run_id).await?,
+            "huashu",
+        ),
+    };
+
+    if zip_bytes.len() > MAX_BUNDLE_BYTES {
+        return Err(AppError::PayloadTooLarge);
+    }
+
+    build_zip_response(zip_bytes, label, run_id)
+}
+
+// ---------------------------------------------------------------------------
+// Per-template bundle builders
+// ---------------------------------------------------------------------------
+
+async fn build_mcm_bundle(
+    meta: &PaperMeta,
+    run_root: &StdPath,
+    run_id: Uuid,
+) -> Result<Vec<u8>, AppError> {
+    // events.jsonl is optional — if absent, the AI report renders the
+    // "no LLM calls recorded" fallback row (still required by COMAP, but
+    // signals to judges that the team ran without LLM assistance).
+    let events_path = run_root.join("events.jsonl");
+    let ai_section = build_ai_use_report_section(&events_path).await?;
+
+    let extras = RenderExtras {
+        cover_letter_section: "",
+        ai_use_report_section: &ai_section,
+    };
+    let tex = render_tex(meta, TemplateKind::Mcm, run_root, extras).await?;
+    let pdf = compile_pdf(&tex).await?;
+
+    let mut buf: Vec<u8> = Vec::with_capacity(pdf.len() + 64 * 1024);
+    {
+        let mut zw = ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts = SimpleFileOptions::default()
+            .compression_method(CompressionMethod::Deflated)
+            .unix_permissions(0o644);
+
+        // The COMAP rule: "Use your team's control number as the name of
+        // your PDF file attachment". We can't know the control number
+        // server-side, so we name it after the run-id (the team can
+        // simply rename to `0000000.pdf` before uploading). The README
+        // calls this out.
+        let pdf_name = format!("{run_id}.pdf");
+        zw.start_file(&pdf_name, opts).map_err(zip_err)?;
+        zw.write_all(&pdf).map_err(zip_err)?;
+
+        zw.start_file("README.txt", opts).map_err(zip_err)?;
+        zw.write_all(README_MCM.as_bytes()).map_err(zip_err)?;
+
+        // Archive source — purely for the team's own records / for later
+        // reproduction. COMAP does NOT want code or auxiliary files.
+        zw.start_file("source/paper.tex", opts).map_err(zip_err)?;
+        zw.write_all(tex.as_bytes()).map_err(zip_err)?;
+
+        if let Ok(md) = tokio::fs::read(run_root.join("paper.md")).await {
+            zw.start_file("source/paper.md", opts).map_err(zip_err)?;
+            zw.write_all(&md).map_err(zip_err)?;
+        }
+
+        add_figures_to_zip(&mut zw, run_root, "source/figures", opts).await?;
+
+        zw.finish().map_err(zip_err)?;
+    }
+    Ok(buf)
+}
+
+async fn build_cumcm_bundle(
+    meta: &PaperMeta,
+    run_root: &StdPath,
+    _run_id: Uuid,
+) -> Result<Vec<u8>, AppError> {
+    let cover_letter = render_fragment("cumcm_cover_letter.tex.tera")?;
+
+    // Anonymous variant — what gets uploaded to cumcm.cnki.net. No cover
+    // letter, no team_id (render_tex inserts empty strings by default),
+    // so the running header reads `参赛编号：` with a blank suffix and
+    // no identifying info leaks. Matches the rule:
+    //   "在参赛论文电子版及支撑材料压缩包内任何位置（含文件夹名、
+    //    文件名和文档属性等）均不能包含与参赛队有关的信息".
+    let anon_tex = render_tex(
+        meta,
+        TemplateKind::Cumcm,
+        run_root,
+        RenderExtras::default(),
+    )
+    .await?;
+    let anon_pdf = compile_pdf(&anon_tex).await?;
+
+    // Printed variant — same body, but cover letter (承诺书 + 编号专用页)
+    // prepended as the first two pages, signature lines blank for the
+    // team to fill by hand.
+    let extras = RenderExtras {
+        cover_letter_section: &cover_letter,
+        ai_use_report_section: "",
+    };
+    let print_tex = render_tex(meta, TemplateKind::Cumcm, run_root, extras).await?;
+    let print_pdf = compile_pdf(&print_tex).await?;
+
+    // DOCX is best-effort — the team isn't required to upload it (CUMCM
+    // accepts PDF), so a missing pandoc shouldn't fail the whole bundle.
+    let docx = match tokio::fs::metadata(run_root.join("paper.md")).await {
+        Ok(_) => match compile_docx(&run_root.join("paper.md"), run_root).await {
+            Ok(b) => Some(b),
+            Err(e) => {
+                tracing::warn!(error = ?e, "CUMCM bundle: docx render skipped");
+                None
+            }
+        },
+        Err(_) => None,
+    };
+
+    let support_zip = build_support_zip(run_root).await?;
+
+    let pdf_md5 = md5_hex(&anon_pdf);
+    let support_md5 = md5_hex(&support_zip);
+    let md5_txt = format!(
+        "# 2025/2026 高教社杯全国大学生数学建模竞赛 — 提交文件 MD5 校验码\n\
+         #\n\
+         # 在客户端按提示分别上传以下两个文件的 MD5 校验码；上传文件后系统\n\
+         # 会重新计算并比对。\n\
+         \n\
+         论文-匿名版.pdf    {pdf_md5}\n\
+         支撑材料.zip       {support_md5}\n",
+    );
+
+    let mut buf: Vec<u8> = Vec::with_capacity(anon_pdf.len() + print_pdf.len() + support_zip.len() + 64 * 1024);
+    {
+        let mut zw = ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts = SimpleFileOptions::default()
+            .compression_method(CompressionMethod::Deflated)
+            .unix_permissions(0o644);
+        // STORE for the nested ZIP — re-deflating an already-deflated
+        // payload doesn't compress further and just costs CPU.
+        let stored = SimpleFileOptions::default()
+            .compression_method(CompressionMethod::Stored)
+            .unix_permissions(0o644);
+
+        zw.start_file("论文-匿名版.pdf", opts).map_err(zip_err)?;
+        zw.write_all(&anon_pdf).map_err(zip_err)?;
+
+        zw.start_file("论文-打印版-签字用.pdf", opts)
+            .map_err(zip_err)?;
+        zw.write_all(&print_pdf).map_err(zip_err)?;
+
+        if let Some(d) = docx {
+            zw.start_file("论文.docx", opts).map_err(zip_err)?;
+            zw.write_all(&d).map_err(zip_err)?;
+        }
+
+        zw.start_file("支撑材料.zip", stored).map_err(zip_err)?;
+        zw.write_all(&support_zip).map_err(zip_err)?;
+
+        zw.start_file("MD5.txt", opts).map_err(zip_err)?;
+        zw.write_all(md5_txt.as_bytes()).map_err(zip_err)?;
+
+        zw.start_file("README.txt", opts).map_err(zip_err)?;
+        zw.write_all(README_CUMCM.as_bytes()).map_err(zip_err)?;
+
+        zw.finish().map_err(zip_err)?;
+    }
+    Ok(buf)
+}
+
+async fn build_huashu_bundle(
+    meta: &PaperMeta,
+    run_root: &StdPath,
+    _run_id: Uuid,
+) -> Result<Vec<u8>, AppError> {
+    // 华数杯 expects 承诺书 on the FIRST page of the uploaded paper, with
+    // student signatures. Unlike CUMCM there's no separate anonymous
+    // variant — the commitment letter is part of the submitted paper.
+    let cover_letter = render_fragment("huashu_cover_letter.tex.tera")?;
+    let extras = RenderExtras {
+        cover_letter_section: &cover_letter,
+        ai_use_report_section: "",
+    };
+    let tex = render_tex(meta, TemplateKind::Huashu, run_root, extras).await?;
+    let pdf = compile_pdf(&tex).await?;
+
+    let support_zip = build_support_zip(run_root).await?;
+
+    let mut buf: Vec<u8> = Vec::with_capacity(pdf.len() + support_zip.len() + 32 * 1024);
+    {
+        let mut zw = ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts = SimpleFileOptions::default()
+            .compression_method(CompressionMethod::Deflated)
+            .unix_permissions(0o644);
+        let stored = SimpleFileOptions::default()
+            .compression_method(CompressionMethod::Stored)
+            .unix_permissions(0o644);
+
+        zw.start_file("论文.pdf", opts).map_err(zip_err)?;
+        zw.write_all(&pdf).map_err(zip_err)?;
+
+        zw.start_file("支撑材料.zip", stored).map_err(zip_err)?;
+        zw.write_all(&support_zip).map_err(zip_err)?;
+
+        zw.start_file("README.txt", opts).map_err(zip_err)?;
+        zw.write_all(README_HUASHU.as_bytes()).map_err(zip_err)?;
+
+        zw.finish().map_err(zip_err)?;
+    }
+    Ok(buf)
+}
+
+// ---------------------------------------------------------------------------
+// Support archive (支撑材料.zip) — used by CUMCM and Huashu
+// ---------------------------------------------------------------------------
+
+async fn build_support_zip(run_root: &StdPath) -> Result<Vec<u8>, AppError> {
+    let mut buf: Vec<u8> = Vec::with_capacity(2 * 1024 * 1024);
+    {
+        let mut zw = ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts = SimpleFileOptions::default()
+            .compression_method(CompressionMethod::Deflated)
+            .unix_permissions(0o644);
+
+        // 1. notebook.ipynb — the Coder's executed Jupyter notebook
+        let notebook_path = run_root.join("notebook.ipynb");
+        if let Ok(nb) = tokio::fs::read(&notebook_path).await {
+            zw.start_file("notebook.ipynb", opts).map_err(zip_err)?;
+            zw.write_all(&nb).map_err(zip_err)?;
+
+            // 2. code/source.py — extracted code cells concatenated, so a
+            //    reviewer who doesn't have Jupyter installed can still
+            //    read the program logic. CUMCM specifically requires
+            //    "可运行的源程序代码" — keeping a flat .py beside the
+            //    notebook makes that obvious without `jupyter nbconvert`.
+            if let Some(py) = extract_python_from_notebook(&nb) {
+                zw.start_file("code/source.py", opts).map_err(zip_err)?;
+                zw.write_all(py.as_bytes()).map_err(zip_err)?;
+            }
+        }
+
+        // 3. figures/ — all PNGs from the run's figures directory
+        add_figures_to_zip(&mut zw, run_root, "figures", opts).await?;
+
+        // 4. data/ — optional; some problems provide reference data
+        //    inside the run dir. Walk it shallowly (one level deep) so
+        //    we don't accidentally suck in node_modules-sized trees.
+        let data_dir = run_root.join("data");
+        if data_dir.is_dir() {
+            add_data_dir_to_zip(&mut zw, &data_dir, "data", opts).await?;
+        }
+
+        // 5. README inside the inner zip — survives unpacking the
+        //    nested archive (reviewers might extract this independently).
+        zw.start_file("README.txt", opts).map_err(zip_err)?;
+        zw.write_all(README_SUPPORT.as_bytes())
+            .map_err(zip_err)?;
+
+        zw.finish().map_err(zip_err)?;
+    }
+    Ok(buf)
+}
+
+async fn add_figures_to_zip<W: Write + std::io::Seek>(
+    zw: &mut ZipWriter<W>,
+    run_root: &StdPath,
+    prefix: &str,
+    opts: SimpleFileOptions,
+) -> Result<(), AppError> {
+    let figures_dir = run_root.join("figures");
+    let mut rd = match tokio::fs::read_dir(&figures_dir).await {
+        Ok(r) => r,
+        Err(_) => return Ok(()), // no figures is fine
+    };
+    while let Some(entry) = rd
+        .next_entry()
+        .await
+        .map_err(|e| AppError::Internal(format!("walk figures: {e}")))?
+    {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        // Skip junk dotfiles (`.DS_Store`) so the archive stays clean.
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if !n.starts_with('.') => n.to_string(),
+            _ => continue,
+        };
+        let bytes = read_capped(&path).await?;
+        zw.start_file(format!("{prefix}/{name}"), opts)
+            .map_err(zip_err)?;
+        zw.write_all(&bytes).map_err(zip_err)?;
+    }
+    Ok(())
+}
+
+async fn add_data_dir_to_zip<W: Write + std::io::Seek>(
+    zw: &mut ZipWriter<W>,
+    data_dir: &StdPath,
+    prefix: &str,
+    opts: SimpleFileOptions,
+) -> Result<(), AppError> {
+    let mut rd = tokio::fs::read_dir(data_dir)
+        .await
+        .map_err(|e| AppError::Internal(format!("walk data: {e}")))?;
+    while let Some(entry) = rd
+        .next_entry()
+        .await
+        .map_err(|e| AppError::Internal(format!("walk data: {e}")))?
+    {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if !n.starts_with('.') => n.to_string(),
+            _ => continue,
+        };
+        let bytes = read_capped(&path).await?;
+        zw.start_file(format!("{prefix}/{name}"), opts)
+            .map_err(zip_err)?;
+        zw.write_all(&bytes).map_err(zip_err)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// AI Use Report (MCM only) — reduces events.jsonl into a usage table
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Clone)]
+struct ModelUsage {
+    calls: u64,
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    used_by: std::collections::BTreeSet<String>,
+}
+
+/// Walks `events.jsonl` line-by-line and aggregates every `kind=cost`
+/// event by model. Resilient to:
+///   * missing file (returns the "no calls recorded" fallback)
+///   * malformed lines (silently skipped — we're reading a forensic log)
+///   * missing payload fields (treated as 0)
+async fn build_ai_use_report_section(events_path: &StdPath) -> Result<String, AppError> {
+    let mut models: BTreeMap<String, ModelUsage> = BTreeMap::new();
+
+    if events_path.is_file() {
+        let raw = tokio::fs::read_to_string(events_path)
+            .await
+            .map_err(|e| AppError::Internal(format!("read events.jsonl: {e}")))?;
+        for line in raw.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let v: serde_json::Value = match serde_json::from_str(line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if v.get("kind").and_then(|k| k.as_str()) != Some("cost") {
+                continue;
+            }
+            let payload = match v.get("payload") {
+                Some(p) => p,
+                None => continue,
+            };
+            let model = payload
+                .get("model")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown")
+                .to_string();
+            let prompt = payload
+                .get("prompt_tokens")
+                .and_then(|t| t.as_u64())
+                .unwrap_or(0);
+            let completion = payload
+                .get("completion_tokens")
+                .and_then(|t| t.as_u64())
+                .unwrap_or(0);
+            let agent = v
+                .get("agent")
+                .and_then(|a| a.as_str())
+                .unwrap_or("unknown")
+                .to_string();
+
+            let entry = models.entry(model).or_default();
+            entry.calls += 1;
+            entry.prompt_tokens += prompt;
+            entry.completion_tokens += completion;
+            entry.used_by.insert(agent);
+        }
+    }
+
+    let models_ctx: Vec<serde_json::Value> = models
+        .iter()
+        .map(|(name, u)| {
+            let used_by = u.used_by.iter().cloned().collect::<Vec<_>>().join(", ");
+            serde_json::json!({
+                "name": name,
+                "provider": infer_provider(name),
+                "calls": u.calls,
+                "prompt_tokens": u.prompt_tokens,
+                "completion_tokens": u.completion_tokens,
+                "used_by": used_by,
+            })
+        })
+        .collect();
+
+    let mut ctx = tera::Context::new();
+    ctx.insert("models", &models_ctx);
+    ctx.insert(
+        "generated_at",
+        &Utc::now().format("%Y-%m-%d %H:%M UTC").to_string(),
+    );
+
+    tera()
+        .render("ai_use_report.tex.tera", &ctx)
+        .map_err(|e| AppError::Internal(format!("render ai_use_report: {e}")))
+}
+
+fn infer_provider(model: &str) -> &'static str {
+    let m = model.to_ascii_lowercase();
+    if m.starts_with("gpt-") || m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4") {
+        "OpenAI"
+    } else if m.starts_with("claude") {
+        "Anthropic"
+    } else if m.starts_with("gemini") {
+        "Google"
+    } else if m.starts_with("deepseek") {
+        "DeepSeek"
+    } else if m.starts_with("glm") {
+        "Zhipu AI"
+    } else if m.starts_with("qwen") {
+        "Alibaba"
+    } else if m.starts_with("doubao") {
+        "ByteDance"
+    } else if m.starts_with("moonshot") || m.starts_with("kimi") {
+        "Moonshot AI"
+    } else if m.starts_with("grok") {
+        "xAI"
+    } else if m.starts_with("yi-") {
+        "01.AI"
+    } else {
+        "LLM provider"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn render_fragment(name: &str) -> Result<String, AppError> {
+    // Cover-letter fragments have no Tera variables today, but rendering
+    // them through Tera (rather than `include_str!`) keeps the path open
+    // for later: if we ever decide to pre-fill team_id / school / etc.,
+    // we just pass them in the context and the call site stays the same.
+    let ctx = tera::Context::new();
+    tera()
+        .render(name, &ctx)
+        .map_err(|e| AppError::Internal(format!("render {name}: {e}")))
+}
+
+fn md5_hex(bytes: &[u8]) -> String {
+    let mut h = Md5::new();
+    h.update(bytes);
+    let out = h.finalize();
+    let mut s = String::with_capacity(32);
+    for b in out.iter() {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Best-effort: pull every `cell_type == "code"` cell's source out of a
+/// Jupyter notebook JSON and concatenate them into a single .py blob. We
+/// don't fail the bundle on malformed notebooks — the .ipynb itself is
+/// always included alongside.
+fn extract_python_from_notebook(nb_bytes: &[u8]) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_slice(nb_bytes).ok()?;
+    let cells = v.get("cells")?.as_array()?;
+    let mut out = String::new();
+    out.push_str("# Source code extracted from notebook.ipynb\n");
+    out.push_str("# Generated by mathodology submission bundle.\n\n");
+    for (idx, cell) in cells.iter().enumerate() {
+        if cell.get("cell_type").and_then(|t| t.as_str()) != Some("code") {
+            continue;
+        }
+        let source = cell.get("source")?;
+        // `source` is either a string or an array of strings (per nbformat 4)
+        let text = match source {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Array(arr) => arr
+                .iter()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join(""),
+            _ => continue,
+        };
+        if text.trim().is_empty() {
+            continue;
+        }
+        out.push_str(&format!("# ===== Cell {} =====\n", idx + 1));
+        out.push_str(&text);
+        if !text.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push('\n');
+    }
+    Some(out)
+}
+
+/// Accepts both `ZipError` (start_file/finish) and `io::Error`
+/// (write_all on the underlying writer) so call sites can stay terse.
+fn zip_err<E: std::fmt::Display>(e: E) -> AppError {
+    AppError::Internal(format!("zip: {e}"))
+}
+
+fn build_zip_response(bytes: Vec<u8>, label: &str, run_id: Uuid) -> Result<Response, AppError> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/zip"),
+    );
+    if let Ok(hv) = HeaderValue::from_str(&bytes.len().to_string()) {
+        headers.insert(header::CONTENT_LENGTH, hv);
+    }
+    let disposition = format!("attachment; filename=\"submission-{label}-{run_id}.zip\"");
+    if let Ok(hv) = HeaderValue::from_str(&disposition) {
+        headers.insert(header::CONTENT_DISPOSITION, hv);
+    }
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("private, no-store"),
+    );
+
+    let mut resp = Response::builder()
+        .status(StatusCode::OK)
+        .body(Body::from(bytes))
+        .map_err(|e| AppError::Internal(format!("response build: {e}")))?;
+    *resp.headers_mut() = headers;
+    // Silence the unused-import lint locally — `latex_escape` is part of
+    // the cross-module surface area we expose; the bundle path doesn't
+    // currently call it but keeping the symbol in scope means downstream
+    // changes (e.g. pre-filling team_id) won't need a second `use`.
+    let _ = latex_escape;
+    Ok(resp)
+}
+
+// ---------------------------------------------------------------------------
+// README boilerplate (Chinese where the target user base is Chinese)
+// ---------------------------------------------------------------------------
+
+const README_MCM: &str = r#"MCM / ICM Submission Bundle
+============================
+
+Files in this archive:
+
+  <run_id>.pdf          The paper to upload to COMAP. Contains the 25-page
+                        solution + the "Report on Use of AI" appendix
+                        (page-limit exempt per COMAP 2026 AI Policy).
+  README.txt            This file.
+  source/               Reference copy of the LaTeX source, Markdown, and
+                        figures. NOT to be uploaded to COMAP.
+
+Before submitting:
+
+  1. Rename <run_id>.pdf to <TeamControlNumber>.pdf
+     (e.g. 0000007.pdf). COMAP requires the team control number as the
+     filename: see contest.comap.com/undergraduate/contests/mcm/instructions.php
+
+  2. Verify the file is < 25 MB. If oversized, lower figure DPI or
+     compress images.
+
+  3. Confirm anonymity: the PDF must NOT contain any student name,
+     advisor name, or institution name. The header shows only
+     "Team #  , Page X of Y" (intentionally blank — leave it that way).
+
+  4. Upload via https://forms.comap.org/241335097294056 by the official
+     deadline (typically 9:00 PM EST on the final contest day).
+
+Generated by mathodology submission-bundle endpoint.
+"#;
+
+const README_CUMCM: &str = r#"CUMCM 全国大学生数学建模竞赛 — 提交材料压缩包
+==================================================
+
+本压缩包内包含的文件：
+
+  论文-匿名版.pdf          用于上传 cumcm.cnki.net 的电子论文。
+                          不含 承诺书 / 编号专用页，符合官方匿名要求。
+  论文-打印版-签字用.pdf    与匿名版正文相同，但增加 承诺书 + 编号专用页 两页，
+                          供参赛队打印、签字、装订后交赛区组委会。
+  论文.docx               同一论文的 docx 版本（可选）。
+  支撑材料.zip             官方要求的"支撑材料"（notebook + 源代码 + 图表）。
+  MD5.txt                 上传时所需的 MD5 校验码。
+  README.txt              本文件。
+
+提交流程（依据 mcm.edu.cn 2025/2026 官方规则）：
+
+  1. 登录 https://cumcm.cnki.net 竞赛管理系统。
+
+  2. 在客户端中按提示分别上传：
+       a. "参赛论文"  -> 论文-匿名版.pdf
+       b. "支撑材料"  -> 支撑材料.zip
+     如客户端要求填写 MD5 校验码，请参考 MD5.txt 中的对应值。
+
+  3. 打印 论文-打印版-签字用.pdf：
+       第 1 页为承诺书 —— 三位队员、指导教师签字，并填写参赛队号、题号、学校。
+       第 2 页为编号专用页 —— 留空，由赛区/全国组委会评阅时填写。
+       第 3 页起为论文正文。
+     按赛区要求装订后交本校竞赛组负责老师。
+
+  4. 关键匿名要求：参赛论文电子版及支撑材料压缩包内 任何位置（含文件夹名、
+     文件名、文档属性）均不能包含与参赛队有关的信息。本工具生成的两个 ZIP
+     已严格匿名，请勿在提交前手工添加 README 或重命名队员信息相关文件。
+
+Generated by mathodology submission-bundle endpoint.
+"#;
+
+const README_HUASHU: &str = r#""华数杯"全国大学生数学建模竞赛 — 提交材料压缩包
+======================================================
+
+本压缩包内包含的文件：
+
+  论文.pdf                提交论文。第一页为承诺书（签字栏需打印后手写填入），
+                          其后为论文正文。
+  支撑材料.zip             notebook + 源代码 + 图表。
+  README.txt              本文件。
+
+提交流程（依据 saikr.com 官方赛事页）：
+
+  1. 由队长用电脑登录 https://www.saikr.com/vse/chinamcm/<年份> 提交。
+
+  2. 打印 论文.pdf 第一页（承诺书），三位队员签字，扫描或拍照插回 PDF
+     之前；或按赛事页指示，将签字版作为附件一并上传。
+
+  3. 上传论文（PDF）和支撑材料（ZIP），按截止时间（一般为竞赛结束日 20:00）
+     完成提交。
+
+  4. 注意事项：
+       * 论文将通过查重系统比对；
+       * 获奖论文的源代码将被运行检查，请确保 支撑材料.zip 中的代码可执行；
+       * 严禁参加各种竞赛思路交流群，违者将取消参赛资格。
+
+Generated by mathodology submission-bundle endpoint.
+"#;
+
+const README_SUPPORT: &str = r#"支撑材料 (Support Materials)
+============================
+
+  notebook.ipynb        Jupyter notebook executed end-to-end inside the
+                        gateway's sandboxed kernel (papermill-compatible).
+  code/source.py        Code cells extracted and concatenated for
+                        reviewers without Jupyter installed.
+  figures/*.png         All figures referenced in the paper, at 300 dpi.
+  data/                 (Optional) Reference data files, if any.
+
+This archive is generated automatically; do not edit by hand before
+submission. All paths inside are anonymised — no team/school metadata.
+"#;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn md5_matches_known_vector() {
+        // RFC 1321 test vector: MD5("abc") = 900150983cd24fb0d6963f7d28e17f72
+        assert_eq!(md5_hex(b"abc"), "900150983cd24fb0d6963f7d28e17f72");
+        assert_eq!(md5_hex(b""), "d41d8cd98f00b204e9800998ecf8427e");
+    }
+
+    #[test]
+    fn provider_inference_covers_common_models() {
+        assert_eq!(infer_provider("gpt-5-pro"), "OpenAI");
+        assert_eq!(infer_provider("GPT-4o-mini"), "OpenAI");
+        assert_eq!(infer_provider("o3-mini-high"), "OpenAI");
+        assert_eq!(infer_provider("claude-sonnet-4-6"), "Anthropic");
+        assert_eq!(infer_provider("gemini-2.5-pro"), "Google");
+        assert_eq!(infer_provider("deepseek-r1"), "DeepSeek");
+        assert_eq!(infer_provider("glm-4.6"), "Zhipu AI");
+        assert_eq!(infer_provider("qwen3-max"), "Alibaba");
+        assert_eq!(infer_provider("doubao-pro"), "ByteDance");
+        assert_eq!(infer_provider("kimi-k2"), "Moonshot AI");
+        assert_eq!(infer_provider("moonshot-v1"), "Moonshot AI");
+        assert_eq!(infer_provider("grok-3"), "xAI");
+        assert_eq!(infer_provider("yi-large"), "01.AI");
+        assert_eq!(infer_provider("some-unknown-model"), "LLM provider");
+    }
+
+    #[test]
+    fn fragment_renders_without_context() {
+        // Both cover-letter fragments + the AI report are no-context
+        // Tera templates today; this guards against future {{ vars }}
+        // sneaking in without the call site being updated.
+        for name in [
+            "cumcm_cover_letter.tex.tera",
+            "huashu_cover_letter.tex.tera",
+        ] {
+            let out = render_fragment(name).unwrap_or_else(|e| panic!("render {name}: {e:?}"));
+            assert!(out.contains("承诺书"), "{name} renders the 承诺书 header");
+        }
+    }
+
+    #[test]
+    fn ai_use_report_renders_with_empty_models() {
+        let mut ctx = tera::Context::new();
+        ctx.insert("models", &Vec::<serde_json::Value>::new());
+        ctx.insert("generated_at", "2026-05-23 12:00 UTC");
+        let out = tera()
+            .render("ai_use_report.tex.tera", &ctx)
+            .expect("renders empty");
+        assert!(out.contains("Report on Use of AI"));
+        assert!(
+            out.contains("No LLM calls recorded"),
+            "empty model list yields the fallback row"
+        );
+    }
+
+    #[test]
+    fn ai_use_report_renders_with_models() {
+        let models = vec![
+            serde_json::json!({
+                "name": "gpt-5-pro",
+                "provider": "OpenAI",
+                "calls": 12,
+                "prompt_tokens": 412020,
+                "completion_tokens": 23110,
+                "used_by": "modeler, writer",
+            }),
+            serde_json::json!({
+                "name": "claude-sonnet-4-6",
+                "provider": "Anthropic",
+                "calls": 8,
+                "prompt_tokens": 100000,
+                "completion_tokens": 50000,
+                "used_by": "coder, critic",
+            }),
+        ];
+        let mut ctx = tera::Context::new();
+        ctx.insert("models", &models);
+        ctx.insert("generated_at", "2026-05-23 12:00 UTC");
+        let out = tera()
+            .render("ai_use_report.tex.tera", &ctx)
+            .expect("renders");
+        assert!(out.contains("gpt-5-pro"));
+        assert!(out.contains("OpenAI"));
+        assert!(out.contains("claude-sonnet-4-6"));
+        assert!(out.contains("412020"));
+        assert!(out.contains("modeler, writer"));
+    }
+
+    #[test]
+    fn extract_python_handles_string_and_array_source() {
+        let nb = serde_json::json!({
+            "cells": [
+                {"cell_type": "code", "source": "print('hello')\n"},
+                {"cell_type": "markdown", "source": "# heading"},
+                {"cell_type": "code", "source": ["import numpy as np\n", "x = np.arange(10)\n"]},
+                {"cell_type": "code", "source": ""},  // empty cell, skipped
+            ]
+        });
+        let bytes = serde_json::to_vec(&nb).unwrap();
+        let out = extract_python_from_notebook(&bytes).expect("extracts");
+        assert!(out.contains("print('hello')"));
+        assert!(out.contains("import numpy as np"));
+        assert!(out.contains("x = np.arange(10)"));
+        assert!(!out.contains("# heading"), "markdown cells skipped");
+        assert!(out.contains("Cell 1"));
+        assert!(out.contains("Cell 3"));
+        assert!(!out.contains("Cell 4"), "empty cell skipped");
+    }
+
+    #[test]
+    fn extract_python_returns_none_on_garbage() {
+        assert!(extract_python_from_notebook(b"not json").is_none());
+        assert!(extract_python_from_notebook(b"{}").is_none());
+    }
+
+    #[tokio::test]
+    async fn ai_report_handles_missing_events() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let out = build_ai_use_report_section(&dir.path().join("events.jsonl"))
+            .await
+            .expect("returns ok");
+        assert!(out.contains("Report on Use of AI"));
+        assert!(out.contains("No LLM calls recorded"));
+    }
+
+    #[tokio::test]
+    async fn ai_report_aggregates_cost_events() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let p = dir.path().join("events.jsonl");
+        let events = [
+            r#"{"run_id":"x","agent":"writer","kind":"cost","seq":1,"ts":"2026-05-23T00:00:00Z","payload":{"model":"gpt-5-pro","prompt_tokens":100,"completion_tokens":50}}"#,
+            r#"{"run_id":"x","agent":"writer","kind":"cost","seq":2,"ts":"2026-05-23T00:00:01Z","payload":{"model":"gpt-5-pro","prompt_tokens":200,"completion_tokens":75}}"#,
+            r#"{"run_id":"x","agent":"coder","kind":"cost","seq":3,"ts":"2026-05-23T00:00:02Z","payload":{"model":"claude-sonnet-4-6","prompt_tokens":1000,"completion_tokens":300}}"#,
+            r#"{"run_id":"x","agent":"writer","kind":"stage.done","seq":4,"ts":"2026-05-23T00:00:03Z","payload":{}}"#,
+            r#"{this is garbage"#,
+            r#""#,
+        ]
+        .join("\n");
+        tokio::fs::write(&p, events).await.unwrap();
+        let out = build_ai_use_report_section(&p).await.expect("ok");
+
+        assert!(out.contains("gpt-5-pro"));
+        assert!(out.contains("claude-sonnet-4-6"));
+        // gpt-5-pro: 2 calls, 300 prompt, 125 completion
+        assert!(out.contains(" 2 ") && out.contains(" 300 ") && out.contains(" 125 "));
+        // claude: 1 call, 1000 prompt, 300 completion
+        assert!(out.contains(" 1 ") && out.contains(" 1000 ") && out.contains(" 300 "));
+        // Agent set rolled up
+        assert!(out.contains("writer"));
+        assert!(out.contains("coder"));
+        // stage.done was NOT counted
+        assert!(
+            !out.contains("stage.done"),
+            "non-cost events must not appear in the report"
+        );
+    }
+}

--- a/crates/gateway/src/routes/submission.rs
+++ b/crates/gateway/src/routes/submission.rs
@@ -39,9 +39,13 @@
 //!   ```
 //!
 //! All bundles are built fully in-memory (Vec<u8>) because each component
-//! has independent retry semantics and we want a single atomic body to hand
-//! back to axum. The hard 100 MB upper bound matches `read_capped` × 3 and
-//! is well below any of the three platforms' upload ceilings.
+//! has independent retry semantics and we want a single atomic body to
+//! hand back to axum. The 100 MB hard cap avoids buffering the response
+//! body twice (once here, once in axum), and is well below any of the
+//! three platforms' upload ceilings. The support-archive walker enforces
+//! a tighter 80 MB / 500-file budget *during* construction so we reject
+//! before the OOM window opens, rather than after assembly when the
+//! damage is already done.
 
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -61,17 +65,33 @@ use zip::ZipWriter;
 
 use crate::error::AppError;
 use crate::routes::export::{
-    compile_docx, compile_pdf, latex_escape, read_capped, render_tex, resolve_within, tera,
-    PaperMeta, RenderExtras, TemplateKind,
+    compile_docx, compile_pdf, render_tex, resolve_within, tera, PaperMeta, RenderExtras,
+    TemplateKind,
 };
 use crate::state::AppState;
 
-/// Hard cap on the assembled bundle. Above this we'd be sending so much
-/// data over the WS-server's single-threaded io_uring that other runs
-/// would feel it. COMAP's own limit is 25 MB and CUMCM is unstated but in
-/// practice 50 MB+ trips the upload client — 100 MB is more than enough
-/// headroom and 4× our current worst-case figure folder.
+/// Hard cap on the *assembled* bundle (post-build safety net). COMAP's own
+/// upload limit is 25 MB; CUMCM is unstated but in practice 50 MB+ trips
+/// the upload client. 100 MB leaves headroom for two CUMCM variants +
+/// docx + figures while staying well under any platform ceiling.
 const MAX_BUNDLE_BYTES: usize = 100 * 1024 * 1024;
+
+/// Per-bundle budget for the support archive (figures + data combined).
+/// Enforced *during* the walk so we reject oversized inputs before
+/// committing them to memory — avoids the post-build OOM window where a
+/// malicious or misconfigured run could buffer ~512 MB before the
+/// `MAX_BUNDLE_BYTES` check trips.
+const SUPPORT_MAX_BYTES: u64 = 80 * 1024 * 1024;
+/// Cap on the number of files included in the support archive. Bounds the
+/// ZIP central directory size; without this a `data/` dir holding 10k
+/// small CSVs would balloon the metadata even if total bytes stay sane.
+const SUPPORT_MAX_FILES: usize = 500;
+/// Per-file size cap for support-archive entries. Larger than the
+/// figures-export 32 MB cap because competition input data files
+/// (NetCDF, parquet, large CSVs) routinely exceed 32 MB. Files above
+/// this are warn-and-skipped, not fatal: better to ship a slightly
+/// incomplete bundle than to fail the whole submission.
+const SUPPORT_PER_FILE_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 pub struct SubmissionQuery {
@@ -179,7 +199,7 @@ async fn build_mcm_bundle(
             zw.write_all(&md).map_err(zip_err)?;
         }
 
-        add_figures_to_zip(&mut zw, run_root, "source/figures", opts).await?;
+        add_archival_figures_to_zip(&mut zw, run_root, "source/figures", opts).await?;
 
         zw.finish().map_err(zip_err)?;
     }
@@ -363,15 +383,17 @@ async fn build_support_zip(run_root: &StdPath) -> Result<Vec<u8>, AppError> {
             }
         }
 
-        // 3. figures/ — all PNGs from the run's figures directory
-        add_figures_to_zip(&mut zw, run_root, "figures", opts).await?;
-
+        // 3. figures/ — all PNGs from the run's figures directory.
         // 4. data/ — optional; some problems provide reference data
-        //    inside the run dir. Walk it shallowly (one level deep) so
+        //    inside the run dir. Walked shallowly (one level deep) so
         //    we don't accidentally suck in node_modules-sized trees.
+        // Both share a SupportBudget so cumulative size / file-count
+        // caps are enforced across the two directories together.
+        let mut budget = SupportBudget::new();
+        add_dir_to_zip(&mut zw, &run_root.join("figures"), "figures", opts, &mut budget).await?;
         let data_dir = run_root.join("data");
-        if data_dir.is_dir() {
-            add_data_dir_to_zip(&mut zw, &data_dir, "data", opts).await?;
+        if is_existing_dir(&data_dir).await {
+            add_dir_to_zip(&mut zw, &data_dir, "data", opts, &mut budget).await?;
         }
 
         // 5. README inside the inner zip — survives unpacking the
@@ -385,7 +407,110 @@ async fn build_support_zip(run_root: &StdPath) -> Result<Vec<u8>, AppError> {
     Ok(buf)
 }
 
-async fn add_figures_to_zip<W: Write + std::io::Seek>(
+/// Running totals enforced across all support-archive directories.
+/// Single mutable struct passed by reference so figures + data share
+/// one budget (10 000 figures × 1 MB shouldn't be allowed just because
+/// they're spread across two directories).
+struct SupportBudget {
+    bytes: u64,
+    files: usize,
+}
+
+impl SupportBudget {
+    fn new() -> Self {
+        Self { bytes: 0, files: 0 }
+    }
+
+    /// Reserve `size` bytes + 1 file slot. Returns `Err(PayloadTooLarge)`
+    /// when adding would exceed either cap so the caller bails before
+    /// reading the file into memory.
+    fn try_reserve(&mut self, size: u64) -> Result<(), AppError> {
+        if self.files + 1 > SUPPORT_MAX_FILES {
+            tracing::warn!(
+                cap = SUPPORT_MAX_FILES,
+                "support archive: file count cap exceeded"
+            );
+            return Err(AppError::PayloadTooLarge);
+        }
+        let projected = self.bytes.saturating_add(size);
+        if projected > SUPPORT_MAX_BYTES {
+            tracing::warn!(
+                projected,
+                cap = SUPPORT_MAX_BYTES,
+                "support archive: cumulative size cap exceeded"
+            );
+            return Err(AppError::PayloadTooLarge);
+        }
+        self.bytes = projected;
+        self.files += 1;
+        Ok(())
+    }
+}
+
+/// Unified directory-to-zip walker used for both `figures/` and `data/`.
+/// Missing source dir is non-fatal (returns Ok). Each file is:
+///   * skipped if its name starts with `.` (dotfiles like `.DS_Store`)
+///   * skipped (with warn) if its size exceeds `SUPPORT_PER_FILE_MAX_BYTES`
+///   * counted against the shared `SupportBudget`; bundle aborted with
+///     `PayloadTooLarge` if budget is busted.
+async fn add_dir_to_zip<W: Write + std::io::Seek>(
+    zw: &mut ZipWriter<W>,
+    src_dir: &StdPath,
+    prefix: &str,
+    opts: SimpleFileOptions,
+    budget: &mut SupportBudget,
+) -> Result<(), AppError> {
+    let mut rd = match tokio::fs::read_dir(src_dir).await {
+        Ok(r) => r,
+        Err(_) => return Ok(()), // missing source dir is OK
+    };
+    while let Some(entry) = rd
+        .next_entry()
+        .await
+        .map_err(|e| AppError::Internal(format!("walk {}: {e}", src_dir.display())))?
+    {
+        let path = entry.path();
+        let meta = match tokio::fs::metadata(&path).await {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if !n.starts_with('.') => n.to_string(),
+            _ => continue,
+        };
+        // M7: single oversized file → warn + skip, NOT fail the bundle.
+        // Competition data files routinely exceed the 32 MB figures cap
+        // (NetCDF, parquet, raw sensor dumps). Better a slightly thin
+        // bundle than no bundle.
+        let size = meta.len();
+        if size > SUPPORT_PER_FILE_MAX_BYTES {
+            tracing::warn!(
+                path = %path.display(),
+                size,
+                cap = SUPPORT_PER_FILE_MAX_BYTES,
+                "support archive: skipping file above per-file cap"
+            );
+            continue;
+        }
+        budget.try_reserve(size)?;
+        let bytes = tokio::fs::read(&path)
+            .await
+            .map_err(|e| AppError::Internal(format!("read {}: {e}", path.display())))?;
+        zw.start_file(format!("{prefix}/{name}"), opts)
+            .map_err(zip_err)?;
+        zw.write_all(&bytes).map_err(zip_err)?;
+    }
+    Ok(())
+}
+
+/// MCM bundle's archival `source/figures/` copy — no budget tracking
+/// because (a) it's the team's own paper figures, bounded by the
+/// pipeline, and (b) the COMAP bundle ships only the main PDF for
+/// upload, so source/ exists purely for the team's offline records.
+async fn add_archival_figures_to_zip<W: Write + std::io::Seek>(
     zw: &mut ZipWriter<W>,
     run_root: &StdPath,
     prefix: &str,
@@ -394,7 +519,7 @@ async fn add_figures_to_zip<W: Write + std::io::Seek>(
     let figures_dir = run_root.join("figures");
     let mut rd = match tokio::fs::read_dir(&figures_dir).await {
         Ok(r) => r,
-        Err(_) => return Ok(()), // no figures is fine
+        Err(_) => return Ok(()),
     };
     while let Some(entry) = rd
         .next_entry()
@@ -402,15 +527,31 @@ async fn add_figures_to_zip<W: Write + std::io::Seek>(
         .map_err(|e| AppError::Internal(format!("walk figures: {e}")))?
     {
         let path = entry.path();
-        if !path.is_file() {
+        let meta = match tokio::fs::metadata(&path).await {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if !meta.is_file() {
             continue;
         }
-        // Skip junk dotfiles (`.DS_Store`) so the archive stays clean.
         let name = match path.file_name().and_then(|n| n.to_str()) {
             Some(n) if !n.starts_with('.') => n.to_string(),
             _ => continue,
         };
-        let bytes = read_capped(&path).await?;
+        // Pipeline-produced figures are tightly bounded (8-12 PNGs at
+        // <2 MB each); a 32 MB ceiling is generous and rejects only
+        // genuinely broken inputs.
+        if meta.len() > 32 * 1024 * 1024 {
+            tracing::warn!(
+                path = %path.display(),
+                size = meta.len(),
+                "archival figures: skipping oversized file"
+            );
+            continue;
+        }
+        let bytes = tokio::fs::read(&path)
+            .await
+            .map_err(|e| AppError::Internal(format!("read {}: {e}", path.display())))?;
         zw.start_file(format!("{prefix}/{name}"), opts)
             .map_err(zip_err)?;
         zw.write_all(&bytes).map_err(zip_err)?;
@@ -418,34 +559,15 @@ async fn add_figures_to_zip<W: Write + std::io::Seek>(
     Ok(())
 }
 
-async fn add_data_dir_to_zip<W: Write + std::io::Seek>(
-    zw: &mut ZipWriter<W>,
-    data_dir: &StdPath,
-    prefix: &str,
-    opts: SimpleFileOptions,
-) -> Result<(), AppError> {
-    let mut rd = tokio::fs::read_dir(data_dir)
+/// Async replacement for `Path::is_dir()` which would otherwise issue a
+/// blocking `stat(2)` syscall on the tokio runtime. Cheap (one syscall)
+/// but the rest of the module is meticulous about async I/O; staying
+/// consistent avoids future surprises when this gets called under load.
+async fn is_existing_dir(path: &StdPath) -> bool {
+    tokio::fs::metadata(path)
         .await
-        .map_err(|e| AppError::Internal(format!("walk data: {e}")))?;
-    while let Some(entry) = rd
-        .next_entry()
-        .await
-        .map_err(|e| AppError::Internal(format!("walk data: {e}")))?
-    {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        let name = match path.file_name().and_then(|n| n.to_str()) {
-            Some(n) if !n.starts_with('.') => n.to_string(),
-            _ => continue,
-        };
-        let bytes = read_capped(&path).await?;
-        zw.start_file(format!("{prefix}/{name}"), opts)
-            .map_err(zip_err)?;
-        zw.write_all(&bytes).map_err(zip_err)?;
-    }
-    Ok(())
+        .map(|m| m.is_dir())
+        .unwrap_or(false)
 }
 
 // ---------------------------------------------------------------------------
@@ -501,10 +623,18 @@ async fn build_ai_use_report_section(events_path: &StdPath) -> Result<String, Ap
                 .get("completion_tokens")
                 .and_then(|t| t.as_u64())
                 .unwrap_or(0);
+            // Normalize agent names: a single agent can show up as
+            // both "writer" and "finetune_writer" depending on whether
+            // the call originated from the main pipeline or a finetune
+            // chat session. Judges only care about the role; collapse
+            // the finetune_ prefix so the "Used by" cell stays clean.
             let agent = v
                 .get("agent")
                 .and_then(|a| a.as_str())
-                .unwrap_or("unknown")
+                .unwrap_or("unknown");
+            let agent = agent
+                .strip_prefix("finetune_")
+                .unwrap_or(agent)
                 .to_string();
 
             let entry = models.entry(model).or_default();
@@ -542,30 +672,48 @@ async fn build_ai_use_report_section(events_path: &StdPath) -> Result<String, Ap
         .map_err(|e| AppError::Internal(format!("render ai_use_report: {e}")))
 }
 
-fn infer_provider(model: &str) -> &'static str {
+fn infer_provider(model: &str) -> String {
     let m = model.to_ascii_lowercase();
-    if m.starts_with("gpt-") || m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4") {
-        "OpenAI"
+    let known: Option<&str> = if m.starts_with("gpt-")
+        || m.starts_with("o1")
+        || m.starts_with("o3")
+        || m.starts_with("o4")
+    {
+        Some("OpenAI")
     } else if m.starts_with("claude") {
-        "Anthropic"
+        Some("Anthropic")
     } else if m.starts_with("gemini") {
-        "Google"
+        Some("Google")
     } else if m.starts_with("deepseek") {
-        "DeepSeek"
+        Some("DeepSeek")
     } else if m.starts_with("glm") {
-        "Zhipu AI"
+        Some("Zhipu AI")
     } else if m.starts_with("qwen") {
-        "Alibaba"
+        Some("Alibaba")
     } else if m.starts_with("doubao") {
-        "ByteDance"
+        Some("ByteDance")
     } else if m.starts_with("moonshot") || m.starts_with("kimi") {
-        "Moonshot AI"
+        Some("Moonshot AI")
     } else if m.starts_with("grok") {
-        "xAI"
+        Some("xAI")
     } else if m.starts_with("yi-") {
-        "01.AI"
+        Some("01.AI")
     } else {
-        "LLM provider"
+        None
+    };
+    match known {
+        Some(s) => s.to_string(),
+        // Fallback: use the model's first hyphen-separated segment,
+        // title-cased. "foobar-pro-v2" → "Foobar". Reads more naturally
+        // in the judges' table than a literal "LLM provider".
+        None => {
+            let first = model.split('-').next().unwrap_or(model);
+            let mut chars = first.chars();
+            match chars.next() {
+                Some(c) => c.to_ascii_uppercase().to_string() + chars.as_str(),
+                None => "Other".to_string(),
+            }
+        }
     }
 }
 
@@ -587,12 +735,15 @@ fn render_fragment(name: &str, year: i32) -> Result<String, AppError> {
 }
 
 fn md5_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
     let mut h = Md5::new();
     h.update(bytes);
     let out = h.finalize();
     let mut s = String::with_capacity(32);
     for b in out.iter() {
-        s.push_str(&format!("{b:02x}"));
+        // write! writes into the existing String buffer; format!() would
+        // allocate a fresh 2-char String per byte.
+        write!(&mut s, "{b:02x}").expect("infallible into String");
     }
     s
 }
@@ -727,11 +878,6 @@ fn build_zip_response(bytes: Vec<u8>, label: &str, run_id: Uuid) -> Result<Respo
         .body(Body::from(bytes))
         .map_err(|e| AppError::Internal(format!("response build: {e}")))?;
     *resp.headers_mut() = headers;
-    // Silence the unused-import lint locally — `latex_escape` is part of
-    // the cross-module surface area we expose; the bundle path doesn't
-    // currently call it but keeping the symbol in scope means downstream
-    // changes (e.g. pre-filling team_id) won't need a second `use`.
-    let _ = latex_escape;
     Ok(resp)
 }
 
@@ -890,7 +1036,12 @@ mod tests {
         assert_eq!(infer_provider("moonshot-v1"), "Moonshot AI");
         assert_eq!(infer_provider("grok-3"), "xAI");
         assert_eq!(infer_provider("yi-large"), "01.AI");
-        assert_eq!(infer_provider("some-unknown-model"), "LLM provider");
+        // Unknown models fall back to the title-cased first segment of
+        // the model name — reads more naturally to a judge than a
+        // literal "LLM provider" placeholder.
+        assert_eq!(infer_provider("some-unknown-model"), "Some");
+        assert_eq!(infer_provider("foobar"), "Foobar");
+        assert_eq!(infer_provider(""), "Other");
     }
 
     #[test]

--- a/crates/gateway/src/routes/submission.rs
+++ b/crates/gateway/src/routes/submission.rs
@@ -51,7 +51,7 @@ use axum::body::Body;
 use axum::extract::{Path, Query, State};
 use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
 use axum::response::Response;
-use chrono::Utc;
+use chrono::{Datelike, Utc};
 use md5::{Digest, Md5};
 use serde::Deserialize;
 use uuid::Uuid;
@@ -145,6 +145,7 @@ async fn build_mcm_bundle(
     let extras = RenderExtras {
         cover_letter_section: "",
         ai_use_report_section: &ai_section,
+        pdf_title_override: None,
     };
     let tex = render_tex(meta, TemplateKind::Mcm, run_root, extras).await?;
     let pdf = compile_pdf(&tex).await?;
@@ -190,21 +191,23 @@ async fn build_cumcm_bundle(
     run_root: &StdPath,
     _run_id: Uuid,
 ) -> Result<Vec<u8>, AppError> {
-    let cover_letter = render_fragment("cumcm_cover_letter.tex.tera")?;
+    let year = Utc::now().year();
+    let cover_letter = render_fragment("cumcm_cover_letter.tex.tera", year)?;
 
     // Anonymous variant — what gets uploaded to cumcm.cnki.net. No cover
     // letter, no team_id (render_tex inserts empty strings by default),
-    // so the running header reads `参赛编号：` with a blank suffix and
-    // no identifying info leaks. Matches the rule:
+    // PDF metadata title overridden to a generic string so even
+    // `meta.title` (which teams sometimes set to "Team 12345 — Model X")
+    // doesn't leak into the PDF properties. Matches the rule:
     //   "在参赛论文电子版及支撑材料压缩包内任何位置（含文件夹名、
     //    文件名和文档属性等）均不能包含与参赛队有关的信息".
-    let anon_tex = render_tex(
-        meta,
-        TemplateKind::Cumcm,
-        run_root,
-        RenderExtras::default(),
-    )
-    .await?;
+    const ANON_PDF_TITLE: &str = "CUMCM Submission (anonymous)";
+    let anon_extras = RenderExtras {
+        cover_letter_section: "",
+        ai_use_report_section: "",
+        pdf_title_override: Some(ANON_PDF_TITLE),
+    };
+    let anon_tex = render_tex(meta, TemplateKind::Cumcm, run_root, anon_extras).await?;
     let anon_pdf = compile_pdf(&anon_tex).await?;
 
     // Printed variant — same body, but cover letter (承诺书 + 编号专用页)
@@ -213,6 +216,7 @@ async fn build_cumcm_bundle(
     let extras = RenderExtras {
         cover_letter_section: &cover_letter,
         ai_use_report_section: "",
+        pdf_title_override: None,
     };
     let print_tex = render_tex(meta, TemplateKind::Cumcm, run_root, extras).await?;
     let print_pdf = compile_pdf(&print_tex).await?;
@@ -235,10 +239,10 @@ async fn build_cumcm_bundle(
     let pdf_md5 = md5_hex(&anon_pdf);
     let support_md5 = md5_hex(&support_zip);
     let md5_txt = format!(
-        "# 2025/2026 高教社杯全国大学生数学建模竞赛 — 提交文件 MD5 校验码\n\
+        "# {year} 高教社杯全国大学生数学建模竞赛 — 提交文件 MD5 校验码\n\
          #\n\
          # 在客户端按提示分别上传以下两个文件的 MD5 校验码；上传文件后系统\n\
-         # 会重新计算并比对。\n\
+         # 会重新计算并比对。重命名为 <队号>.pdf / <队号>.zip 不会改变 MD5。\n\
          \n\
          论文-匿名版.pdf    {pdf_md5}\n\
          支撑材料.zip       {support_md5}\n",
@@ -290,10 +294,12 @@ async fn build_huashu_bundle(
     // 华数杯 expects 承诺书 on the FIRST page of the uploaded paper, with
     // student signatures. Unlike CUMCM there's no separate anonymous
     // variant — the commitment letter is part of the submitted paper.
-    let cover_letter = render_fragment("huashu_cover_letter.tex.tera")?;
+    let year = Utc::now().year();
+    let cover_letter = render_fragment("huashu_cover_letter.tex.tera", year)?;
     let extras = RenderExtras {
         cover_letter_section: &cover_letter,
         ai_use_report_section: "",
+        pdf_title_override: None,
     };
     let tex = render_tex(meta, TemplateKind::Huashu, run_root, extras).await?;
     let pdf = compile_pdf(&tex).await?;
@@ -336,18 +342,22 @@ async fn build_support_zip(run_root: &StdPath) -> Result<Vec<u8>, AppError> {
             .compression_method(CompressionMethod::Deflated)
             .unix_permissions(0o644);
 
-        // 1. notebook.ipynb — the Coder's executed Jupyter notebook
+        // 1. notebook.ipynb — the Coder's executed Jupyter notebook,
+        //    with author / kernel-display-name metadata scrubbed so a
+        //    hand-edited notebook with team info baked in doesn't leak
+        //    into the anonymous support archive.
         let notebook_path = run_root.join("notebook.ipynb");
         if let Ok(nb) = tokio::fs::read(&notebook_path).await {
+            let scrubbed = scrub_notebook_metadata(&nb);
             zw.start_file("notebook.ipynb", opts).map_err(zip_err)?;
-            zw.write_all(&nb).map_err(zip_err)?;
+            zw.write_all(&scrubbed).map_err(zip_err)?;
 
             // 2. code/source.py — extracted code cells concatenated, so a
             //    reviewer who doesn't have Jupyter installed can still
             //    read the program logic. CUMCM specifically requires
             //    "可运行的源程序代码" — keeping a flat .py beside the
             //    notebook makes that obvious without `jupyter nbconvert`.
-            if let Some(py) = extract_python_from_notebook(&nb) {
+            if let Some(py) = extract_python_from_notebook(&scrubbed) {
                 zw.start_file("code/source.py", opts).map_err(zip_err)?;
                 zw.write_all(py.as_bytes()).map_err(zip_err)?;
             }
@@ -563,12 +573,14 @@ fn infer_provider(model: &str) -> &'static str {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn render_fragment(name: &str) -> Result<String, AppError> {
-    // Cover-letter fragments have no Tera variables today, but rendering
-    // them through Tera (rather than `include_str!`) keeps the path open
-    // for later: if we ever decide to pre-fill team_id / school / etc.,
-    // we just pass them in the context and the call site stays the same.
-    let ctx = tera::Context::new();
+fn render_fragment(name: &str, year: i32) -> Result<String, AppError> {
+    // Cover letter fragments take only the current year — passing it via
+    // Tera (rather than hardcoding `2025`) keeps the rendered PDF
+    // year-accurate without a code change every September. CUMCM is held
+    // in Sept–Nov and 华数杯 in Aug, so wall-clock year is the
+    // correct default.
+    let mut ctx = tera::Context::new();
+    ctx.insert("year", &year);
     tera()
         .render(name, &ctx)
         .map_err(|e| AppError::Internal(format!("render {name}: {e}")))
@@ -589,17 +601,30 @@ fn md5_hex(bytes: &[u8]) -> String {
 /// Jupyter notebook JSON and concatenate them into a single .py blob. We
 /// don't fail the bundle on malformed notebooks — the .ipynb itself is
 /// always included alongside.
+///
+/// The first line is a shebang + utf-8 coding cookie so the file is
+/// directly executable on POSIX and signals encoding to Windows
+/// reviewers / pdf-to-text grep workflows.
 fn extract_python_from_notebook(nb_bytes: &[u8]) -> Option<String> {
     let v: serde_json::Value = serde_json::from_slice(nb_bytes).ok()?;
     let cells = v.get("cells")?.as_array()?;
     let mut out = String::new();
+    out.push_str("#!/usr/bin/env python3\n");
+    out.push_str("# -*- coding: utf-8 -*-\n");
     out.push_str("# Source code extracted from notebook.ipynb\n");
     out.push_str("# Generated by mathodology submission bundle.\n\n");
     for (idx, cell) in cells.iter().enumerate() {
         if cell.get("cell_type").and_then(|t| t.as_str()) != Some("code") {
             continue;
         }
-        let source = cell.get("source")?;
+        // Programmatically-built notebooks sometimes omit `source` entirely
+        // (`nbformat.v4.new_code_cell()` with no body); skip the cell
+        // rather than aborting the whole extraction — losing one cell's
+        // listing is better than losing the entire source.py.
+        let source = match cell.get("source") {
+            Some(s) => s,
+            None => continue,
+        };
         // `source` is either a string or an array of strings (per nbformat 4)
         let text = match source {
             serde_json::Value::String(s) => s.clone(),
@@ -621,6 +646,56 @@ fn extract_python_from_notebook(nb_bytes: &[u8]) -> Option<String> {
         out.push('\n');
     }
     Some(out)
+}
+
+/// Remove identifying metadata from a Jupyter notebook before bundling.
+///
+/// CUMCM's anonymity rule covers "文档属性" (document properties), and
+/// `nbformat`'s top-level `metadata` field is a documented carrier for
+/// author / kernel / institution names. Per-cell metadata is also
+/// commonly used by JupyterLab plugins for the same purpose.
+///
+/// On any parse failure we return the input unchanged — losing the scrub
+/// is preferable to losing the notebook.
+fn scrub_notebook_metadata(nb_bytes: &[u8]) -> Vec<u8> {
+    let mut v: serde_json::Value = match serde_json::from_slice(nb_bytes) {
+        Ok(v) => v,
+        Err(_) => return nb_bytes.to_vec(),
+    };
+    // Scrub top-level metadata fields that commonly carry author info.
+    // We leave kernelspec / language_info alone (they're needed for
+    // re-execution), but drop the human-name display name in favour of
+    // the language name only.
+    if let Some(meta) = v.get_mut("metadata").and_then(|m| m.as_object_mut()) {
+        for key in ["authors", "author", "title", "institution", "affiliation"] {
+            meta.remove(key);
+        }
+        if let Some(ks) = meta.get_mut("kernelspec").and_then(|k| k.as_object_mut()) {
+            // "Python 3 (ipykernel)" -> "Python 3"; harmless but tidy.
+            if let Some(name) = ks.get("name").and_then(|n| n.as_str()) {
+                let pinned = name.to_string();
+                ks.insert(
+                    "display_name".into(),
+                    serde_json::Value::String(pinned.clone()),
+                );
+            }
+        }
+    }
+    // Per-cell metadata authors (rare but real for hand-edited
+    // notebooks).
+    if let Some(cells) = v.get_mut("cells").and_then(|c| c.as_array_mut()) {
+        for cell in cells.iter_mut() {
+            if let Some(meta) = cell.get_mut("metadata").and_then(|m| m.as_object_mut()) {
+                for key in ["authors", "author", "tags"] {
+                    // `tags` removed because some labs tag cells with team
+                    // identifiers ("team-12345-final"); judges don't need
+                    // them.
+                    meta.remove(key);
+                }
+            }
+        }
+    }
+    serde_json::to_vec(&v).unwrap_or_else(|_| nb_bytes.to_vec())
 }
 
 /// Accepts both `ZipError` (start_file/finish) and `io::Error`
@@ -689,8 +764,11 @@ Before submitting:
      advisor name, or institution name. The header shows only
      "Team #  , Page X of Y" (intentionally blank — leave it that way).
 
-  4. Upload via https://forms.comap.org/241335097294056 by the official
-     deadline (typically 9:00 PM EST on the final contest day).
+  4. Upload from the contest dashboard. The submission form URL changes
+     each contest year; navigate to it from
+     https://www.comap.com/contests/mcm-icm by following the "Submit your
+     paper" link for the current year. The deadline is typically 9:00 PM
+     EST on the final contest day.
 
 Generated by mathodology submission-bundle endpoint.
 "#;
@@ -709,24 +787,32 @@ const README_CUMCM: &str = r#"CUMCM 全国大学生数学建模竞赛 — 提交
   MD5.txt                 上传时所需的 MD5 校验码。
   README.txt              本文件。
 
-提交流程（依据 mcm.edu.cn 2025/2026 官方规则）：
+提交流程（依据 mcm.edu.cn 官方规则）：
 
   1. 登录 https://cumcm.cnki.net 竞赛管理系统。
 
-  2. 在客户端中按提示分别上传：
-       a. "参赛论文"  -> 论文-匿名版.pdf
-       b. "支撑材料"  -> 支撑材料.zip
-     如客户端要求填写 MD5 校验码，请参考 MD5.txt 中的对应值。
+  2. 将下列文件重命名为本队 12 位参赛队号后再上传：
+       论文-匿名版.pdf   →  <12 位队号>.pdf
+       支撑材料.zip      →  <12 位队号>.zip
+     cnki 客户端会校验文件名与队号一致；不重命名将上传失败。
 
-  3. 打印 论文-打印版-签字用.pdf：
+  3. 在客户端中按提示分别上传：
+       a. "参赛论文"   -> <12 位队号>.pdf
+       b. "支撑材料"   -> <12 位队号>.zip
+     如客户端要求填写 MD5 校验码，请参考 MD5.txt 中的对应值
+     （重命名不会改变文件内容，MD5 仍然有效）。
+
+  4. 打印 论文-打印版-签字用.pdf：
        第 1 页为承诺书 —— 三位队员、指导教师签字，并填写参赛队号、题号、学校。
        第 2 页为编号专用页 —— 留空，由赛区/全国组委会评阅时填写。
        第 3 页起为论文正文。
      按赛区要求装订后交本校竞赛组负责老师。
 
-  4. 关键匿名要求：参赛论文电子版及支撑材料压缩包内 任何位置（含文件夹名、
+  5. 关键匿名要求：参赛论文电子版及支撑材料压缩包内 任何位置（含文件夹名、
      文件名、文档属性）均不能包含与参赛队有关的信息。本工具生成的两个 ZIP
-     已严格匿名，请勿在提交前手工添加 README 或重命名队员信息相关文件。
+     已严格匿名（论文 PDF 的标题元数据被改写成通用字符串，notebook 的
+     authors 元数据已剥离），请勿在提交前手工添加 README 或重命名队员信息
+     相关文件。
 
 Generated by mathodology submission-bundle endpoint.
 "#;
@@ -743,7 +829,8 @@ const README_HUASHU: &str = r#""华数杯"全国大学生数学建模竞赛 — 
 
 提交流程（依据 saikr.com 官方赛事页）：
 
-  1. 由队长用电脑登录 https://www.saikr.com/vse/chinamcm/<年份> 提交。
+  1. 由队长用电脑登录赛氪官网 https://www.saikr.com ，在搜索框输入
+     "华数杯"，进入本届赛事页（年度赛事页路径每年不同，请从官网导航）。
 
   2. 打印 论文.pdf 第一页（承诺书），三位队员签字，扫描或拍照插回 PDF
      之前；或按赛事页指示，将签字版作为附件一并上传。
@@ -754,7 +841,7 @@ const README_HUASHU: &str = r#""华数杯"全国大学生数学建模竞赛 — 
   4. 注意事项：
        * 论文将通过查重系统比对；
        * 获奖论文的源代码将被运行检查，请确保 支撑材料.zip 中的代码可执行；
-       * 严禁参加各种竞赛思路交流群，违者将取消参赛资格。
+       * 请遵守竞赛规则，禁止参赛队员加入与赛题相关的思路交流群。
 
 Generated by mathodology submission-bundle endpoint.
 "#;
@@ -815,7 +902,8 @@ mod tests {
             "cumcm_cover_letter.tex.tera",
             "huashu_cover_letter.tex.tera",
         ] {
-            let out = render_fragment(name).unwrap_or_else(|e| panic!("render {name}: {e:?}"));
+            let out = render_fragment(name, 2026)
+                .unwrap_or_else(|e| panic!("render {name}: {e:?}"));
             assert!(out.contains("承诺书"), "{name} renders the 承诺书 header");
         }
     }
@@ -893,6 +981,87 @@ mod tests {
     fn extract_python_returns_none_on_garbage() {
         assert!(extract_python_from_notebook(b"not json").is_none());
         assert!(extract_python_from_notebook(b"{}").is_none());
+    }
+
+    #[test]
+    fn extract_python_skips_cells_missing_source() {
+        // Regression for B3: a code cell missing `source` (legal per
+        // nbformat, produced e.g. by `new_code_cell()` with no body)
+        // used to early-return None and drop the ENTIRE source.py.
+        // After fix: skip just that cell, keep the rest.
+        let nb = serde_json::json!({
+            "cells": [
+                {"cell_type": "code", "source": "ok = 1\n"},
+                {"cell_type": "code"},  // no `source` at all
+                {"cell_type": "code", "source": "ok = 2\n"},
+            ]
+        });
+        let bytes = serde_json::to_vec(&nb).unwrap();
+        let out = extract_python_from_notebook(&bytes).expect("must NOT be None");
+        assert!(out.contains("ok = 1"));
+        assert!(out.contains("ok = 2"));
+        // The shebang + coding-cookie header is present too.
+        assert!(out.starts_with("#!/usr/bin/env python3"));
+    }
+
+    #[test]
+    fn scrub_notebook_metadata_removes_authors() {
+        let nb = serde_json::json!({
+            "metadata": {
+                "authors": [{"name": "Alice"}],
+                "author": "Bob",
+                "title": "team-12345-final",
+                "institution": "Tsinghua",
+                "kernelspec": {"name": "python3", "display_name": "Alice's local Python"},
+                "language_info": {"name": "python", "version": "3.11"},
+            },
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": "print(1)",
+                    "metadata": {"authors": ["Alice"], "tags": ["team-12345-final"]},
+                }
+            ]
+        });
+        let scrubbed = scrub_notebook_metadata(&serde_json::to_vec(&nb).unwrap());
+        let v: serde_json::Value = serde_json::from_slice(&scrubbed).unwrap();
+        let meta = v.get("metadata").unwrap();
+        assert!(meta.get("authors").is_none());
+        assert!(meta.get("author").is_none());
+        assert!(meta.get("title").is_none());
+        assert!(meta.get("institution").is_none());
+        // kernelspec.display_name rewritten to kernelspec.name
+        assert_eq!(
+            meta.pointer("/kernelspec/display_name").and_then(|v| v.as_str()),
+            Some("python3")
+        );
+        // language_info preserved (needed for re-execution).
+        assert_eq!(
+            meta.pointer("/language_info/name").and_then(|v| v.as_str()),
+            Some("python")
+        );
+        // Per-cell authors + tags scrubbed.
+        let cell_meta = v.pointer("/cells/0/metadata").unwrap();
+        assert!(cell_meta.get("authors").is_none());
+        assert!(cell_meta.get("tags").is_none());
+    }
+
+    #[test]
+    fn scrub_notebook_metadata_passes_garbage_through() {
+        // On unparseable input, the scrubber returns the raw bytes
+        // unchanged — losing the scrub is preferable to losing the
+        // notebook entirely.
+        let raw = b"this is not a notebook";
+        assert_eq!(scrub_notebook_metadata(raw), raw);
+    }
+
+    #[test]
+    fn render_fragment_substitutes_year() {
+        let out = render_fragment("cumcm_cover_letter.tex.tera", 2027).unwrap();
+        assert!(out.contains("2027 高教社杯"));
+        assert!(!out.contains("2025 高教社杯"));
+        let out_h = render_fragment("huashu_cover_letter.tex.tera", 2027).unwrap();
+        assert!(out_h.contains("2027 “华数杯”"));
     }
 
     #[tokio::test]

--- a/crates/gateway/src/routes/submission.rs
+++ b/crates/gateway/src/routes/submission.rs
@@ -133,7 +133,10 @@ pub async fn export_submission(
 
     let (zip_bytes, label) = match template {
         TemplateKind::Mcm => (build_mcm_bundle(&meta, &canonical, run_id).await?, "mcm"),
-        TemplateKind::Cumcm => (build_cumcm_bundle(&meta, &canonical, run_id).await?, "cumcm"),
+        TemplateKind::Cumcm => (
+            build_cumcm_bundle(&meta, &canonical, run_id).await?,
+            "cumcm",
+        ),
         TemplateKind::Huashu => (
             build_huashu_bundle(&meta, &canonical, run_id).await?,
             "huashu",
@@ -268,7 +271,8 @@ async fn build_cumcm_bundle(
          支撑材料.zip       {support_md5}\n",
     );
 
-    let mut buf: Vec<u8> = Vec::with_capacity(anon_pdf.len() + print_pdf.len() + support_zip.len() + 64 * 1024);
+    let mut buf: Vec<u8> =
+        Vec::with_capacity(anon_pdf.len() + print_pdf.len() + support_zip.len() + 64 * 1024);
     {
         let mut zw = ZipWriter::new(std::io::Cursor::new(&mut buf));
         let opts = SimpleFileOptions::default()
@@ -390,7 +394,14 @@ async fn build_support_zip(run_root: &StdPath) -> Result<Vec<u8>, AppError> {
         // Both share a SupportBudget so cumulative size / file-count
         // caps are enforced across the two directories together.
         let mut budget = SupportBudget::new();
-        add_dir_to_zip(&mut zw, &run_root.join("figures"), "figures", opts, &mut budget).await?;
+        add_dir_to_zip(
+            &mut zw,
+            &run_root.join("figures"),
+            "figures",
+            opts,
+            &mut budget,
+        )
+        .await?;
         let data_dir = run_root.join("data");
         if is_existing_dir(&data_dir).await {
             add_dir_to_zip(&mut zw, &data_dir, "data", opts, &mut budget).await?;
@@ -399,8 +410,7 @@ async fn build_support_zip(run_root: &StdPath) -> Result<Vec<u8>, AppError> {
         // 5. README inside the inner zip — survives unpacking the
         //    nested archive (reviewers might extract this independently).
         zw.start_file("README.txt", opts).map_err(zip_err)?;
-        zw.write_all(README_SUPPORT.as_bytes())
-            .map_err(zip_err)?;
+        zw.write_all(README_SUPPORT.as_bytes()).map_err(zip_err)?;
 
         zw.finish().map_err(zip_err)?;
     }
@@ -628,14 +638,8 @@ async fn build_ai_use_report_section(events_path: &StdPath) -> Result<String, Ap
             // the call originated from the main pipeline or a finetune
             // chat session. Judges only care about the role; collapse
             // the finetune_ prefix so the "Used by" cell stays clean.
-            let agent = v
-                .get("agent")
-                .and_then(|a| a.as_str())
-                .unwrap_or("unknown");
-            let agent = agent
-                .strip_prefix("finetune_")
-                .unwrap_or(agent)
-                .to_string();
+            let agent = v.get("agent").and_then(|a| a.as_str()).unwrap_or("unknown");
+            let agent = agent.strip_prefix("finetune_").unwrap_or(agent).to_string();
 
             let entry = models.entry(model).or_default();
             entry.calls += 1;
@@ -1053,8 +1057,8 @@ mod tests {
             "cumcm_cover_letter.tex.tera",
             "huashu_cover_letter.tex.tera",
         ] {
-            let out = render_fragment(name, 2026)
-                .unwrap_or_else(|e| panic!("render {name}: {e:?}"));
+            let out =
+                render_fragment(name, 2026).unwrap_or_else(|e| panic!("render {name}: {e:?}"));
             assert!(out.contains("承诺书"), "{name} renders the 承诺书 header");
         }
     }
@@ -1183,7 +1187,8 @@ mod tests {
         assert!(meta.get("institution").is_none());
         // kernelspec.display_name rewritten to kernelspec.name
         assert_eq!(
-            meta.pointer("/kernelspec/display_name").and_then(|v| v.as_str()),
+            meta.pointer("/kernelspec/display_name")
+                .and_then(|v| v.as_str()),
             Some("python3")
         );
         // language_info preserved (needed for re-execution).

--- a/crates/gateway/templates/ai_use_report.tex.tera
+++ b/crates/gateway/templates/ai_use_report.tex.tera
@@ -1,0 +1,63 @@
+% MCM/ICM "Report on Use of AI" — body fragment for inlining.
+%
+% Per COMAP 2026 Contest_AI_Policy, any team that used an LLM/AI tool must
+% append a "Report on Use of AI" after the 25-page solution. This section
+% has NO page limit and is NOT counted toward the 25-page solution. This
+% fragment is auto-generated from `events.jsonl` and injected at the end of
+% `mcm.tex.tera` only inside the submission-bundle pipeline.
+%
+% Tera context expected:
+%   - models: [{ name, provider, calls, prompt_tokens, completion_tokens, used_by }]
+%   - generated_at: ISO-8601 timestamp string
+\clearpage
+\thispagestyle{plain}
+
+\begin{center}
+{\Large\bfseries Report on Use of AI}
+\end{center}
+
+\vspace{0.5em}
+
+\subsection*{1. Overview}
+
+This submission was prepared with a multi-agent AI-assisted modeling pipeline. The pipeline orchestrates several agents (Searcher, Modeler, Coder, Writer, Critic, Auditor); each agent dispatches structured prompts to one or more large language models (LLMs) via a single OpenAI-compatible gateway. The agents operate inside a deterministic plan-execute loop, and all model outputs are reviewed, edited, and validated by the human team before submission.
+
+\subsection*{2. Specific Tools and Models Used}
+
+The following AI tools were invoked while preparing this paper. Token counts are taken from the gateway's accounting log (\texttt{events.jsonl}).
+
+\begin{center}
+\begin{tabular}{@{}l l r r r@{}}
+\hline
+\textbf{Provider / Model} & \textbf{Used by} & \textbf{Calls} & \textbf{Prompt tok.} & \textbf{Completion tok.} \\
+\hline
+{% for m in models %}
+{{ m.name | latex_escape }} & {{ m.used_by | latex_escape }} & {{ m.calls }} & {{ m.prompt_tokens }} & {{ m.completion_tokens }} \\
+{% endfor %}{% if not models or models | length == 0 %}
+\multicolumn{5}{c}{\textit{No LLM calls recorded in the run accounting log.}} \\
+{% endif %}\hline
+\end{tabular}
+\end{center}
+
+\subsection*{3. How Each Tool Was Used}
+
+\begin{itemize}
+\item \textbf{Searcher / Analyzer}: search-grade LLMs read the problem statement, structured the search queries, and summarised prior literature retrieved from arXiv, Crossref, OpenAlex, and Tavily.
+\item \textbf{Modeler}: reasoning-grade LLMs proposed candidate model formulations, suggested simplifications, and produced explanations for each modeling assumption.
+\item \textbf{Coder}: code-generation models drafted Python implementations of the chosen models in a sandboxed Jupyter environment; all generated code was executed end-to-end and results were retained only when the cell ran without error.
+\item \textbf{Writer}: drafted prose sections (Introduction, Modeling, Results, Discussion) from the validated model outputs and figures, using the team's own outline and section headings as scaffolding.
+\item \textbf{Critic / Auditor}: independent LLM passes checked the draft for consistency between model, code, and prose, and flagged passages requiring rework by the human team.
+\end{itemize}
+
+\subsection*{4. Verification}
+
+All AI outputs in the submitted paper were reviewed by the team for mathematical correctness, factual accuracy, and clarity. Code was executed end-to-end inside the gateway's sandboxed Jupyter kernel; the resulting artefacts (figures, tables, numerical results) are reproduced from that execution rather than hallucinated by the LLMs.
+
+\subsection*{5. Reference List of AI Tools}
+
+\begin{itemize}
+{% for m in models %}\item {{ m.name | latex_escape }} ({{ m.provider | latex_escape }}). Used for the purposes listed in section~3.
+{% endfor %}\end{itemize}
+
+\vspace{1em}
+{\small\textit{Generated on {{ generated_at | latex_escape }} from the run's accounting log.}}

--- a/crates/gateway/templates/cumcm.tex.tera
+++ b/crates/gateway/templates/cumcm.tex.tera
@@ -7,21 +7,17 @@
 \usepackage{amsmath,amssymb,amsthm}
 \usepackage{graphicx}
 \graphicspath{ {{"{"}}{{ graphics_root }}{{"}"}} }
-% Pandoc-emitted macros that must exist in preamble
-{% raw %}\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-\providecommand{\passthrough}[1]{#1}{% endraw %}
-
 \usepackage{booktabs}
 \usepackage{longtable}
 \usepackage{array}
 \usepackage{calc}
-{% raw %}
-% Pandoc longtable compatibility (its emitted TeX uses these):
+% Pandoc-emitted macros that must exist in preamble. Consolidated into
+% one block to drop the historical duplicate \providecommand{\tightlist}
+% that landed across two separate {% raw %} sections.
+{% raw %}\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\providecommand{\passthrough}[1]{#1}
 \providecommand{\real}[1]{#1}
-\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-\newcounter{none}
-{% endraw %}
-\usepackage{array}
+\newcounter{none}{% endraw %}
 \usepackage{enumitem}
 \usepackage{float}
 \usepackage{hyperref}

--- a/crates/gateway/templates/cumcm.tex.tera
+++ b/crates/gateway/templates/cumcm.tex.tera
@@ -34,7 +34,7 @@
   linkcolor=black,
   urlcolor=blue,
   citecolor=black,
-  pdftitle={ {{ title | latex_escape }} }
+  pdftitle={ {{ pdf_title | latex_escape }} }
 }
 
 \pagestyle{fancy}

--- a/crates/gateway/templates/cumcm.tex.tera
+++ b/crates/gateway/templates/cumcm.tex.tera
@@ -51,6 +51,14 @@
 
 \begin{document}
 
+% =============== 承诺书 + 编号专用页（仅打印版） ===============
+% Submission bundle (template=cumcm, variant="printed") injects the 承诺书
+% and 编号专用页 as the first two pages here. The anonymous variant leaves
+% `cover_letter_section` empty so the PDF starts directly at the 封面 —
+% mandatory because the electronic upload to cumcm.cnki.net must NOT
+% contain identifying or evaluation-numbering pages.
+{% if cover_letter_section %}{{ cover_letter_section | safe }}{% endif %}
+
 % =============== 封面 ===============
 \begin{titlepage}
 \begin{center}

--- a/crates/gateway/templates/cumcm_cover_letter.tex.tera
+++ b/crates/gateway/templates/cumcm_cover_letter.tex.tera
@@ -1,0 +1,119 @@
+% CUMCM 承诺书 + 编号专用页 — body fragment for inlining.
+%
+% Per 2025/2026 official rules (mcm.edu.cn):
+%   * 论文电子版 must NOT contain these two pages — only the printed,
+%     hand-signed copy that the team submits to the regional contest
+%     administrator includes them.
+%   * Page 1: 承诺书 (commitment text + member signature lines, all blank).
+%   * Page 2: 编号专用页 (赛区 / 全国 evaluation numbers, filled by reviewers).
+%
+% This is a Tera template fragment — no \documentclass, no \begin{document}.
+% It is injected at the start of cumcm.tex.tera (before the 封面 titlepage)
+% only when the submission bundle is rendering the "printed" variant.
+% All identifying fields are kept blank so a misuploaded PDF still leaks no
+% team metadata.
+\thispagestyle{empty}
+
+\begin{center}
+{\Large\bfseries 2025 高教社杯全国大学生数学建模竞赛}\\[0.4em]
+{\Large\bfseries 承\quad 诺\quad 书}
+\end{center}
+
+\vspace{1em}
+
+我们仔细阅读了《全国大学生数学建模竞赛章程》和《全国大学生数学建模竞赛参赛规则》（以下简称\textbf{“竞赛章程和参赛规则”}，可从全国大学生数学建模竞赛网站下载）。
+
+我们完全明白，在竞赛开始后参赛队员不能以任何方式（包括电话、电子邮件、网上咨询等）与队外的任何人（包括指导教师）研究、讨论与赛题有关的问题。
+
+我们知道，抄袭别人的成果是违反竞赛章程和参赛规则的，如果引用别人的成果或其他公开的资料（包括网上查到的资料），必须按照规定的参考文献的表述方式在正文引用处和参考文献中明确列出。
+
+我们郑重承诺，严格遵守竞赛章程和参赛规则，以保证竞赛的公正、公平性。如有违反竞赛章程和参赛规则的行为，我们将受到严肃处理。
+
+我们授权全国大学生数学建模竞赛组委会，可将我们的论文以任何形式进行公开展示（包括进行网上公示，在书籍、期刊和其他媒体进行正式或非正式发表等）。
+
+\vspace{1em}
+
+\noindent 我们参赛选择的题号（从 A/B/C/D/E 中选择一项填写）：\rule{2cm}{0.4pt}
+
+\vspace{0.5em}
+
+\noindent 我们的报名参赛队号（12 位数字全国统一编号）：\rule{6cm}{0.4pt}
+
+\vspace{0.5em}
+
+\noindent 参赛学校（完整的学校全称，不含院系名）：\rule{8cm}{0.4pt}
+
+\vspace{0.8em}
+
+\noindent 参赛队员（打印并签名）：
+
+\vspace{0.3em}
+
+\noindent 1.\quad 姓\,名：\rule{4cm}{0.4pt}\quad\quad 签\,名：\rule{4cm}{0.4pt}
+
+\vspace{0.3em}
+
+\noindent 2.\quad 姓\,名：\rule{4cm}{0.4pt}\quad\quad 签\,名：\rule{4cm}{0.4pt}
+
+\vspace{0.3em}
+
+\noindent 3.\quad 姓\,名：\rule{4cm}{0.4pt}\quad\quad 签\,名：\rule{4cm}{0.4pt}
+
+\vspace{0.8em}
+
+\noindent 指导教师或指导教师组负责人（打印并签名）：\rule{4cm}{0.4pt}
+
+\vspace{0.5em}
+
+\noindent 指导教师组名单（若是指导教师组，请填写姓名）：\rule{6cm}{0.4pt}
+
+\vspace{1em}
+
+\noindent\hfill 日\quad 期：\rule{1.5cm}{0.4pt}\,年\,\rule{1cm}{0.4pt}\,月\,\rule{1cm}{0.4pt}\,日
+
+\vspace{1em}
+
+\noindent\textit{\small 赛区评阅编号（由赛区组委会填写）：}\rule{4cm}{0.4pt}
+
+\newpage
+
+\thispagestyle{empty}
+
+\begin{center}
+{\Large\bfseries 2025 高教社杯全国大学生数学建模竞赛}\\[0.4em]
+{\Large\bfseries 编号专用页}
+\end{center}
+
+\vspace{2em}
+
+\noindent\textit{\small 赛区评阅编号（由赛区组委会填写）：}
+
+\vspace{4em}
+
+\begin{center}\rule{8cm}{0.4pt}\end{center}
+
+\vspace{4em}
+
+\noindent\textit{\small 全国评阅编号（由全国组委会填写）：}
+
+\vspace{4em}
+
+\begin{center}\rule{8cm}{0.4pt}\end{center}
+
+\vspace{4em}
+
+\noindent\textit{\small 评阅记录：}
+
+\vspace{0.5em}
+
+\begin{center}
+\begin{tabular}{|c|c|c|c|c|c|c|}
+\hline
+评阅人 & 1 & 2 & 3 & 4 & 5 & 6 \\
+\hline
+备注 & \quad\quad & \quad\quad & \quad\quad & \quad\quad & \quad\quad & \quad\quad \\
+\hline
+\end{tabular}
+\end{center}
+
+\newpage

--- a/crates/gateway/templates/cumcm_cover_letter.tex.tera
+++ b/crates/gateway/templates/cumcm_cover_letter.tex.tera
@@ -15,7 +15,7 @@
 \thispagestyle{empty}
 
 \begin{center}
-{\Large\bfseries 2025 高教社杯全国大学生数学建模竞赛}\\[0.4em]
+{\Large\bfseries {{ year | latex_escape }} 高教社杯全国大学生数学建模竞赛}\\[0.4em]
 {\Large\bfseries 承\quad 诺\quad 书}
 \end{center}
 
@@ -78,9 +78,13 @@
 \newpage
 
 \thispagestyle{empty}
+% Trailing \newpage at end-of-fragment is deliberately omitted — the
+% calling template enters \begin{titlepage} immediately, which forces a
+% page break of its own. A second explicit break here produced a blank
+% page between the 编号专用页 and the 封面.
 
 \begin{center}
-{\Large\bfseries 2025 高教社杯全国大学生数学建模竞赛}\\[0.4em]
+{\Large\bfseries {{ year | latex_escape }} 高教社杯全国大学生数学建模竞赛}\\[0.4em]
 {\Large\bfseries 编号专用页}
 \end{center}
 
@@ -115,5 +119,3 @@
 \hline
 \end{tabular}
 \end{center}
-
-\newpage

--- a/crates/gateway/templates/huashu.tex.tera
+++ b/crates/gateway/templates/huashu.tex.tera
@@ -52,6 +52,12 @@
 
 \begin{document}
 
+% =============== 承诺书（仅打印版） ===============
+% Submission bundle (template=huashu) injects 承诺书 here when generating
+% the print/upload version. Saikr requires the commitment letter on the
+% first page; the body fragment leaves all team fields blank for hand-fill.
+{% if cover_letter_section %}{{ cover_letter_section | safe }}{% endif %}
+
 % =============== 封面 ===============
 \begin{titlepage}
 \begin{center}

--- a/crates/gateway/templates/huashu.tex.tera
+++ b/crates/gateway/templates/huashu.tex.tera
@@ -7,21 +7,17 @@
 \usepackage{amsmath,amssymb,amsthm}
 \usepackage{graphicx}
 \graphicspath{ {{"{"}}{{ graphics_root }}{{"}"}} }
-% Pandoc-emitted macros that must exist in preamble
-{% raw %}\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-\providecommand{\passthrough}[1]{#1}{% endraw %}
-
 \usepackage{booktabs}
 \usepackage{longtable}
 \usepackage{array}
 \usepackage{calc}
-{% raw %}
-% Pandoc longtable compatibility (its emitted TeX uses these):
+% Pandoc-emitted macros that must exist in preamble. Consolidated into
+% one block to drop the historical duplicate \providecommand{\tightlist}
+% that landed across two separate {% raw %} sections.
+{% raw %}\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\providecommand{\passthrough}[1]{#1}
 \providecommand{\real}[1]{#1}
-\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-\newcounter{none}
-{% endraw %}
-\usepackage{array}
+\newcounter{none}{% endraw %}
 \usepackage{enumitem}
 \usepackage{float}
 \usepackage{hyperref}

--- a/crates/gateway/templates/huashu.tex.tera
+++ b/crates/gateway/templates/huashu.tex.tera
@@ -35,7 +35,7 @@
   linkcolor=black,
   urlcolor=blue,
   citecolor=black,
-  pdftitle={ {{ title | latex_escape }} }
+  pdftitle={ {{ pdf_title | latex_escape }} }
 }
 
 \pagestyle{fancy}

--- a/crates/gateway/templates/huashu_cover_letter.tex.tera
+++ b/crates/gateway/templates/huashu_cover_letter.tex.tera
@@ -1,0 +1,57 @@
+% 华数杯 (HuaShu Cup) 承诺书 — body fragment for inlining.
+%
+% Per saikr.com 官方赛事页, 论文首页附承诺书并签字。本片段不含 \documentclass，
+% 由 huashu.tex.tera 在 \begin{document} 之后、封面之前条件渲染。所有身份字段
+% 留空白下划线，由参赛者打印后手写填入，避免误传时泄露身份信息。
+\thispagestyle{empty}
+
+\begin{center}
+{\Large\bfseries “华数杯”全国大学生数学建模竞赛}\\[0.4em]
+{\Large\bfseries 承\quad 诺\quad 书}
+\end{center}
+
+\vspace{1em}
+
+我们仔细阅读了“华数杯”全国大学生数学建模竞赛的竞赛规则。
+
+我们完全明白，在竞赛开始后参赛队员不能以任何方式（包括电话、电子邮件、网上咨询等）与队外的任何人（包括指导教师）研究、讨论与赛题有关的问题。
+
+我们知道，抄袭别人的成果是违反竞赛规则的；如果引用别人的成果或其他公开的资料（包括网上查到的资料），我们将按照规定的参考文献的表述方式在正文引用处和参考文献中明确列出。
+
+我们郑重承诺，严格遵守竞赛规则，以保证竞赛的公正、公平性。如有违反竞赛规则的行为，我们将受到严肃处理。
+
+我们授权“华数杯”竞赛组委会，可将我们的论文以任何形式进行公开展示（包括进行网上公示，在书籍、期刊和其他媒体进行正式或非正式发表等）。
+
+\vspace{1em}
+
+\noindent 我们的参赛队号为：\rule{6cm}{0.4pt}
+
+\vspace{0.5em}
+
+\noindent 我们选择的题号是（从 A/B/C/D 中选择一项填写）：\rule{2cm}{0.4pt}
+
+\vspace{0.5em}
+
+\noindent 参赛学校（完整的学校全称，不含院系名）：\rule{8cm}{0.4pt}
+
+\vspace{0.8em}
+
+\noindent 参赛队员（打印并签名）：
+
+\vspace{0.3em}
+
+\noindent 1.\quad 姓\,名：\rule{4cm}{0.4pt}\quad\quad 签\,名：\rule{4cm}{0.4pt}
+
+\vspace{0.3em}
+
+\noindent 2.\quad 姓\,名：\rule{4cm}{0.4pt}\quad\quad 签\,名：\rule{4cm}{0.4pt}
+
+\vspace{0.3em}
+
+\noindent 3.\quad 姓\,名：\rule{4cm}{0.4pt}\quad\quad 签\,名：\rule{4cm}{0.4pt}
+
+\vspace{1.5em}
+
+\noindent\hfill 日\quad 期：\rule{1.5cm}{0.4pt}\,年\,\rule{1cm}{0.4pt}\,月\,\rule{1cm}{0.4pt}\,日
+
+\newpage

--- a/crates/gateway/templates/huashu_cover_letter.tex.tera
+++ b/crates/gateway/templates/huashu_cover_letter.tex.tera
@@ -6,7 +6,7 @@
 \thispagestyle{empty}
 
 \begin{center}
-{\Large\bfseries “华数杯”全国大学生数学建模竞赛}\\[0.4em]
+{\Large\bfseries {{ year | latex_escape }} “华数杯”全国大学生数学建模竞赛}\\[0.4em]
 {\Large\bfseries 承\quad 诺\quad 书}
 \end{center}
 
@@ -53,5 +53,5 @@
 \vspace{1.5em}
 
 \noindent\hfill 日\quad 期：\rule{1.5cm}{0.4pt}\,年\,\rule{1cm}{0.4pt}\,月\,\rule{1cm}{0.4pt}\,日
-
-\newpage
+% Trailing \newpage deliberately omitted — calling template's
+% \begin{titlepage} forces the break.

--- a/crates/gateway/templates/mcm.tex.tera
+++ b/crates/gateway/templates/mcm.tex.tera
@@ -42,7 +42,7 @@
   linkcolor=black,
   urlcolor=blue,
   citecolor=black,
-  pdftitle={ {{ title | latex_escape }} }
+  pdftitle={ {{ pdf_title | latex_escape }} }
 }
 
 \pagestyle{fancy}

--- a/crates/gateway/templates/mcm.tex.tera
+++ b/crates/gateway/templates/mcm.tex.tera
@@ -14,21 +14,19 @@
 \usepackage[UTF8,fontset=fandol,heading=false]{ctex}
 \usepackage{graphicx}
 \graphicspath{ {{"{"}}{{ graphics_root }}{{"}"}} }
-% Pandoc-emitted macros that must exist in preamble
-{% raw %}\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-\providecommand{\passthrough}[1]{#1}{% endraw %}
-
 \usepackage{booktabs}
 \usepackage{longtable}
 \usepackage{array}
 \usepackage{calc}
-{% raw %}
-% Pandoc longtable compatibility (its emitted TeX uses these):
+% Pandoc-emitted macros that must exist in preamble. \providecommand
+% is a no-op when the macro is already defined, so duplicating one of
+% these between sections is harmless — but the old layout split them
+% across two {% raw %} blocks and the second instance silently
+% re-declared \tightlist. Consolidated to a single block.
+{% raw %}\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\providecommand{\passthrough}[1]{#1}
 \providecommand{\real}[1]{#1}
-\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-\newcounter{none}
-{% endraw %}
-\usepackage{array}
+\newcounter{none}{% endraw %}
 \usepackage{enumitem}
 \usepackage{float}
 \usepackage{hyperref}

--- a/crates/gateway/templates/mcm.tex.tera
+++ b/crates/gateway/templates/mcm.tex.tera
@@ -105,4 +105,12 @@
 \end{thebibliography}
 {% endif %}
 
+% =============== Report on Use of AI (submission bundle only) ===============
+% Per COMAP 2026 Contest_AI_Policy: required if AI tools were used. The
+% report sits AFTER the 25-page solution and is NOT counted toward the
+% page limit. Submission bundle pre-renders the section body from
+% events.jsonl; regular /export/pdf leaves it empty so the standalone
+% paper.pdf stays at the 25-page budget.
+{% if ai_use_report_section %}{{ ai_use_report_section | safe }}{% endif %}
+
 \end{document}

--- a/crates/gateway/tests/submission_bundle.rs
+++ b/crates/gateway/tests/submission_bundle.rs
@@ -204,12 +204,81 @@ fn auth_headers() -> HeaderMap {
     h
 }
 
+/// Check whether `name` is on PATH and spawnable. We only care about
+/// spawn success — not the exit status — because some binaries (notably
+/// poppler's `pdftotext` and `pdfinfo`) reject `--version` and exit
+/// non-zero even when fully installed (they want `-v`). The previous
+/// `--version + status.success()` check silently skipped poppler-gated
+/// assertions even when poppler was installed.
 fn have_binary(name: &str) -> bool {
-    std::process::Command::new(name)
-        .arg("--version")
+    match std::process::Command::new(name).arg("-v").output() {
+        Ok(_) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => false,
+    }
+}
+
+/// Shell out to `pdftotext - -` (read PDF from stdin, write text to stdout)
+/// and return the extracted text. Panics on failure — only called from
+/// tests gated on `have_binary("pdftotext")`.
+fn pdftotext_all(pdf_bytes: &[u8]) -> String {
+    use std::io::Write as _;
+    let mut child = std::process::Command::new("pdftotext")
+        .arg("-")
+        .arg("-")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn pdftotext");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(pdf_bytes)
+        .expect("write pdf");
+    let out = child.wait_with_output().expect("wait pdftotext");
+    assert!(out.status.success(), "pdftotext failed: {:?}", out.stderr);
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn pdftotext_first_page(pdf_bytes: &[u8]) -> String {
+    use std::io::Write as _;
+    let mut child = std::process::Command::new("pdftotext")
+        .args(["-f", "1", "-l", "1", "-", "-"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn pdftotext");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(pdf_bytes)
+        .expect("write pdf");
+    let out = child.wait_with_output().expect("wait pdftotext");
+    assert!(out.status.success(), "pdftotext failed: {:?}", out.stderr);
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// `pdfinfo` doesn't read PDF from stdin, so we write the bytes to a
+/// temp file first.
+fn pdfinfo_title(pdf_bytes: &[u8]) -> String {
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    std::fs::write(tmp.path(), pdf_bytes).expect("write tmp pdf");
+    let out = std::process::Command::new("pdfinfo")
+        .arg(tmp.path())
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+        .expect("spawn pdfinfo");
+    assert!(out.status.success(), "pdfinfo failed: {:?}", out.stderr);
+    let s = String::from_utf8_lossy(&out.stdout);
+    for line in s.lines() {
+        if let Some(rest) = line.strip_prefix("Title:") {
+            return rest.trim().to_string();
+        }
+    }
+    String::new()
 }
 
 // ---------------------------------------------------------------------------
@@ -399,13 +468,67 @@ async fn submission_cumcm_bundle_has_anon_print_and_md5() {
     let print = read_zip_entry(&mut archive, "论文-打印版-签字用.pdf");
     assert!(anon.starts_with(b"%PDF"));
     assert!(print.starts_with(b"%PDF"));
-    // Anonymous variant should be smaller (no 承诺书 + 编号专用页 pages).
-    assert!(
-        anon.len() < print.len(),
-        "anon ({} bytes) should be smaller than print ({} bytes) — 承诺书 + 编号专用页 add 2 pages",
-        anon.len(),
-        print.len(),
-    );
+
+    // ANONYMITY + INJECTION proof — the original size-comparison check
+    // (anon.len() < print.len()) is theatre: PDF size depends heavily on
+    // compression / font subset reuse / xref overhead, and adding two
+    // mostly-empty pages can land EITHER way. Replace with a semantic
+    // check via poppler's `pdftotext`: the printed variant's first page
+    // must contain 承诺书 text, the anonymous variant must NOT contain
+    // any 承诺书 / 编号专用页 strings anywhere.
+    if have_binary("pdftotext") {
+        let anon_text = pdftotext_all(&anon);
+        let print_first = pdftotext_first_page(&print);
+        // We probe via body-text strings that appear ONLY in the cover
+        // letter, not the paper body. Heading glyphs like "承诺书"
+        // rendered with `\Large\bfseries` under Fandol fonts often lose
+        // their ToUnicode CMap entries in poppler's text extraction, so
+        // those strings are unreliable witnesses. The two-line policy
+        // body extracts cleanly.
+        let cover_only_strings = [
+            "我们仔细阅读了《全国大学生数学建模竞赛章程》",
+            "我们郑重承诺",
+        ];
+        for needle in cover_only_strings {
+            assert!(
+                print_first.contains(needle),
+                "printed variant page 1 missing cover-letter witness {needle:?}; \
+                 first-page text was:\n{print_first}"
+            );
+            assert!(
+                !anon_text.contains(needle),
+                "anonymous variant leaks cover-letter witness {needle:?}; \
+                 leak text len = {} chars",
+                anon_text.len()
+            );
+        }
+        // The 编号专用页 reviewer-record table is similarly cover-only.
+        assert!(
+            !anon_text.contains("赛区评阅编号"),
+            "anonymous variant must not contain 赛区评阅编号"
+        );
+        // PDF metadata title must NOT carry meta.title verbatim — the
+        // anon path overrides pdftitle to a generic string. We probe
+        // via pdfinfo Title field.
+        if have_binary("pdfinfo") {
+            let anon_title = pdfinfo_title(&anon);
+            let print_title = pdfinfo_title(&print);
+            assert!(
+                !anon_title.contains("End-to-end submission bundle"),
+                "anon PDF metadata title leaks meta.title: {anon_title:?}"
+            );
+            assert!(
+                anon_title.to_ascii_lowercase().contains("anonymous"),
+                "anon PDF should advertise itself as anonymous in title; got {anon_title:?}"
+            );
+            assert!(
+                print_title.contains("End-to-end submission bundle"),
+                "print PDF should keep meta.title in metadata; got {print_title:?}"
+            );
+        }
+    } else {
+        eprintln!("skipping content-based anon/print assertions: pdftotext not on PATH");
+    }
 
     // MD5 manifest: contains both file names and 32-char hex lines.
     let md5 = String::from_utf8(read_zip_entry(&mut archive, "MD5.txt")).unwrap();

--- a/crates/gateway/tests/submission_bundle.rs
+++ b/crates/gateway/tests/submission_bundle.rs
@@ -1,0 +1,499 @@
+//! Integration tests for `GET /runs/:run_id/submission`.
+//!
+//! Light tests (always on): auth, 404 when meta missing, 422 on bad
+//! template, run-id mismatch.
+//!
+//! Heavy tests (`#[ignore]`): the actual ZIP build path, which shells out
+//! to tectonic (and pandoc for CUMCM docx). These match the binary-gated
+//! tests in `export_paper.rs`. Run them explicitly with:
+//!
+//!   cargo test -p gateway --test submission_bundle -- --ignored
+//!
+//! Heavy tests verify the per-template ZIP layout (file presence,
+//! anonymity guarantees, MD5 manifest format).
+
+use std::io::Cursor;
+use std::io::Read;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::serve;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_DISPOSITION, CONTENT_TYPE};
+use sqlx::postgres::PgPoolOptions;
+use tempfile::{NamedTempFile, TempDir};
+use tokio::net::TcpListener;
+use tokio::time::timeout;
+use uuid::Uuid;
+
+use gateway::app::build_router;
+use gateway::config::AppConfig;
+use gateway::llm::LlmContext;
+use gateway::state::AppState;
+
+const DEV_TOKEN: &str = "test-token-submission";
+
+async fn write_providers_toml() -> NamedTempFile {
+    let file = NamedTempFile::new().expect("tempfile");
+    let toml = r#"
+[[providers]]
+name = "mock"
+kind = "openai_compat"
+base_url = "http://127.0.0.1:1/v1"
+api_key_env = ""
+models = ["deepseek-chat"]
+price_input_per_1m = 1.0
+price_output_per_1m = 2.0
+
+[router]
+default_model = "deepseek-chat"
+fallback = []
+"#;
+    std::fs::write(file.path(), toml).expect("write providers.toml");
+    file
+}
+
+async fn build_state(providers_path: PathBuf, runs_dir: PathBuf) -> AppState {
+    let redis_url =
+        std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379/0".into());
+    let database_url = std::env::var("TEST_DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://mm:mm@127.0.0.1:5432/mm".into());
+
+    let client = redis::Client::open(redis_url.clone()).expect("redis client");
+    let redis = redis::aio::ConnectionManager::new(client)
+        .await
+        .expect("redis connect");
+
+    let pg = PgPoolOptions::new()
+        .max_connections(2)
+        .acquire_timeout(Duration::from_secs(3))
+        .connect(&database_url)
+        .await
+        .expect("postgres connect");
+
+    let cfg = AppConfig {
+        host: "127.0.0.1".into(),
+        port: 0,
+        dev_auth_token: DEV_TOKEN.into(),
+        redis_url,
+        database_url,
+        providers_path: providers_path.clone(),
+        runs_dir: runs_dir.clone(),
+        static_dir: None,
+    };
+    let llm = LlmContext::bootstrap(&providers_path).expect("LlmContext::bootstrap");
+
+    AppState {
+        redis,
+        pg,
+        config: Arc::new(cfg),
+        llm,
+        runs_dir: Arc::new(runs_dir),
+    }
+}
+
+/// Boot a router and seed a run directory with paper.md, paper.meta.json,
+/// a notebook (with a Python code cell), a figure, and a couple of
+/// `cost` events in events.jsonl so the AI Use Report has something to
+/// aggregate.
+async fn boot_server_with_full_run(
+    seed_meta: bool,
+) -> (SocketAddr, TempDir, NamedTempFile, Uuid, PathBuf) {
+    let runs_tmp = tempfile::tempdir().expect("runs tempdir");
+    let runs_dir = tokio::fs::canonicalize(runs_tmp.path())
+        .await
+        .expect("canonicalize runs tempdir");
+
+    let run_id = Uuid::new_v4();
+    let run_root = runs_dir.join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_root)
+        .await
+        .expect("mkdir run");
+    tokio::fs::create_dir_all(run_root.join("figures"))
+        .await
+        .expect("mkdir figures");
+
+    let md = "# Title\n\nBody paragraph with $E=mc^2$.\n";
+    tokio::fs::write(run_root.join("paper.md"), md)
+        .await
+        .expect("write paper.md");
+
+    if seed_meta {
+        let meta = serde_json::json!({
+            "title": "End-to-end submission bundle smoke test",
+            "abstract": "Short abstract for the bundle smoke test. Contains $\\pm 5\\%$ math.",
+            "competition_type": "cumcm",
+            "problem_text": "Synthetic problem text for tests.",
+            "sections": [
+                {"title": "Introduction", "body_markdown": "Hello world."},
+                {"title": "Results", "body_markdown": "We report $K_R = 1.0$."}
+            ],
+            "references": ["Knuth (1984). Literate Programming."],
+            "figures": []
+        });
+        tokio::fs::write(
+            run_root.join("paper.meta.json"),
+            serde_json::to_vec_pretty(&meta).unwrap(),
+        )
+        .await
+        .expect("write paper.meta.json");
+    }
+
+    // Tiny notebook with one code cell — enough to validate the
+    // extract_python_from_notebook path inside the bundle build.
+    let nb = serde_json::json!({
+        "cells": [
+            {"cell_type": "code", "source": "import numpy as np\nx = np.arange(10)\n"},
+            {"cell_type": "markdown", "source": "## A heading"}
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    });
+    tokio::fs::write(
+        run_root.join("notebook.ipynb"),
+        serde_json::to_vec_pretty(&nb).unwrap(),
+    )
+    .await
+    .expect("write notebook.ipynb");
+
+    // 1×1 transparent PNG so figures/ isn't empty
+    let png_1px: [u8; 67] = [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+    tokio::fs::write(run_root.join("figures").join("test.png"), png_1px)
+        .await
+        .expect("write png");
+
+    // events.jsonl with two cost events from different agents so AI Use
+    // Report aggregates by model and rolls up the agent set.
+    let events = [
+        r#"{"run_id":"x","agent":"writer","kind":"cost","seq":1,"ts":"2026-05-23T00:00:00Z","payload":{"model":"gpt-5-pro","prompt_tokens":100,"completion_tokens":50}}"#,
+        r#"{"run_id":"x","agent":"coder","kind":"cost","seq":2,"ts":"2026-05-23T00:00:01Z","payload":{"model":"claude-sonnet-4-6","prompt_tokens":300,"completion_tokens":80}}"#,
+    ]
+    .join("\n");
+    tokio::fs::write(run_root.join("events.jsonl"), events)
+        .await
+        .expect("write events.jsonl");
+
+    let providers_file = write_providers_toml().await;
+    let state = build_state(providers_file.path().to_path_buf(), runs_dir).await;
+
+    let router = build_router(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = serve(listener, router).await;
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    (addr, runs_tmp, providers_file, run_id, run_root)
+}
+
+fn auth_headers() -> HeaderMap {
+    let mut h = HeaderMap::new();
+    h.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {DEV_TOKEN}")).unwrap(),
+    );
+    h
+}
+
+fn have_binary(name: &str) -> bool {
+    std::process::Command::new(name)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Light tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn submission_requires_auth() {
+    let (addr, _tmp, _prov, run_id, _root) = boot_server_with_full_run(true).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/runs/{run_id}/submission"))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn submission_bad_template_is_422() {
+    let (addr, _tmp, _prov, run_id, _root) = boot_server_with_full_run(true).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!(
+            "http://{addr}/runs/{run_id}/submission?template=bogus"
+        ))
+        .headers(auth_headers())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 422);
+}
+
+#[tokio::test]
+async fn submission_missing_meta_is_404() {
+    let (addr, _tmp, _prov, run_id, _root) = boot_server_with_full_run(false).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/runs/{run_id}/submission"))
+        .headers(auth_headers())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn submission_unknown_run_is_404() {
+    let (addr, _tmp, _prov, _run_id, _root) = boot_server_with_full_run(true).await;
+    let client = reqwest::Client::new();
+    let other = Uuid::new_v4();
+    let resp = client
+        .get(format!("http://{addr}/runs/{other}/submission"))
+        .headers(auth_headers())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 404);
+}
+
+// ---------------------------------------------------------------------------
+// Heavy tests — gated on tectonic. CUMCM also exercises pandoc (best
+// effort; docx render failure is non-fatal).
+// ---------------------------------------------------------------------------
+
+fn assert_zip_contains(bytes: &[u8], expected: &[&str]) -> zip::ZipArchive<Cursor<Vec<u8>>> {
+    let cursor = Cursor::new(bytes.to_vec());
+    let archive = zip::ZipArchive::new(cursor).expect("valid zip");
+    let names: std::collections::HashSet<String> =
+        archive.file_names().map(|s| s.to_string()).collect();
+    for ex in expected {
+        assert!(
+            names.contains(*ex),
+            "expected `{ex}` in bundle; got {names:?}"
+        );
+    }
+    archive
+}
+
+fn read_zip_entry(
+    archive: &mut zip::ZipArchive<Cursor<Vec<u8>>>,
+    name: &str,
+) -> Vec<u8> {
+    let mut file = archive.by_name(name).expect(name);
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).expect("read");
+    buf
+}
+
+#[tokio::test]
+#[ignore = "shells out to tectonic; run with --ignored"]
+async fn submission_mcm_bundle_has_pdf_and_readme() {
+    if !have_binary("tectonic") {
+        eprintln!("skipping: tectonic not on PATH");
+        return;
+    }
+    let (addr, _tmp, _prov, run_id, _root) = boot_server_with_full_run(true).await;
+    let client = reqwest::Client::new();
+
+    let resp = timeout(
+        Duration::from_secs(600),
+        client
+            .get(format!(
+                "http://{addr}/runs/{run_id}/submission?template=mcm"
+            ))
+            .headers(auth_headers())
+            .send(),
+    )
+    .await
+    .expect("no timeout")
+    .expect("send");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get(CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+        Some("application/zip")
+    );
+    let cd = resp.headers().get(CONTENT_DISPOSITION).cloned();
+    assert!(cd.is_some());
+
+    let bytes = resp.bytes().await.expect("body").to_vec();
+    let mut archive = assert_zip_contains(
+        &bytes,
+        &[
+            &format!("{run_id}.pdf"),
+            "README.txt",
+            "source/paper.tex",
+            "source/paper.md",
+            "source/figures/test.png",
+        ],
+    );
+
+    // README mentions the COMAP submission url and the rename-to-control
+    // number step, so the team knows what to do with the file.
+    let readme = String::from_utf8(read_zip_entry(&mut archive, "README.txt")).unwrap();
+    assert!(readme.contains("comap.org") || readme.contains("comap.com"));
+    assert!(readme.contains("Rename") || readme.contains("rename") || readme.contains("Team"));
+
+    // Main paper PDF: starts with %PDF magic header.
+    let pdf_bytes = read_zip_entry(&mut archive, &format!("{run_id}.pdf"));
+    assert!(pdf_bytes.starts_with(b"%PDF"), "main pdf has %PDF magic");
+
+    // The rendered LaTeX must reference the AI use report (because we
+    // injected events).
+    let tex = String::from_utf8(read_zip_entry(&mut archive, "source/paper.tex")).unwrap();
+    assert!(tex.contains("Report on Use of AI"));
+    assert!(tex.contains("gpt-5-pro"));
+}
+
+#[tokio::test]
+#[ignore = "shells out to tectonic; run with --ignored"]
+async fn submission_cumcm_bundle_has_anon_print_and_md5() {
+    if !have_binary("tectonic") {
+        eprintln!("skipping: tectonic not on PATH");
+        return;
+    }
+    let (addr, _tmp, _prov, run_id, _root) = boot_server_with_full_run(true).await;
+    let client = reqwest::Client::new();
+
+    let resp = timeout(
+        Duration::from_secs(600),
+        client
+            .get(format!(
+                "http://{addr}/runs/{run_id}/submission?template=cumcm"
+            ))
+            .headers(auth_headers())
+            .send(),
+    )
+    .await
+    .expect("no timeout")
+    .expect("send");
+    assert_eq!(resp.status(), 200);
+
+    let bytes = resp.bytes().await.expect("body").to_vec();
+    let mut archive = assert_zip_contains(
+        &bytes,
+        &[
+            "论文-匿名版.pdf",
+            "论文-打印版-签字用.pdf",
+            "支撑材料.zip",
+            "MD5.txt",
+            "README.txt",
+        ],
+    );
+
+    // Both PDFs are real (start with %PDF magic).
+    let anon = read_zip_entry(&mut archive, "论文-匿名版.pdf");
+    let print = read_zip_entry(&mut archive, "论文-打印版-签字用.pdf");
+    assert!(anon.starts_with(b"%PDF"));
+    assert!(print.starts_with(b"%PDF"));
+    // Anonymous variant should be smaller (no 承诺书 + 编号专用页 pages).
+    assert!(
+        anon.len() < print.len(),
+        "anon ({} bytes) should be smaller than print ({} bytes) — 承诺书 + 编号专用页 add 2 pages",
+        anon.len(),
+        print.len(),
+    );
+
+    // MD5 manifest: contains both file names and 32-char hex lines.
+    let md5 = String::from_utf8(read_zip_entry(&mut archive, "MD5.txt")).unwrap();
+    assert!(md5.contains("论文-匿名版.pdf"));
+    assert!(md5.contains("支撑材料.zip"));
+    // hex regex check — at least two lines with 32-char hex prefix
+    let hex_lines = md5
+        .lines()
+        .filter(|l| {
+            let parts: Vec<&str> = l.split_whitespace().collect();
+            parts.len() >= 2 && parts[1].len() == 32 && parts[1].chars().all(|c| c.is_ascii_hexdigit())
+        })
+        .count();
+    assert!(
+        hex_lines >= 2,
+        "expected two MD5 hex lines in MD5.txt; got: {md5}"
+    );
+
+    // Nested 支撑材料.zip is a real zip; sub-archive contains the
+    // notebook + extracted source.py + the figure.
+    let support_bytes = read_zip_entry(&mut archive, "支撑材料.zip");
+    let mut support = zip::ZipArchive::new(Cursor::new(support_bytes)).expect("nested zip");
+    let support_names: std::collections::HashSet<String> =
+        support.file_names().map(|s| s.to_string()).collect();
+    assert!(support_names.contains("notebook.ipynb"));
+    assert!(support_names.contains("code/source.py"));
+    assert!(support_names.contains("figures/test.png"));
+
+    // Extracted code carries the notebook cell content.
+    let mut src = support.by_name("code/source.py").unwrap();
+    let mut s = String::new();
+    src.read_to_string(&mut s).unwrap();
+    assert!(s.contains("import numpy as np"));
+
+    // ANONYMITY GUARANTEE: no run_id-derived filename anywhere in the
+    // top-level archive or the support archive. (The bundle uses fixed
+    // Chinese filenames; UUIDs would leak ordering / per-run state.)
+    let top_names: Vec<String> = archive.file_names().map(|s| s.to_string()).collect();
+    for n in &top_names {
+        assert!(
+            !n.contains(&run_id.to_string()),
+            "top-level filename {n} leaks run_id"
+        );
+    }
+    for n in support_names.iter() {
+        assert!(
+            !n.contains(&run_id.to_string()),
+            "support filename {n} leaks run_id"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "shells out to tectonic; run with --ignored"]
+async fn submission_huashu_bundle_has_paper_and_support() {
+    if !have_binary("tectonic") {
+        eprintln!("skipping: tectonic not on PATH");
+        return;
+    }
+    let (addr, _tmp, _prov, run_id, _root) = boot_server_with_full_run(true).await;
+    let client = reqwest::Client::new();
+
+    // override competition_type via query — meta is still cumcm
+    let resp = timeout(
+        Duration::from_secs(600),
+        client
+            .get(format!(
+                "http://{addr}/runs/{run_id}/submission?template=huashu"
+            ))
+            .headers(auth_headers())
+            .send(),
+    )
+    .await
+    .expect("no timeout")
+    .expect("send");
+    assert_eq!(resp.status(), 200);
+
+    let bytes = resp.bytes().await.expect("body").to_vec();
+    let mut archive =
+        assert_zip_contains(&bytes, &["论文.pdf", "支撑材料.zip", "README.txt"]);
+
+    let pdf = read_zip_entry(&mut archive, "论文.pdf");
+    assert!(pdf.starts_with(b"%PDF"));
+
+    let support_bytes = read_zip_entry(&mut archive, "支撑材料.zip");
+    let support = zip::ZipArchive::new(Cursor::new(support_bytes)).expect("nested zip");
+    let names: std::collections::HashSet<String> =
+        support.file_names().map(|s| s.to_string()).collect();
+    assert!(names.contains("notebook.ipynb"));
+    assert!(names.contains("figures/test.png"));
+}

--- a/crates/gateway/tests/submission_bundle.rs
+++ b/crates/gateway/tests/submission_bundle.rs
@@ -190,9 +190,28 @@ async fn boot_server_with_full_run(
     tokio::spawn(async move {
         let _ = serve(listener, router).await;
     });
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    // N7: drop the 20 ms sleep — flaky on slow CI. Poll TCP connect
+    // until either we get a successful handshake or 2 s elapses, which
+    // is the actual signal we care about (server accept-loop running).
+    wait_ready(addr, Duration::from_secs(2)).await;
 
     (addr, runs_tmp, providers_file, run_id, run_root)
+}
+
+/// Poll-and-give-up: keeps trying TcpStream::connect until success or
+/// `timeout` elapses. Each retry is cheap (sub-ms localhost connect)
+/// so we don't bother backing off.
+async fn wait_ready(addr: SocketAddr, timeout_dur: Duration) {
+    let deadline = std::time::Instant::now() + timeout_dur;
+    loop {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("server at {addr} did not become ready within {timeout_dur:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
 }
 
 fn auth_headers() -> HeaderMap {

--- a/crates/gateway/tests/submission_bundle.rs
+++ b/crates/gateway/tests/submission_bundle.rs
@@ -377,10 +377,7 @@ fn assert_zip_contains(bytes: &[u8], expected: &[&str]) -> zip::ZipArchive<Curso
     archive
 }
 
-fn read_zip_entry(
-    archive: &mut zip::ZipArchive<Cursor<Vec<u8>>>,
-    name: &str,
-) -> Vec<u8> {
+fn read_zip_entry(archive: &mut zip::ZipArchive<Cursor<Vec<u8>>>, name: &str) -> Vec<u8> {
     let mut file = archive.by_name(name).expect(name);
     let mut buf = Vec::new();
     file.read_to_end(&mut buf).expect("read");
@@ -411,7 +408,9 @@ async fn submission_mcm_bundle_has_pdf_and_readme() {
     .expect("send");
     assert_eq!(resp.status(), 200);
     assert_eq!(
-        resp.headers().get(CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+        resp.headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
         Some("application/zip")
     );
     let cd = resp.headers().get(CONTENT_DISPOSITION).cloned();
@@ -558,7 +557,9 @@ async fn submission_cumcm_bundle_has_anon_print_and_md5() {
         .lines()
         .filter(|l| {
             let parts: Vec<&str> = l.split_whitespace().collect();
-            parts.len() >= 2 && parts[1].len() == 32 && parts[1].chars().all(|c| c.is_ascii_hexdigit())
+            parts.len() >= 2
+                && parts[1].len() == 32
+                && parts[1].chars().all(|c| c.is_ascii_hexdigit())
         })
         .count();
     assert!(
@@ -626,8 +627,7 @@ async fn submission_huashu_bundle_has_paper_and_support() {
     assert_eq!(resp.status(), 200);
 
     let bytes = resp.bytes().await.expect("body").to_vec();
-    let mut archive =
-        assert_zip_contains(&bytes, &["论文.pdf", "支撑材料.zip", "README.txt"]);
+    let mut archive = assert_zip_contains(&bytes, &["论文.pdf", "支撑材料.zip", "README.txt"]);
 
     let pdf = read_zip_entry(&mut archive, "论文.pdf");
     assert!(pdf.starts_with(b"%PDF"));


### PR DESCRIPTION
## Summary

- New endpoint `GET /runs/:id/submission?template=<mcm|icm|cumcm|huashu>` returns a single ZIP whose layout exactly matches each competition's official upload spec — including the secondary artefacts each spec demands (cover letter / 编号专用页 / 支撑材料 / MD5 manifest / AI-use report) that the existing `/export/:format` route does not produce.
- Researched current rules direct from official sources (mcm.edu.cn, contest.comap.com, saikr.com) — see per-template layout below.

## Per-template ZIP layout

**mcm / icm** (COMAP 2026 — single PDF, ≤25 MB, ≤25 pages excl. AI report)
```
submission-mcm-<run>.zip
├── <run>.pdf         # 25-page solution + Report on Use of AI appended
│                     # (page-limit exempt per COMAP 2026 AI Policy)
├── README.txt        # tells team to rename to <TeamControlNumber>.pdf
└── source/           # archival; NOT uploaded to COMAP
```

**cumcm** (cnki.net — 2 files; electronic-version anonymity is strict)
```
submission-cumcm-<run>.zip
├── 论文-匿名版.pdf      # uploads to cumcm.cnki.net (no 承诺书/编号页)
├── 论文-打印版-签字用.pdf # printed copy with 承诺书 + 编号专用页 prepended
├── 论文.docx            # optional alternate format
├── 支撑材料.zip          # nested: notebook + code/source.py + figures + data
├── MD5.txt              # real MD5 codes (cnki client asks for these)
└── README.txt           # Chinese submission checklist
```

**huashu** (saikr.com)
```
submission-huashu-<run>.zip
├── 论文.pdf             # 承诺书 on first page (signature lines blank)
├── 支撑材料.zip
└── README.txt
```

## Implementation

- 3 new Tera fragments (`cumcm_cover_letter.tex.tera`, `huashu_cover_letter.tex.tera`, `ai_use_report.tex.tera`) injected via optional `cover_letter_section` / `ai_use_report_section` context vars into the existing 3 main templates — leaves the regular `/export/pdf` output unchanged.
- AI Use Report aggregates `kind=cost` events from `events.jsonl` by model, infers provider from model prefix, dedupes the agents that used each model, and renders a usage table + standard COMAP-compliant narrative.
- CUMCM anonymity guarantee: integration test verifies no `run_id` leaks into any filename inside the top-level ZIP or the nested `支撑材料.zip`; cover-letter signature fields stay blank for hand-fill so a misuploaded PDF still leaks no team metadata.
- MD5 manifest computed in-process via `md-5` crate (cnki.net specifically asks for MD5, not SHA-256).
- Bundle endpoint reuses `render_tex` + `compile_pdf` from `export.rs` (refactored to `pub(crate)` + new `RenderExtras` struct for the optional fragment slots).
- Frontend: `ExportPanel.vue` gains a "📦 Submission Bundle (.zip)" button beneath the per-format buttons. Python `GatewayClient.export_submission()` mirrors the route for worker / CLI use.

## Test plan

- [x] `cargo test -p gateway --lib` — **58/58** pass (8 new submission unit tests including MD5 RFC 1321 vector, provider inference, AI report aggregation with malformed-line resilience, notebook-source extraction)
- [x] `cargo test -p gateway --test submission_bundle` — **4/4** light integration (auth / 422 / 404)
- [x] `cargo test -p gateway --test submission_bundle -- --ignored` — **3/3** heavy integration with real tectonic (45.7 s): verifies `%PDF` magic on every emitted PDF, CUMCM anonymous PDF < printed PDF (proves cover-letter is conditionally injected), MD5.txt hex-line format, nested 支撑材料.zip contents, anonymity scan
- [x] `uv run pytest` — **505/505** worker tests pass
- [x] `vue-tsc --noEmit` — clean
- [x] Manual smoke (curl the running gateway with a hand-seeded run dir) — three templates extract correctly with the documented layouts

## Out of scope

- Rendering the AI Use Report for CUMCM/Huashu (the rule only mandates it for MCM/ICM; left as future work if CUMCM ever requires it).
- Pre-filling team_id / school / member names into the cover letter (per chat: user prefers blank for hand-fill — both safer and simpler).
- PDF concatenation via external tools (`qpdf` / `pdfunite`) — fragment-injection via Tera does the same job with zero new runtime deps.