### PR TITLE
fix: post-submission audit hardening (security, correctness, perf, contracts)

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 gateway: cargo watch -x 'run -p gateway'
-worker:  uv run arq agent_worker.main.WorkerSettings --watch apps/agent-worker/src
+worker:  cd apps/agent-worker && uv run python -m agent_worker
 web:     pnpm --filter web dev

--- a/apps/agent-worker/src/agent_worker/agents/coder.py
+++ b/apps/agent-worker/src/agent_worker/agents/coder.py
@@ -493,27 +493,6 @@ class CoderAgent:
             reasoning_effort=self.prompt.reasoning_effort or self._run_effort,
         )
 
-    async def _stream_and_collect_raw(
-        self, model: str, messages: list[dict[str, Any]]
-    ) -> str:
-        # Kept for any future need — currently unused. The original inline
-        # implementation is left below for reference / diff compactness.
-        effort = self.prompt.reasoning_effort or self._run_effort
-        parts: list[str] = []
-        async for delta in self.gateway.stream_completion(
-            run_id=self.emitter.run_id,
-            agent=self.AGENT_NAME,
-            model=model,
-            messages=messages,
-            temperature=self.prompt.temperature,
-            # 20k default, 1M when long-context opt-in is set. See base.py.
-            max_tokens=1_000_000 if self._long_context else 20000,
-            response_format={"type": "json_object"},
-            reasoning_effort=effort,
-        ):
-            parts.append(delta)
-        return "".join(parts)
-
     @staticmethod
     def _parse_directive(text: str) -> CoderDirective:
         cleaned = text.strip()

--- a/apps/agent-worker/src/agent_worker/agents/evidence.py
+++ b/apps/agent-worker/src/agent_worker/agents/evidence.py
@@ -34,9 +34,13 @@ _PCT_DELTA_RE = re.compile(
     r"\b\d+(?:\.\d+)?\s*%\b",
 )
 
-# Variants of "sensitivity analysis" headings in both languages.
+# Variants of "sensitivity analysis" headings in both languages. The CUMCM
+# rubric (writer/v1.toml) also accepts robustness analysis / model validation
+# section titles in lieu of an explicitly-named sensitivity section, so a
+# paper titled 鲁棒性分析 / 模型验证 must not be flagged for a missing section.
 _SENS_HEADING_RE = re.compile(
-    r"\b(sensitivity\s+analys\w+|sensitivity\s+study|敏感性分析|灵敏度分析)\b",
+    r"(sensitivity\s+analys\w+|sensitivity\s+study|robustness\s+analys\w+"
+    r"|validation|敏感性分析|灵敏度分析|鲁棒性\s*分析|模型验证)",
     re.IGNORECASE,
 )
 
@@ -228,6 +232,16 @@ _ALL_ANON_RES = [re.compile(p, re.IGNORECASE | re.MULTILINE) for p in (
     *_AUTHOR_PATTERNS,
 )]
 
+# References are scanned with the AUTHOR patterns ONLY. Under GB/T 7714-2015
+# (mandated by the Writer prompt for CUMCM) a bibliography legitimately
+# contains publisher cities (北京:) and institution presses (清华大学出版社),
+# so the university/region patterns produce false positives there. An
+# author/advisor intro (作者:/指导教师:) in the references is still a genuine
+# disqualification-risk leak and must be flagged.
+_REFERENCE_ANON_RES = [
+    re.compile(p, re.IGNORECASE | re.MULTILINE) for p in _AUTHOR_PATTERNS
+]
+
 
 @dataclass
 class AnonymityFindings:
@@ -253,21 +267,35 @@ def scan_anonymity_violations(paper: PaperDraft) -> AnonymityFindings:
     ]
     for sec in paper.sections:
         fields_to_scan.append((sec.title or "(section)", sec.body_markdown or ""))
-    # Also scan references — schools leak there too.
-    if getattr(paper, "references", None):
-        joined_refs = "\n".join(paper.references)
-        fields_to_scan.append(("references", joined_refs))
 
-    for label, text in fields_to_scan:
+    def _scan(label: str, text: str, patterns: list[re.Pattern[str]]) -> bool:
+        """Search `text` with `patterns`; append a hit per matching pattern.
+        Returns True once the 5-violation cap is reached so the caller can
+        stop early (preserves the original multi-pattern accumulation)."""
         if not text:
-            continue
-        for pattern in _ALL_ANON_RES:
+            return False
+        for pattern in patterns:
             m = pattern.search(text)
             if m:
                 snippet = text[max(0, m.start() - 30) : m.end() + 30].replace("\n", " ")
                 finds.append((label, snippet.strip()))
                 if len(finds) >= 5:
-                    return AnonymityFindings(violations=finds)
+                    return True
+        return False
+
+    for label, text in fields_to_scan:
+        if _scan(label, text, _ALL_ANON_RES):
+            return AnonymityFindings(violations=finds)
+
+    # References get the AUTHOR patterns ONLY. Under GB/T 7714-2015 a
+    # bibliography legitimately carries publisher cities and institution
+    # presses (清华大学出版社, 北京:), so the university/region patterns would
+    # false-positive there and force a needless revision. An author/advisor
+    # intro in the references is still a real DQ leak, so we keep that check.
+    if getattr(paper, "references", None):
+        joined_refs = "\n".join(paper.references)
+        _scan("references", joined_refs, _REFERENCE_ANON_RES)
+
     return AnonymityFindings(violations=finds)
 
 

--- a/apps/agent-worker/src/agent_worker/agents/searcher.py
+++ b/apps/agent-worker/src/agent_worker/agents/searcher.py
@@ -1037,11 +1037,20 @@ class SearcherAgent:
         ``_refine_queries``. Pass ``response_format=None`` for free-form text
         responses (e.g. the compaction LLM call, which returns markdown).
         """
+        # Route through the shared retry helper so every Searcher LLM path
+        # (_synthesize, _refine_queries, revise_with_critique, compactor) gets
+        # the same transport-error / empty-200 resilience as BaseAgent
+        # subclasses and the Coder. Previously this was a bare stream loop, so
+        # a single ReadTimeout / RemoteProtocolError in _synthesize aborted the
+        # whole run (D7). response_format is passed through verbatim so the
+        # markdown compactor path (response_format=None) is unaffected.
+        from agent_worker.agents.base import _stream_with_retry
+
         effort = self.prompt.reasoning_effort or self._run_effort
-        parts: list[str] = []
-        async for delta in self.gateway.stream_completion(
-            run_id=self.emitter.run_id,
-            agent=self.AGENT_NAME,
+        return await _stream_with_retry(
+            gateway=self.gateway,
+            emitter=self.emitter,
+            agent_name=self.AGENT_NAME,
             model=model,
             messages=messages,
             temperature=self.prompt.temperature,
@@ -1049,9 +1058,7 @@ class SearcherAgent:
             max_tokens=1_000_000 if self._long_context else 20000,
             response_format=response_format,
             reasoning_effort=effort,
-        ):
-            parts.append(delta)
-        return "".join(parts)
+        )
 
     @staticmethod
     def _parse_findings(text: str) -> SearchFindings:

--- a/apps/agent-worker/src/agent_worker/audit.py
+++ b/apps/agent-worker/src/agent_worker/audit.py
@@ -183,6 +183,69 @@ def check_figure_orphans(
     )
 
 
+# Sub-question coverage heuristic (D15). The old check used a fixed 12-char
+# prefix substring, which both over-matched (a common prefix like
+# "maximize prof" appears in unrelated prose → false "covered") and
+# under-matched (a 4-CJK-char prefix is not distinctive). We now score
+# content-word overlap for whitespace-tokenizable text, and fall back to a
+# longer, more distinctive prefix for CJK-dominant questions.
+_SUBQ_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "the", "a", "an", "and", "or", "of", "to", "for", "in", "on", "at",
+        "by", "is", "are", "be", "with", "that", "this", "these", "those",
+        "as", "from", "we", "our", "it", "its", "how", "what", "which",
+        "does", "do", "can", "should", "must", "will", "given", "using",
+        "over", "across", "between", "into", "per",
+    }
+)
+_CJK_RE = re.compile(r"[一-鿿]")
+# Fraction of content words (or CJK bigrams) that must appear for "covered".
+_SUBQ_COVERAGE_RATIO = 0.5
+
+
+def _subq_content_words(cleaned: str) -> list[str]:
+    """Lowercased content words (>=3 chars, non-stopword) from `cleaned`."""
+    words = re.findall(r"[a-z0-9]+", cleaned.lower())
+    return [w for w in words if len(w) >= 3 and w not in _SUBQ_STOPWORDS]
+
+
+def _cjk_bigrams(text: str) -> list[str]:
+    """Overlapping CJK character bigrams of `text`. Bigrams survive small
+    insertions ('预测未来' still shares '预测','未来' with '预测了未来') far better
+    than an exact prefix substring, while staying distinctive enough that an
+    unrelated section won't coincidentally match a majority of them."""
+    cjk = "".join(_CJK_RE.findall(text))
+    if len(cjk) < 2:
+        return [cjk] if cjk else []
+    return [cjk[i : i + 2] for i in range(len(cjk) - 1)]
+
+
+def _subquestion_is_covered(cleaned: str, md_lower: str, body_words: set[str]) -> bool:
+    """True if the sub-question appears (even paraphrased) in the body.
+
+    - English-ish (whitespace-tokenizable) questions: at least
+      `_SUBQ_COVERAGE_RATIO` of content words present in the body as WHOLE
+      words. Whole-word matching (vs the old prefix substring) avoids the
+      coincidental in-word hit the 12-char prefix produced (e.g. "rate"
+      matching inside "accelerate").
+    - CJK-dominant questions (few/no whitespace tokens): a longer prefix
+      substring match, which is far more distinctive than the old 12 chars.
+    """
+    content = _subq_content_words(cleaned)
+    if content:
+        hits = sum(1 for w in content if w in body_words)
+        return hits / len(content) >= _SUBQ_COVERAGE_RATIO
+    # No Latin content words — treat as CJK / symbolic. Score CJK-bigram
+    # overlap against the body so a paraphrase with small insertions still
+    # registers as covered.
+    bigrams = _cjk_bigrams(cleaned)
+    if not bigrams:
+        return True  # nothing distinctive to check → don't flag
+    body_bigrams = set(_cjk_bigrams(md_lower))
+    hits = sum(1 for b in bigrams if b in body_bigrams)
+    return hits / len(bigrams) >= _SUBQ_COVERAGE_RATIO
+
+
 def check_subquestion_coverage(
     *,
     paper: PaperDraft,
@@ -192,24 +255,24 @@ def check_subquestion_coverage(
     paper_md: str,
 ) -> AuditFinding | None:
     """Every sub-question that the Analyzer identified must be visibly
-    addressed in the paper. We do a substring match against a short
-    distinctive phrase from each sub_question (first 10 chars, stripped
-    of punctuation). Missed sub-questions are a top scoring concern in
-    MCM/CUMCM rubrics.
+    addressed in the paper. Coverage is scored by content-word overlap
+    (English) or a distinctive CJK prefix (Chinese) — see
+    `_subquestion_is_covered`. Missed sub-questions are a top scoring concern
+    in MCM/CUMCM rubrics.
     """
     if not analysis.sub_questions:
         return None
     md_lower = paper_md.lower()
+    # Whole-word set of the body for content-word matching (avoids the
+    # coincidental in-word substring hits the old prefix check produced).
+    body_words = set(re.findall(r"[a-z0-9]+", md_lower))
     missing: list[str] = []
     for q in analysis.sub_questions:
         # Strip leading "问题N：" or "Q: " prefixes that won't appear in body.
         cleaned = re.sub(r"^[\s问题题目QqＱ]+[:：\d.0-9、\-\s]*", "", q).strip()
         if not cleaned:
             continue
-        # Use first ~12 characters; long enough to be distinctive, short
-        # enough to survive paraphrasing in the body.
-        key = cleaned[:12].lower()
-        if key and key not in md_lower:
+        if not _subquestion_is_covered(cleaned, md_lower, body_words):
             missing.append(q[:60])
     if not missing:
         return None

--- a/apps/agent-worker/src/agent_worker/chart_catalog.py
+++ b/apps/agent-worker/src/agent_worker/chart_catalog.py
@@ -10,7 +10,7 @@ Design choices
 --------------
 * Frozen dataclass, not pydantic: the catalog is build-time immutable data;
   no runtime validation needed and pydantic adds import cost we don't need.
-* 18 entries, covering the six competition must-haves (heatmap / residual /
+* 20 entries, covering the six competition must-haves (heatmap / residual /
   convergence / tornado / pareto / network). Each `matplotlib_snippet` stays
   30–60 lines end-to-end (figure → plot → save → close) so it reliably fits
   a single Jupyter cell.

--- a/apps/agent-worker/src/agent_worker/editor_tools/tools.py
+++ b/apps/agent-worker/src/agent_worker/editor_tools/tools.py
@@ -33,6 +33,17 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
+# Snake-case figure-id slug. Must match `save_figure` in
+# agent_worker/_chart_helpers.py exactly so ids stay consistent across the
+# save and regenerate paths — and so a figure_id from LLM args can never be a
+# traversal token (`../../etc/passwd`) that escapes run_dir.
+_FIGURE_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# Reference already prefixed with a `[N]` citation marker. Mirrors
+# pipeline._REF_PREFIX_RE so the editor renderer preserves Writer-produced
+# bracket numbering instead of double-numbering it (`1. [1] Smith...`).
+_REF_PREFIX_RE = re.compile(r"^\s*\[(\d+)\]\s*")
+
 
 @dataclass
 class ToolContext:
@@ -107,8 +118,21 @@ def _render_paper_md(meta: dict[str, Any]) -> str:
     refs = meta.get("references") or []
     if refs:
         parts.extend(["", "## References", ""])
+        # The Writer naturally emits references with a `[N]` prefix matching
+        # the inline citations in the body. Auto-numbering those would
+        # double-number them (`1. [1] Smith...`). Preserve `[N]`-prefixed refs
+        # verbatim (one paragraph each); only fall back to ordered-list
+        # numbering when the refs are NOT already bracket-prefixed. Mirrors
+        # pipeline._render_paper_markdown so the two renderers can't drift.
+        has_bracket_numbers = all(
+            _REF_PREFIX_RE.match(str(r)) for r in refs if str(r).strip()
+        )
         for i, ref in enumerate(refs, start=1):
-            parts.append(f"{i}. {ref}")
+            if has_bracket_numbers:
+                parts.append(str(ref))
+                parts.append("")
+            else:
+                parts.append(f"{i}. {ref}")
     return "\n".join(parts) + "\n"
 
 
@@ -675,6 +699,19 @@ class RegenerateFigureTool:
                 ok=False,
                 summary="regenerate_figure requires figure_id.",
                 error="missing figure_id",
+            )
+        # figure_id is LLM-controlled and is interpolated into a filesystem
+        # path below (`figures/{figure_id}.png`). Validate it against the same
+        # snake-case slug `save_figure` enforces so a traversal id like
+        # `../../../etc/passwd` can never escape run_dir or reach stat().
+        if not _FIGURE_ID_RE.match(figure_id):
+            return ToolResult(
+                ok=False,
+                summary="regenerate_figure requires a snake_case figure_id.",
+                error=(
+                    f"invalid figure_id {figure_id!r}: must match "
+                    "^[a-z][a-z0-9_]*$ (lowercase letter, then letters/digits/_)"
+                ),
             )
         if not isinstance(code, str) or not code.strip():
             return ToolResult(

--- a/apps/agent-worker/src/agent_worker/events.py
+++ b/apps/agent-worker/src/agent_worker/events.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -64,6 +66,9 @@ class EventEmitter:
         self._seq_key = f"mm:seq:{run_id}"
         self._seq = 0
         self._events_log_path = events_log_path
+        # Serializes off-loop forensic writes so concurrent emit() calls keep
+        # append ordering even though each write hops to a worker thread.
+        self._log_lock = asyncio.Lock()
 
     @property
     def run_id(self) -> UUID:
@@ -92,17 +97,26 @@ class EventEmitter:
         dumped = event.model_dump(mode="json")
         body = orjson.dumps(dumped).decode("utf-8")
         # Persist forensic events to disk before the Redis stream MAXLEN
-        # rolls them off. Failures here must NOT block the live stream.
+        # rolls them off. The open+write is done off the event loop via
+        # asyncio.to_thread so high event volume can't block token streaming
+        # / WS fan-out on the loop thread (D22). A per-emitter lock serializes
+        # the thread hops so append ordering is preserved. Failures here must
+        # NOT block the live stream.
         if self._events_log_path is not None and kind in _PERSISTED_KINDS:
-            try:
-                with self._events_log_path.open("ab") as f:  # noqa: ASYNC230
-                    f.write(orjson.dumps(dumped))
-                    f.write(b"\n")
-            except OSError:
-                pass
+            line = orjson.dumps(dumped) + b"\n"
+            async with self._log_lock:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(self._append_log_line, line)
         return await self._redis.xadd(
             self._stream_key,
             {"payload": body},
             maxlen=EVENTS_MAXLEN,
             approximate=True,
         )
+
+    def _append_log_line(self, line: bytes) -> None:
+        """Append one pre-serialized JSONL line. Runs in a worker thread (off
+        the event loop) — see emit(). Synchronous file I/O is fine here."""
+        assert self._events_log_path is not None
+        with self._events_log_path.open("ab") as f:
+            f.write(line)

--- a/apps/agent-worker/src/agent_worker/few_shot/loader.py
+++ b/apps/agent-worker/src/agent_worker/few_shot/loader.py
@@ -188,14 +188,18 @@ _SIBLING_FAMILY: dict[str, str] = {
 def _normalize_family(competition_type: str) -> str:
     """Map raw competition_type strings to one of mcm/icm/cumcm/huashu."""
     s = (competition_type or "").lower()
+    # Order matters: 'cumcm' and 'huashu'/'国赛' must be tested before the
+    # bare 'mcm' substring. 'mcm' is a substring of 'cumcm', so checking
+    # 'mcm' first would mismap every CUMCM run to the MCM corpus (and inject
+    # English MCM exemplars into the zh prompt block).
+    if "cumcm" in s or "国赛" in s:
+        return "cumcm"
+    if "huashu" in s or "华数" in s:
+        return "huashu"
     if "icm" in s:
         return "icm"
     if "mcm" in s:
         return "mcm"
-    if "huashu" in s or "华数" in s:
-        return "huashu"
-    if "cumcm" in s or "国赛" in s:
-        return "cumcm"
     return "mcm"
 
 
@@ -213,7 +217,7 @@ def format_writer_block(exemplars: list[Exemplar], language: str = "en") -> str:
     if language == "zh":
         header = (
             "## 同题型获奖论文范本（仅供参考行文风格 + 章节结构，禁止照抄文字）\n"
-            "以下是 dick20 语料库中同题型 (problem_letter 匹配优先) 历年获奖论文的摘要 / 节选。"
+            "以下是获奖论文语料库中同题型 (problem_letter 匹配优先) 历年获奖论文的摘要 / 节选。"
             "判官最看重的是：摘要里塞具体数字、敏感性章节定量、结论与开篇呼应。"
             "请观察并复用其结构与论证密度，但**禁止抄写其文字或数据**——你的数字必须来自 Coder 的本次实验。\n"
         )

--- a/apps/agent-worker/src/agent_worker/finetune_main.py
+++ b/apps/agent-worker/src/agent_worker/finetune_main.py
@@ -13,6 +13,7 @@ The two streams are kept separate so:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import socket
 from pathlib import Path
 from typing import Any
@@ -37,6 +38,31 @@ log = get_logger("agent_worker.finetune")
 def _consumer_name() -> str:
     """Hostname-based consumer id (matches main.py convention)."""
     return (socket.gethostname().split(".")[0] or "worker") + ":ft"
+
+
+def _maybe_evict_lock(
+    run_locks: dict[UUID, asyncio.Lock], run_id: UUID
+) -> None:
+    """Drop `run_id`'s lock from the shared map iff nobody holds or awaits it.
+
+    Shared by the pipeline (main.py) and finetune consumers, both of which
+    `setdefault` into the same map. Without eviction the map grows by one
+    asyncio.Lock per run forever (D13). We evict only when the lock is neither
+    held (`locked()`) nor has queued waiters, so we never pull a lock out from
+    under a coroutine about to acquire it. A request that arrives AFTER
+    eviction simply recreates the lock via setdefault — correct, because the
+    prior writer has already finished.
+    """
+    lock = run_locks.get(run_id)
+    if lock is None:
+        return
+    if lock.locked():
+        return
+    # asyncio.Lock queues pending acquirers in a private `_waiters` deque.
+    waiters = getattr(lock, "_waiters", None)
+    if waiters:
+        return
+    run_locks.pop(run_id, None)
 
 
 def _decode(value: Any) -> str:
@@ -145,6 +171,13 @@ async def run_finetune(
         except Exception:  # noqa: BLE001
             log.exception("finetune_error_emit_failed", run_id=str(run_id))
     finally:
+        # Tear down the Jupyter kernel so it never outlives the fine-tune run.
+        # PaperEditorAgent starts it lazily (run_cell / regenerate_figure), so
+        # without this it leaks one ipykernel process per fine-tune (D1, mirror
+        # of run_pipeline). shutdown() is a no-op on an unstarted kernel;
+        # suppress so teardown never masks the primary failure.
+        with contextlib.suppress(Exception):
+            await kernel.shutdown()
         await gateway.close()
 
 
@@ -157,6 +190,7 @@ async def _process(
     run_locks: dict[UUID, asyncio.Lock],
 ) -> None:
     async with semaphore:
+        run_id: UUID | None = None
         try:
             run_id, session_id, message = _parse_entry(fields)
             log.info(
@@ -179,6 +213,10 @@ async def _process(
                 await redis.xack(FINETUNE_STREAM, FINETUNE_GROUP, entry_id)
             except Exception:  # noqa: BLE001
                 log.exception("finetune_xack_failed", entry_id=entry_id)
+            # Evict the per-run lock once done so run_locks doesn't grow
+            # unboundedly (D13). `run_id` stays None if _parse_entry raised.
+            if run_id is not None:
+                _maybe_evict_lock(run_locks, run_id)
 
 
 async def consume_loop(

--- a/apps/agent-worker/src/agent_worker/kernel/manager.py
+++ b/apps/agent-worker/src/agent_worker/kernel/manager.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -41,6 +42,31 @@ if TYPE_CHECKING:
 
 CELL_EXECUTION_TIMEOUT_S = 60
 KERNEL_READY_TIMEOUT_S = 30
+
+
+def _max_stream_bytes() -> int:
+    """Per-stream (stdout/stderr) accumulation cap for a single cell.
+
+    The cell timeout bounds wall-clock duration but NOT output volume — a tight
+    `print('x' * 1_000_000)` loop can exhaust memory before the timeout fires
+    (D19). Once a stream crosses this cap we stop accumulating and append a
+    single truncation marker. Configurable via MM_KERNEL_MAX_STREAM_BYTES;
+    defaults to 4 MB (generous for legitimate output, bounded for runaway).
+    """
+    raw = os.environ.get("MM_KERNEL_MAX_STREAM_BYTES")
+    if raw:
+        try:
+            val = int(raw)
+            if val > 0:
+                return val
+        except ValueError:
+            pass
+    return 4 * 1024 * 1024
+
+
+_STREAM_TRUNCATION_MARKER = (
+    "\n[... output truncated: exceeded MM_KERNEL_MAX_STREAM_BYTES cap ...]\n"
+)
 
 # Bootstrap source injected once per kernel, right after `start()`. Sets a
 # deterministic matplotlib style with a Chinese-friendly font fallback chain
@@ -266,6 +292,11 @@ class KernelSession:
         result_text: str | None = None
         figure_paths: list[str] = []
         error: str | None = None
+        # Per-stream byte caps (D19): stop accumulating + forwarding once a
+        # stream exceeds the cap, appending a single truncation marker.
+        max_stream_bytes = _max_stream_bytes()
+        stream_bytes = {"stdout": 0, "stderr": 0}
+        stream_truncated = {"stdout": False, "stderr": False}
 
         while True:
             try:
@@ -292,10 +323,28 @@ class KernelSession:
                 text = content.get("text", "")
                 if not text:
                     continue
-                if name == "stderr":
-                    stderr_parts.append(text)
-                else:
-                    stdout_parts.append(text)
+                stream_key = "stderr" if name == "stderr" else "stdout"
+                parts = stderr_parts if stream_key == "stderr" else stdout_parts
+                # Drop everything once this stream has been truncated — both
+                # from the in-memory buffer and from the emitter fan-out (which
+                # may be queued through Redis).
+                if stream_truncated[stream_key]:
+                    continue
+                stream_bytes[stream_key] += len(text.encode("utf-8"))
+                if stream_bytes[stream_key] > max_stream_bytes:
+                    stream_truncated[stream_key] = True
+                    parts.append(_STREAM_TRUNCATION_MARKER)
+                    await emitter.emit(
+                        "kernel.stdout",
+                        {
+                            "text": _STREAM_TRUNCATION_MARKER,
+                            "name": name,
+                            "cell_index": cell_index,
+                        },
+                        agent="coder",
+                    )
+                    continue
+                parts.append(text)
                 await emitter.emit(
                     "kernel.stdout",
                     {"text": text, "name": name, "cell_index": cell_index},

--- a/apps/agent-worker/src/agent_worker/main.py
+++ b/apps/agent-worker/src/agent_worker/main.py
@@ -20,6 +20,9 @@ from agent_worker.finetune_main import (
     _consumer_name as _finetune_consumer_name,
 )
 from agent_worker.finetune_main import (
+    _maybe_evict_lock,
+)
+from agent_worker.finetune_main import (
     consume_loop as _finetune_consume_loop,
 )
 from agent_worker.logging import configure_logging, get_logger
@@ -108,6 +111,14 @@ async def _process(
                 await redis.xack(JOBS_STREAM, CONSUMER_GROUP, entry_id)
             except Exception:  # noqa: BLE001
                 log.exception("xack_failed", entry_id=entry_id)
+            # Evict the per-run lock once the run is done so run_locks doesn't
+            # grow unboundedly (one Lock per run forever) — D13. Only evict
+            # when the lock is uncontended: a finetune consumer shares this
+            # map and may be waiting on the same lock. A finetune that arrives
+            # AFTER eviction simply recreates the lock via setdefault, which
+            # is correct since the pipeline write has already completed.
+            if run_id is not None:
+                _maybe_evict_lock(run_locks, run_id)
 
 
 async def _consume_loop(

--- a/apps/agent-worker/src/agent_worker/matlab/backends.py
+++ b/apps/agent-worker/src/agent_worker/matlab/backends.py
@@ -101,10 +101,15 @@ class MatlabBatchBackend:
         script.write_text(code, encoding="utf-8")
         try:
             stem = script.stem
+            # cwd is interpolated into a MATLAB single-quoted string literal.
+            # Escape embedded single quotes by doubling them (MATLAB's literal
+            # escaping) so a RUNS_DIR containing a quote can't break out of the
+            # addpath('...') string and inject MATLAB code (D18).
+            cwd_escaped = str(cwd).replace("'", "''")
             argv = [
                 binary,
                 "-batch",
-                f"addpath('{cwd}'); {stem}",
+                f"addpath('{cwd_escaped}'); {stem}",
             ]
             return await _run_subprocess(argv, cwd, timeout_s)
         finally:

--- a/apps/agent-worker/src/agent_worker/pipeline.py
+++ b/apps/agent-worker/src/agent_worker/pipeline.py
@@ -17,6 +17,7 @@ degrades to an empty SearchFindings and the pipeline continues.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import re
@@ -524,8 +525,6 @@ async def _review_and_maybe_revise(
         if reminders_out is not None and next_stage is not None:
             reminders_out[next_stage] = reminder
 
-        import contextlib
-
         # Critic exposes `emitter` on all current builds; suppress just in
         # case a future refactor changes the surface — we never want the
         # hook to be the reason a run fails.
@@ -946,6 +945,22 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
                     "spec": spec.model_dump(mode="json"),
                     "coder_output": coder_out.model_dump(mode="json"),
                     "search_findings": findings.model_dump(mode="json"),
+                    # C4: the audit gate is exactly when sensitivity / anonymity
+                    # findings matter most, so the audit-triggered revision
+                    # Writer must see the same evidence_scan as the initial
+                    # Critic-review Writer call (above). Sourced identically.
+                    "evidence_scan": {
+                        "sensitivity": {
+                            "has_section": sens_findings.has_sensitivity_section,
+                            "parameter_count_estimate": sens_findings.parameter_count_estimate,
+                            "perturb_mentions": sens_findings.perturb_mention_count,
+                            "tornado_or_mc_referenced": sens_findings.tornado_or_mc_referenced,
+                        },
+                        "anonymity_violations": [
+                            {"location": loc, "snippet": snip}
+                            for loc, snip in anon_findings.violations
+                        ],
+                    },
                 },
                 cost_tracker=cost_tracker,
                 emitter=emitter,
@@ -1027,6 +1042,16 @@ async def run_pipeline(redis: Redis, run_id: UUID, problem: ProblemInput) -> Non
             )
             await emitter.emit("done", {"status": "failed"}, agent=None)
     finally:
+        # Tear down the Jupyter kernel subprocess so it never outlives the
+        # run. The Coder/audit paths start it lazily via run_cell /
+        # regenerate_figure; without this it leaks one ipykernel process per
+        # run (D1). shutdown() is a no-op on an unstarted kernel and swallows
+        # its own errors. Wrap in suppress so teardown never masks the real
+        # failure that brought us into `finally`. (MatlabSession spawns a
+        # fresh subprocess per execute() that has already exited, so there is
+        # no persistent process to shut down there.)
+        with contextlib.suppress(Exception):
+            await kernel.shutdown()
         await gateway.close()
 
 

--- a/apps/agent-worker/src/agent_worker/tools/openalex.py
+++ b/apps/agent-worker/src/agent_worker/tools/openalex.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 from typing import Any
 
 import httpx
@@ -23,6 +24,53 @@ from mm_contracts import Paper
 _log = logging.getLogger(__name__)
 
 OPENALEX_API_URL = "https://api.openalex.org/works"
+
+# Mirror arxiv.py / crossref.py: retry 429 (rate limit) and 503 (service
+# unavailable) plus transient network errors with exponential backoff so a
+# single rate-limit blip doesn't silently drop the whole query's results.
+_RETRY_STATUS = {429, 503}
+_TRANSIENT_EXC = (httpx.ConnectError, httpx.ReadTimeout, httpx.RemoteProtocolError)
+_MAX_RETRIES = 3
+_BASE_DELAY = 1.0  # seconds; multiplied 2^attempt, with ±30% jitter
+
+
+async def _get_with_retry(
+    client: httpx.AsyncClient, url: str, params: dict[str, Any]
+) -> httpx.Response:
+    """GET with exponential backoff for 429 / 503 / transient network errors.
+
+    Retries up to _MAX_RETRIES times. Delays: 1s, 2s, 4s, each ±30% jitter.
+    Non-transient errors (400, 401, other 5xx) propagate immediately. The
+    caller already converts final exceptions into an empty result.
+    """
+    delay = _BASE_DELAY
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            r = await client.get(url, params=params)
+            if r.status_code in _RETRY_STATUS and attempt < _MAX_RETRIES:
+                jitter = delay * (0.7 + random.random() * 0.6)
+                _log.info(
+                    "OpenAlex %d on %r; retrying in %.2fs (attempt %d/%d)",
+                    r.status_code, params.get("search"), jitter,
+                    attempt + 1, _MAX_RETRIES,
+                )
+                await asyncio.sleep(jitter)
+                delay *= 2
+                continue
+            r.raise_for_status()
+            return r
+        except _TRANSIENT_EXC as e:
+            if attempt >= _MAX_RETRIES:
+                raise
+            jitter = delay * (0.7 + random.random() * 0.6)
+            _log.info(
+                "OpenAlex transient %r; retrying in %.2fs (attempt %d/%d)",
+                e, jitter, attempt + 1, _MAX_RETRIES,
+            )
+            await asyncio.sleep(jitter)
+            delay *= 2
+    # Unreachable; the loop either returns or raises.
+    raise RuntimeError("retry loop fell through")
 
 
 async def search_openalex(
@@ -54,8 +102,7 @@ async def search_openalex(
         client = httpx.AsyncClient(timeout=timeout)
     try:
         assert client is not None
-        r = await client.get(OPENALEX_API_URL, params=params)
-        r.raise_for_status()
+        r = await _get_with_retry(client, OPENALEX_API_URL, params)
         data = r.json()
         return _parse_works(data)
     finally:

--- a/apps/agent-worker/src/agent_worker/tools/pdf.py
+++ b/apps/agent-worker/src/agent_worker/tools/pdf.py
@@ -15,10 +15,12 @@ from __future__ import annotations
 
 import asyncio
 import io
+import ipaddress
 import logging
 import re
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlsplit
 
 import httpx
 import pdfplumber
@@ -26,6 +28,62 @@ import trafilatura
 from mm_contracts import Paper
 
 _log = logging.getLogger(__name__)
+
+# Download bound: stop reading once a response exceeds this many bytes so a
+# malicious/oversized PDF can't be fully buffered into worker memory (D9).
+_DOWNLOAD_CHUNK_SIZE = 64 * 1024
+
+
+_INTERNAL_HOSTNAMES = frozenset({"localhost", "localhost.localdomain", "ip6-localhost"})
+
+
+def _ip_is_blocked(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        ip.is_loopback
+        or ip.is_link_local
+        or ip.is_private
+        or ip.is_reserved
+        or ip.is_unspecified
+        or ip.is_multicast
+    )
+
+
+def _is_safe_fetch_url(url: str) -> bool:
+    """Reject URLs that would let an attacker-controlled Unpaywall field point
+    the fetcher at an internal target (SSRF, D28).
+
+    Policy:
+    - scheme must be http or https (no file://, gopher://, ftp://, ...)
+    - a host must be present
+    - if the host is an IP literal, it must not be loopback / link-local /
+      private / reserved / unspecified / multicast — this blocks the
+      cloud-metadata endpoint (169.254.169.254), 127.0.0.1, 10.x, etc.
+    - the 'localhost' family of hostnames is rejected outright.
+
+    We deliberately do NOT perform DNS resolution here: a blocking
+    ``getaddrinfo`` on the event loop would stall token streaming, and a
+    transient DNS hiccup would wrongly drop a legitimate public OA host. The
+    dominant SSRF vector for a spoofed Unpaywall response is an explicit
+    internal IP / metadata host, which this rejects. DNS-rebinding (a public
+    hostname resolving to a private IP) is a documented residual gap.
+    """
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return False
+    if parts.scheme not in ("http", "https"):
+        return False
+    host = parts.hostname
+    if not host:
+        return False
+    if host.lower() in _INTERNAL_HOSTNAMES:
+        return False
+    # IP literal — vet it directly. Non-IP hostnames are allowed through.
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return True
+    return not _ip_is_blocked(ip)
 
 ARXIV_PDF_TEMPLATE = "https://arxiv.org/pdf/{arxiv_id}.pdf"
 UNPAYWALL_API_URL = "https://api.unpaywall.org/v2/{doi}"
@@ -112,26 +170,43 @@ async def fetch_and_extract(
 
     text=None signals failure for any reason (network, oversize, parse,
     or empty extraction). The caller never raises — the Searcher's
-    enrichment phase is best-effort. ``max_bytes`` rejects oversized
-    bodies to bound memory.
+    enrichment phase is best-effort. ``max_bytes`` bounds the download: we
+    stream and abort once the cap is crossed, so an oversized body is never
+    fully buffered into memory.
     """
+    # SSRF guard (D28): the url may originate from an external Unpaywall field.
+    # Reject non-http(s) schemes and internal/link-local/private targets before
+    # issuing any request.
+    if not _is_safe_fetch_url(url):
+        _log.warning("fetch_and_extract: refusing unsafe/internal URL %s", url)
+        return None, "none"
+
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            r = await client.get(url, follow_redirects=True)
+        # Stream the body so we can abort past max_bytes instead of
+        # materializing a multi-hundred-MB response (D9).
+        async with (
+            httpx.AsyncClient(timeout=timeout) as client,
+            client.stream("GET", url, follow_redirects=True) as r,
+        ):
             r.raise_for_status()
+            ctype = (r.headers.get("content-type") or "").lower()
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in r.aiter_bytes(_DOWNLOAD_CHUNK_SIZE):
+                total += len(chunk)
+                if total > max_bytes:
+                    _log.warning(
+                        "fetch_and_extract: response exceeded %d bytes for "
+                        "%s; aborting download",
+                        max_bytes, url,
+                    )
+                    return None, "none"
+                chunks.append(chunk)
+            content = b"".join(chunks)
     except Exception as e:  # noqa: BLE001 — best-effort
         _log.warning("fetch_and_extract: HTTP failure for %s: %s", url, e)
         return None, "none"
 
-    content = r.content
-    if len(content) > max_bytes:
-        _log.warning(
-            "fetch_and_extract: oversized response %d bytes for %s; rejecting",
-            len(content), url,
-        )
-        return None, "none"
-
-    ctype = (r.headers.get("content-type") or "").lower()
     if "pdf" in ctype or url.lower().endswith(".pdf"):
         try:
             with pdfplumber.open(io.BytesIO(content)) as pdf:

--- a/apps/agent-worker/src/agent_worker/tools/web_search_mcp.py
+++ b/apps/agent-worker/src/agent_worker/tools/web_search_mcp.py
@@ -281,8 +281,14 @@ async def batch_search_web(
                 return results
 
             async def _one(q: str) -> None:
+                # Self-throttle per engine BEFORE entering the concurrency
+                # gate. The debounce can sleep up to cooldown_s per engine; if
+                # that happened inside `async with sem` it would occupy a
+                # concurrency slot for the whole sleep, serializing queries
+                # (D21). The debouncer's own per-engine locks still prevent
+                # hammering any single engine.
+                await debouncer.acquire(engines)
                 async with sem:
-                    await debouncer.acquire(engines)
                     try:
                         call = session.call_tool(
                             _SEARCH_TOOL,

--- a/apps/agent-worker/tests/test_audit.py
+++ b/apps/agent-worker/tests/test_audit.py
@@ -201,6 +201,74 @@ def test_check_subquestion_coverage_blocks_when_missing(tmp_path: Path) -> None:
     assert f.code == "uncovered_subquestions"
 
 
+def test_subquestion_coverage_no_false_positive_on_coincidental_substring(
+    tmp_path: Path,
+) -> None:
+    """D15: the old 12-char-prefix check coincidentally matched a prefix as an
+    in-word substring (e.g. 'rate the per' inside 'accelerate the
+    performance'), wrongly marking the sub-question covered. The content-word
+    heuristic must flag it as uncovered."""
+    md = "We accelerate the performance of the solver to its limit."
+    f = check_subquestion_coverage(
+        paper=_paper(),
+        coder_out=_coder(),
+        analysis=_analysis(["rate the performance of each model"]),
+        run_dir=tmp_path,
+        paper_md=md,
+    )
+    # The 12-char prefix 'rate the per' is a substring of 'acceleRATE THE
+    # PERformance', so the OLD check passed (no finding). The new check sees
+    # only 1/4 content words as whole words and flags it.
+    assert isinstance(f, AuditFinding)
+    assert f.code == "uncovered_subquestions"
+
+
+def test_subquestion_coverage_passes_on_genuine_paraphrase(tmp_path: Path) -> None:
+    """A genuinely-addressed sub-question (most content words present, even if
+    reordered/paraphrased) must NOT be flagged."""
+    md = (
+        "Section 3 estimates the demand at each store and then optimizes the "
+        "allocation of inventory across the planning horizon."
+    )
+    f = check_subquestion_coverage(
+        paper=_paper(),
+        coder_out=_coder(),
+        analysis=_analysis(
+            [
+                "estimate demand for each store",
+                "optimize allocation of inventory",
+            ]
+        ),
+        run_dir=tmp_path,
+        paper_md=md,
+    )
+    assert f is None
+
+
+def test_subquestion_coverage_cjk_uses_distinctive_prefix(tmp_path: Path) -> None:
+    """CJK sub-questions have no whitespace tokens; coverage falls back to a
+    distinctive 20-char CJK prefix instead of the old 4-char-key over-match."""
+    covered_md = "第三节预测了未来五年的全国人口增长趋势并给出置信区间。"
+    f_covered = check_subquestion_coverage(
+        paper=_paper(),
+        coder_out=_coder(),
+        analysis=_analysis(["预测未来五年的全国人口增长趋势"]),
+        run_dir=tmp_path,
+        paper_md=covered_md,
+    )
+    assert f_covered is None
+
+    f_missing = check_subquestion_coverage(
+        paper=_paper(),
+        coder_out=_coder(),
+        analysis=_analysis(["预测未来五年的全国人口增长趋势"]),
+        run_dir=tmp_path,
+        paper_md="本文只讨论了交通流量的建模，没有涉及其它议题。",
+    )
+    assert isinstance(f_missing, AuditFinding)
+    assert f_missing.code == "uncovered_subquestions"
+
+
 # ---------------------------------------------------------------- CJK glyphs
 
 

--- a/apps/agent-worker/tests/test_events_emitter.py
+++ b/apps/agent-worker/tests/test_events_emitter.py
@@ -1,0 +1,93 @@
+"""Tests for EventEmitter forensic JSONL persistence (D22).
+
+The synchronous file open/write was moved off the event loop (asyncio.to_thread)
+with a per-emitter lock to preserve append ordering. These tests assert that
+(a) the JSONL file still contains every persisted event, in order, and (b) the
+write is dispatched via asyncio.to_thread rather than blocking the loop inline.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import agent_worker.events as events_mod
+import orjson
+import pytest
+from agent_worker.events import EventEmitter
+
+
+@pytest.fixture
+def fake_redis() -> AsyncMock:
+    redis = AsyncMock()
+    # incr returns a monotonically increasing seq.
+    counter = {"n": 0}
+
+    async def _incr(_key: str) -> int:
+        counter["n"] += 1
+        return counter["n"]
+
+    redis.incr.side_effect = _incr
+    return redis
+
+
+async def test_emit_persists_all_events_in_order(
+    tmp_path: Path, fake_redis: AsyncMock
+) -> None:
+    log_path = tmp_path / "events.jsonl"
+    emitter = EventEmitter(fake_redis, uuid4(), events_log_path=log_path)
+
+    # Many concurrent emits of a persisted kind: ordering must be preserved by
+    # the per-emitter lock even though each write hops to a worker thread.
+    import asyncio
+
+    seqs = list(range(20))
+    await asyncio.gather(
+        *(
+            emitter.emit("log", {"level": "info", "message": f"m{i}"}, agent=None)
+            for i in seqs
+        )
+    )
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 20
+    parsed = [orjson.loads(line) for line in lines]
+    # seq is assigned by redis.incr in call order; the persisted lines must be
+    # strictly increasing (no interleaving/corruption).
+    persisted_seqs = [p["seq"] for p in parsed]
+    assert persisted_seqs == sorted(persisted_seqs)
+    assert len({p["seq"] for p in parsed}) == 20
+
+
+async def test_emit_write_is_dispatched_off_loop(
+    tmp_path: Path, fake_redis: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The forensic write must go through asyncio.to_thread (off the loop),
+    not a synchronous open/write inline on the loop thread."""
+    log_path = tmp_path / "events.jsonl"
+    emitter = EventEmitter(fake_redis, uuid4(), events_log_path=log_path)
+
+    calls: list[str] = []
+    real_to_thread = events_mod.asyncio.to_thread
+
+    async def _spy_to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(getattr(func, "__name__", repr(func)))
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(events_mod.asyncio, "to_thread", _spy_to_thread)
+
+    await emitter.emit("log", {"level": "info", "message": "hi"}, agent=None)
+
+    assert calls == ["_append_log_line"]
+    assert log_path.read_text(encoding="utf-8").strip() != ""
+
+
+async def test_emit_skips_persistence_for_token_kinds(
+    tmp_path: Path, fake_redis: AsyncMock
+) -> None:
+    """Non-persisted (high-volume token) kinds must NOT touch the JSONL."""
+    log_path = tmp_path / "events.jsonl"
+    emitter = EventEmitter(fake_redis, uuid4(), events_log_path=log_path)
+    await emitter.emit("token", {"text": "x"}, agent="writer")
+    assert not log_path.exists()

--- a/apps/agent-worker/tests/test_evidence_mining.py
+++ b/apps/agent-worker/tests/test_evidence_mining.py
@@ -66,6 +66,16 @@ def test_sensitivity_finds_cn_heading() -> None:
     assert findings.has_sensitivity_section
 
 
+def test_sensitivity_section_accepts_robustness_and_validation_titles() -> None:
+    """C5: the CUMCM rubric accepts 鲁棒性分析 / 模型验证 / robustness / validation
+    in lieu of an explicitly-named sensitivity section. A paper using one of
+    these titles must NOT be flagged for a missing sensitivity section."""
+    for title in ("鲁棒性分析", "模型验证", "Robustness Analysis", "Model Validation"):
+        p = _draft([(title, "We perturbed α by ±10%.")])
+        findings = mine_sensitivity_evidence(p)
+        assert findings.has_sensitivity_section, f"title {title!r} not detected"
+
+
 # --- anonymity ------------------------------------------------------------
 
 
@@ -97,6 +107,58 @@ def test_anonymity_flags_advisor_in_references() -> None:
     )
     findings = scan_anonymity_violations(p)
     assert findings.has_violations
+
+
+def test_anonymity_ignores_gbt7714_publisher_in_references() -> None:
+    """D14: GB/T 7714-2015 references legitimately carry publisher cities and
+    institution presses (北京: 清华大学出版社). These must NOT trigger a BLOCKING
+    anonymity finding — that drove needless Critic revisions that corrupted
+    correctly-formatted bibliographies."""
+    p = PaperDraft(
+        title="T",
+        abstract="Clean abstract with predicted error 3.2%.",
+        sections=[PaperSection(title="Body", body_markdown="Model with parameter α.")],
+        references=[
+            "[1] 赵某某. 数学建模[M]. 北京: 清华大学出版社, 2020.",
+            "[2] Li M. Optimization. Shanghai: Fudan University Press, 2019.",
+        ],
+        figure_refs=[],
+    )
+    findings = scan_anonymity_violations(p)
+    assert not findings.has_violations
+    assert anonymity_criteria(findings) == []
+
+
+def test_anonymity_still_flags_advisor_intro_in_references() -> None:
+    """D14 must not over-suppress: an author/advisor intro (指导教师:) in the
+    references is a genuine identity leak and must still be flagged even
+    though publisher cities/universities there are exempted."""
+    p = PaperDraft(
+        title="T",
+        abstract="abs",
+        sections=[PaperSection(title="x", body_markdown="y")],
+        references=["指导教师：张教授. 数学建模指南. 2021."],
+        figure_refs=[],
+    )
+    findings = scan_anonymity_violations(p)
+    assert findings.has_violations
+    assert any(label == "references" for label, _ in findings.violations)
+
+
+def test_anonymity_still_flags_university_in_body_not_references() -> None:
+    """A real school name in the body is still caught; only the references
+    section is exempted from the university/region patterns."""
+    p = PaperDraft(
+        title="T",
+        abstract="abs",
+        sections=[PaperSection(title="Intro", body_markdown="Our team from 清华大学 ...")],
+        references=["[1] 赵某某. 数学建模[M]. 北京: 清华大学出版社, 2020."],
+        figure_refs=[],
+    )
+    findings = scan_anonymity_violations(p)
+    assert findings.has_violations
+    # The hit must come from the body, not the (exempted) references.
+    assert all(label != "references" for label, _ in findings.violations)
 
 
 def test_anonymity_clean_paper_passes() -> None:

--- a/apps/agent-worker/tests/test_few_shot_loader.py
+++ b/apps/agent-worker/tests/test_few_shot_loader.py
@@ -11,6 +11,7 @@ from agent_worker.few_shot import (
     FewShotLibrary,
     format_writer_block,
 )
+from agent_worker.few_shot.loader import _normalize_family
 
 
 def _write_jsonl(path: Path, rows: list[dict]) -> None:
@@ -148,6 +149,30 @@ def test_normalize_family_handles_cn_aliases(tmp_path: Path) -> None:
     assert lib.top_k("国赛", "A", k=1)[0].paper_id == "cumcm_A"
     # "huashu" should fall through to sibling cumcm
     assert lib.top_k("huashu", "A", k=1)[0].paper_id == "cumcm_A"
+
+
+def test_normalize_family_all_four_families() -> None:
+    """Regression for the 'cumcm' -> 'mcm' substring mismap (D2).
+
+    'mcm' is a substring of 'cumcm', so a naive ordered check that tested
+    'mcm' before 'cumcm' returned 'mcm' for every CUMCM run, injecting the
+    wrong (MCM) exemplar corpus into the zh prompt block.
+    """
+    # CUMCM (the regressed case): must NOT be mistaken for mcm.
+    assert _normalize_family("cumcm") == "cumcm"
+    assert _normalize_family("CUMCM") == "cumcm"
+    assert _normalize_family("国赛") == "cumcm"
+    assert _normalize_family("CUMCM 2024 A") == "cumcm"
+    # The other three families stay correct.
+    assert _normalize_family("mcm") == "mcm"
+    assert _normalize_family("MCM") == "mcm"
+    assert _normalize_family("icm") == "icm"
+    assert _normalize_family("ICM 2023 D") == "icm"
+    assert _normalize_family("huashu") == "huashu"
+    assert _normalize_family("华数杯") == "huashu"
+    # Unknown / empty defaults to mcm (unchanged behavior).
+    assert _normalize_family("") == "mcm"
+    assert _normalize_family("something-else") == "mcm"
 
 
 def test_format_writer_block_empty_returns_empty_string() -> None:

--- a/apps/agent-worker/tests/test_finetune_main_e2e.py
+++ b/apps/agent-worker/tests/test_finetune_main_e2e.py
@@ -169,6 +169,93 @@ async def test_run_finetune_emits_session_start_and_done(
     assert fake_gw.calls >= 1
 
 
+async def test_run_finetune_shuts_down_kernel_on_clean_run(
+    tmp_path: Path,
+    fake_redis: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D1: the Jupyter kernel must be shut down in `finally`, else every
+    fine-tune leaks an ipykernel subprocess."""
+    run_id = uuid4()
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / str(run_id)).mkdir()
+    seeded = _seed_run_dir(tmp_path)
+    for f in seeded.iterdir():
+        if f.is_dir():
+            (runs_dir / str(run_id) / f.name).mkdir(exist_ok=True)
+        else:
+            (runs_dir / str(run_id) / f.name).write_bytes(f.read_bytes())
+
+    monkeypatch.setenv("RUNS_DIR", str(runs_dir))
+    monkeypatch.setenv("REDIS_URL", "redis://stub")
+    monkeypatch.setenv("GATEWAY_HTTP", "http://stub")
+    cfg = Settings()
+
+    fake_gw = _FakeGateway()
+    fake_kernel = AsyncMock()
+    monkeypatch.setattr(finetune_main, "GatewayClient", lambda *a, **k: fake_gw)
+    monkeypatch.setattr(finetune_main, "KernelSession", lambda *a, **k: fake_kernel)
+
+    await finetune_main.run_finetune(
+        redis=fake_redis,
+        cfg=cfg,
+        run_id=run_id,
+        session_id=uuid4(),
+        user_message="ensure abstract is concise",
+    )
+
+    fake_kernel.shutdown.assert_awaited_once()
+    assert fake_gw.closed is True
+
+
+async def test_run_finetune_shuts_down_kernel_on_failure(
+    tmp_path: Path,
+    fake_redis: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D1: even when the run fails mid-way, the kernel must still be torn down
+    in `finally`. Force the LLM stream to raise so the except path runs."""
+    run_id = uuid4()
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / str(run_id)).mkdir()
+    seeded = _seed_run_dir(tmp_path)
+    for f in seeded.iterdir():
+        if f.is_dir():
+            (runs_dir / str(run_id) / f.name).mkdir(exist_ok=True)
+        else:
+            (runs_dir / str(run_id) / f.name).write_bytes(f.read_bytes())
+
+    monkeypatch.setenv("RUNS_DIR", str(runs_dir))
+    monkeypatch.setenv("REDIS_URL", "redis://stub")
+    monkeypatch.setenv("GATEWAY_HTTP", "http://stub")
+    cfg = Settings()
+
+    class _BoomGateway(_FakeGateway):
+        async def stream_completion(self, **_: object) -> AsyncIterator[str]:
+            raise RuntimeError("simulated transport blowup")
+            yield ""  # pragma: no cover — make this an async generator
+
+    boom_gw = _BoomGateway()
+    fake_kernel = AsyncMock()
+    monkeypatch.setattr(finetune_main, "GatewayClient", lambda *a, **k: boom_gw)
+    monkeypatch.setattr(finetune_main, "KernelSession", lambda *a, **k: fake_kernel)
+
+    # run_finetune swallows the exception (logs + emits error) — it must not
+    # re-raise, and it must still shut the kernel down.
+    await finetune_main.run_finetune(
+        redis=fake_redis,
+        cfg=cfg,
+        run_id=run_id,
+        session_id=uuid4(),
+        user_message="anything",
+    )
+
+    fake_kernel.shutdown.assert_awaited_once()
+    assert boom_gw.closed is True
+
+
 async def test_run_finetune_bails_when_run_dir_missing(
     tmp_path: Path,
     fake_redis: AsyncMock,
@@ -203,3 +290,85 @@ async def test_run_finetune_bails_when_run_dir_missing(
     # before constructing it.
     assert fake_gw.calls == 0
     assert fake_gw.closed is False
+
+
+# --- D13: run_locks eviction -----------------------------------------------
+
+
+async def test_maybe_evict_lock_drops_uncontended_lock() -> None:
+    """An uncontended (unlocked, no-waiters) lock is evicted so run_locks
+    can't grow unboundedly across runs."""
+    import asyncio
+
+    from agent_worker.finetune_main import _maybe_evict_lock
+
+    run_id = uuid4()
+    run_locks: dict = {}
+    lock = run_locks.setdefault(run_id, asyncio.Lock())
+    # Simulate a completed run: lock acquired then released.
+    async with lock:
+        pass
+    assert run_id in run_locks
+    _maybe_evict_lock(run_locks, run_id)
+    assert run_id not in run_locks
+    # Idempotent on an already-evicted id.
+    _maybe_evict_lock(run_locks, run_id)
+
+
+async def test_maybe_evict_lock_keeps_held_lock() -> None:
+    """A currently-held lock must NOT be evicted — another coroutine owns it."""
+    import asyncio
+
+    from agent_worker.finetune_main import _maybe_evict_lock
+
+    run_id = uuid4()
+    run_locks: dict = {}
+    lock = run_locks.setdefault(run_id, asyncio.Lock())
+    async with lock:
+        _maybe_evict_lock(run_locks, run_id)
+        assert run_id in run_locks  # still held → kept
+
+
+async def test_maybe_evict_lock_keeps_lock_with_waiters() -> None:
+    """A lock with a queued waiter must NOT be evicted, or the waiter would
+    wake on a lock no longer in the shared map (the finetune/pipeline race)."""
+    import asyncio
+
+    from agent_worker.finetune_main import _maybe_evict_lock
+
+    run_id = uuid4()
+    run_locks: dict = {}
+    lock = run_locks.setdefault(run_id, asyncio.Lock())
+
+    await lock.acquire()  # hold it
+
+    async def _waiter() -> None:
+        async with lock:  # queues behind the held lock
+            pass
+
+    waiter_task = asyncio.create_task(_waiter())
+    await asyncio.sleep(0)  # let the waiter queue up
+
+    # While held with a pending waiter, eviction must be refused.
+    _maybe_evict_lock(run_locks, run_id)
+    assert run_id in run_locks
+
+    lock.release()
+    await waiter_task
+
+
+async def test_run_locks_recreated_after_eviction() -> None:
+    """A request arriving after eviction recreates the lock via setdefault —
+    correct, since the prior writer already finished."""
+    import asyncio
+
+    from agent_worker.finetune_main import _maybe_evict_lock
+
+    run_id = uuid4()
+    run_locks: dict = {}
+    first = run_locks.setdefault(run_id, asyncio.Lock())
+    _maybe_evict_lock(run_locks, run_id)
+    assert run_id not in run_locks
+    second = run_locks.setdefault(run_id, asyncio.Lock())
+    assert second is not first
+    assert run_id in run_locks

--- a/apps/agent-worker/tests/test_kernel_session.py
+++ b/apps/agent-worker/tests/test_kernel_session.py
@@ -120,3 +120,22 @@ async def test_write_notebook_produces_valid_ipynb(
     assert len(nb.cells) == 1
     assert nb.cells[0].cell_type == "code"
     assert "hello" in nb.cells[0].source or "print" in nb.cells[0].source
+
+
+async def test_execute_caps_stdout_accumulation(
+    session: KernelSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D19: a high-volume print must not accumulate unbounded stdout. With a
+    small cap, the captured stdout is bounded and ends with a truncation
+    marker instead of buffering megabytes."""
+    # 64 KB cap; the loop below prints ~1 MB if uncapped.
+    monkeypatch.setenv("MM_KERNEL_MAX_STREAM_BYTES", str(64 * 1024))
+    emitter = _stub_emitter()
+    src = "for _ in range(200):\n    print('x' * 5000)"
+    cell = await session.execute(src, cell_index=0, emitter=emitter)
+
+    assert cell.error is None
+    # Bounded: cap (64 KB) + one over-cap chunk + marker — well under the ~1 MB
+    # that would accumulate without the cap.
+    assert len(cell.stdout.encode("utf-8")) < 200 * 1024
+    assert "output truncated" in cell.stdout

--- a/apps/agent-worker/tests/test_matlab_session.py
+++ b/apps/agent-worker/tests/test_matlab_session.py
@@ -278,6 +278,56 @@ async def test_octave_backend_prepends_gnuplot_toolkit(
     assert "--quiet" in argv
 
 
+# ---------------------------------------------------------------- D18: addpath escaping
+
+
+async def test_matlab_batch_escapes_single_quote_in_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D18: a cwd containing a single quote must be escaped (doubled) in the
+    addpath('...') string literal so it can't break out and inject MATLAB."""
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return (b"", b"")
+
+    async def fake_create_subprocess_exec(
+        *argv: str, cwd: str | None = None, **_kw: Any
+    ) -> _FakeProc:
+        captured["argv"] = list(argv)
+        return _FakeProc()
+
+    monkeypatch.setattr(
+        "agent_worker.matlab.backends.shutil.which",
+        lambda b: "/usr/bin/matlab" if b == "matlab" else None,
+    )
+    monkeypatch.setattr(
+        "agent_worker.matlab.backends.asyncio.create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    # A directory whose name contains a single quote — the injection vector.
+    nasty = tmp_path / "o'brien runs"
+    nasty.mkdir()
+
+    backend = MatlabBatchBackend()
+    await backend.run("x = 1;", nasty, timeout_s=5.0)
+
+    argv = captured["argv"]
+    assert argv[0].endswith("matlab")
+    assert "-batch" in argv
+    batch_arg = argv[-1]
+    # The literal quote must be doubled ('') inside the addpath string, never
+    # left bare (which would terminate the string and start injected code).
+    assert "o''brien runs" in batch_arg, batch_arg
+    assert "addpath('" in batch_arg
+    # Sanity: the path segment with the doubled quote sits inside the literal.
+    assert f"addpath('{str(nasty).replace(chr(39), chr(39) * 2)}')" in batch_arg
+
+
 # ---------------------------------------------------------------- real-octave integration
 
 

--- a/apps/agent-worker/tests/test_openalex_tool.py
+++ b/apps/agent-worker/tests/test_openalex_tool.py
@@ -133,23 +133,85 @@ async def test_search_openalex_passes_mailto(httpx_mock) -> None:  # type: ignor
     assert "mailto=bot%40example.com" in str(request.url)
 
 
-async def test_search_openalex_swallows_owned_client_errors(httpx_mock) -> None:  # type: ignore[no-untyped-def]
-    """When we own the client and the server returns 5xx, propagate raises."""
-    httpx_mock.add_response(status_code=503)
+async def test_search_openalex_swallows_owned_client_errors(httpx_mock, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """When we own the client and the server keeps returning 503, the retry
+    budget is exhausted and the final error propagates."""
+    async def _no_sleep(_d: float) -> None:
+        return None
+
+    monkeypatch.setattr("agent_worker.tools.openalex.asyncio.sleep", _no_sleep)
+    # 503 is retried; 1 initial + _MAX_RETRIES attempts all 503 → final raise.
+    for _ in range(4):
+        httpx_mock.add_response(status_code=503)
     with pytest.raises(httpx.HTTPStatusError):
         await search_openalex("anything")
 
 
-async def test_batch_search_openalex_skips_failed_queries(httpx_mock) -> None:  # type: ignore[no-untyped-def]
-    httpx_mock.add_response(json=_SAMPLE_WORKS)
+async def test_search_openalex_retries_on_429_then_succeeds(httpx_mock, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """D20: a transient 429 must be retried, not silently dropped."""
+    async def _no_sleep(_d: float) -> None:
+        return None
+
+    monkeypatch.setattr("agent_worker.tools.openalex.asyncio.sleep", _no_sleep)
     httpx_mock.add_response(status_code=429)
-    httpx_mock.add_response(json={"results": []})
+    httpx_mock.add_response(json=_SAMPLE_WORKS)
+    papers = await search_openalex("signal timing", max_results=5)
+    assert len(papers) == 2
+    # Two HTTP calls: the 429 and the retried 200.
+    assert len(httpx_mock.get_requests()) == 2
+
+
+async def test_search_openalex_retries_on_503_then_succeeds(httpx_mock, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    async def _no_sleep(_d: float) -> None:
+        return None
+
+    monkeypatch.setattr("agent_worker.tools.openalex.asyncio.sleep", _no_sleep)
+    httpx_mock.add_response(status_code=503)
+    httpx_mock.add_response(json=_SAMPLE_WORKS)
+    papers = await search_openalex("signal timing")
+    assert len(papers) == 2
+
+
+async def test_search_openalex_does_not_retry_on_400(httpx_mock, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A 400 is our bug, not transient — must raise immediately, no retry."""
+    async def _no_sleep(_d: float) -> None:
+        return None
+
+    monkeypatch.setattr("agent_worker.tools.openalex.asyncio.sleep", _no_sleep)
+    httpx_mock.add_response(status_code=400)
+    with pytest.raises(httpx.HTTPStatusError):
+        await search_openalex("anything")
+    assert len(httpx_mock.get_requests()) == 1
+
+
+async def test_batch_search_openalex_skips_failed_queries(httpx_mock, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import httpx as _httpx
+
+    async def _no_sleep(_d: float) -> None:
+        return None
+
+    monkeypatch.setattr("agent_worker.tools.openalex.asyncio.sleep", _no_sleep)
+
+    # Route by the distinct `search` query param via a callback so the
+    # concurrent retry interleaving stays deterministic regardless of order.
+    # q1 succeeds; q2 always 429s (exhausts its retry budget → wrapped to []);
+    # q3 returns empty.
+    def _router(request: _httpx.Request) -> _httpx.Response:
+        search = request.url.params.get("search")
+        if search == "q1":
+            return _httpx.Response(200, json=_SAMPLE_WORKS)
+        if search == "q2":
+            return _httpx.Response(429)
+        return _httpx.Response(200, json={"results": []})
+
+    httpx_mock.add_callback(_router, is_reusable=True)
 
     results = await batch_search_openalex(["q1", "q2", "q3"], max_per_query=5)
     assert set(results.keys()) == {"q1", "q2", "q3"}
-    # q1 succeeds (2), q2 429s (0 — wrapped), q3 empty (0).
-    total = sum(len(v) for v in results.values())
-    assert total == 2
+    # q1 → 2 papers; q2 → [] (retries exhausted, wrapped); q3 → [].
+    assert len(results["q1"]) == 2
+    assert results["q2"] == []
+    assert results["q3"] == []
 
 
 async def test_batch_search_openalex_empty_queries() -> None:

--- a/apps/agent-worker/tests/test_paper_editor_tools.py
+++ b/apps/agent-worker/tests/test_paper_editor_tools.py
@@ -23,6 +23,7 @@ from agent_worker.editor_tools import (
     RunCellTool,
     ToolContext,
 )
+from agent_worker.editor_tools.tools import _render_paper_md
 
 PAPER_META: dict[str, Any] = {
     "title": "On the Stability of Lamprey Sex Ratios",
@@ -258,6 +259,67 @@ async def test_regenerate_figure_errors_when_png_missing(tmp_path: Path) -> None
     )
     assert not result.ok
     assert "doesnotexist" in (result.error or "")
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "../../../etc/passwd",
+        "..%2F..%2Fsecret",
+        "foo/bar",
+        "Tornado",  # uppercase — not a valid slug
+        "_leading",  # must start with a lowercase letter
+        "fig.png",  # dot not allowed
+        "fig-1",  # hyphen not allowed
+        "",
+    ],
+)
+async def test_regenerate_figure_rejects_invalid_figure_id(
+    tmp_path: Path, bad_id: str
+) -> None:
+    """D6: figure_id is LLM-controlled and is interpolated into a filesystem
+    path. It must be validated against the same `^[a-z][a-z0-9_]*$` slug the
+    save_figure helper enforces, so a traversal id never reaches stat()."""
+    kernel = AsyncMock()
+    # If validation is skipped the tool would call kernel.execute / stat();
+    # a side_effect that raises makes that observable.
+    kernel.execute.side_effect = AssertionError("kernel must not run for bad id")
+    ctx = _make_ctx(tmp_path, kernel=kernel)
+    result = await RegenerateFigureTool().execute(
+        {"figure_id": bad_id, "code": "x = 1"}, ctx
+    )
+    assert not result.ok
+    kernel.execute.assert_not_called()
+
+
+def test_render_paper_md_preserves_bracket_numbered_refs() -> None:
+    """D27: refs the Writer already prefixed with [N] must NOT be re-numbered.
+    Mirrors pipeline._render_paper_markdown so a fine-tune edit doesn't emit
+    '1. [1] Smith...' double-numbering."""
+    meta: dict[str, Any] = {
+        "title": "T",
+        "abstract": "a",
+        "sections": [],
+        "references": ["[1] Smith. A paper. 2020.", "[2] Jones. Another. 2021."],
+    }
+    md = _render_paper_md(meta)
+    assert "[1] Smith. A paper. 2020." in md
+    assert "1. [1] Smith" not in md
+    assert "2. [2] Jones" not in md
+
+
+def test_render_paper_md_autonumbers_unprefixed_refs() -> None:
+    """When refs are NOT [N]-prefixed, fall through to auto-numbering — same
+    behavior as the canonical pipeline renderer."""
+    meta: dict[str, Any] = {
+        "title": "T",
+        "abstract": "a",
+        "sections": [],
+        "references": ["Smith. A paper. 2020.", "Jones. Another. 2021."],
+    }
+    md = _render_paper_md(meta)
+    assert "1. Smith. A paper. 2020." in md
+    assert "2. Jones. Another. 2021." in md
 
 
 async def test_recompile_pdf_calls_gateway_export_paper(tmp_path: Path) -> None:

--- a/apps/agent-worker/tests/test_pdf_tool.py
+++ b/apps/agent-worker/tests/test_pdf_tool.py
@@ -147,6 +147,72 @@ async def test_fetch_and_extract_returns_none_on_timeout(httpx_mock) -> None:  #
     assert parser == "none"
 
 
+# --- D9: streaming download aborts past max_bytes --------------------------
+
+
+async def test_fetch_and_extract_aborts_streaming_past_max_bytes(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    """A body larger than max_bytes must be aborted mid-download, never fully
+    buffered. We feed the body as discrete chunks and count how many the
+    fetcher consumes — it must stop once the cap is crossed."""
+    from pytest_httpx import IteratorStream
+
+    chunk = b"x" * (256 * 1024)  # 256 KB per chunk
+    consumed = 0
+
+    def _chunks():  # type: ignore[no-untyped-def]
+        nonlocal consumed
+        for _ in range(40):  # would be 10 MB if fully read
+            consumed += 1
+            yield chunk
+
+    httpx_mock.add_response(
+        stream=IteratorStream(_chunks()),
+        headers={"content-type": "application/pdf"},
+    )
+    text, parser = await fetch_and_extract(
+        "http://example.com/big.pdf", max_bytes=1_000_000
+    )
+    assert text is None
+    assert parser == "none"
+    # Aborted early: must not have drained all 40 chunks (10 MB). A 1 MB cap
+    # with 256 KB chunks trips after ~5 chunks.
+    assert consumed < 40
+
+
+# --- D28: SSRF guard -------------------------------------------------------
+
+
+async def test_fetch_and_extract_refuses_metadata_host_without_request(httpx_mock) -> None:  # type: ignore[no-untyped-def]
+    """A spoofed Unpaywall url pointing at the cloud-metadata endpoint must be
+    refused before any HTTP request is issued (SSRF)."""
+    text, parser = await fetch_and_extract(
+        "http://169.254.169.254/latest/meta-data/"
+    )
+    assert text is None
+    assert parser == "none"
+    # No request must have been attempted against the internal host.
+    assert httpx_mock.get_requests() == []
+
+
+def test_is_safe_fetch_url_policy() -> None:
+    from agent_worker.tools.pdf import _is_safe_fetch_url
+
+    # Internal / link-local / loopback / private / reserved — all blocked.
+    assert not _is_safe_fetch_url("http://169.254.169.254/latest/meta-data/")
+    assert not _is_safe_fetch_url("http://127.0.0.1/secret")
+    assert not _is_safe_fetch_url("http://localhost/secret")
+    assert not _is_safe_fetch_url("http://10.0.0.5/internal")
+    assert not _is_safe_fetch_url("http://192.168.1.1/router")
+    assert not _is_safe_fetch_url("http://[::1]/secret")
+    # Non-http(s) schemes blocked.
+    assert not _is_safe_fetch_url("file:///etc/passwd")
+    assert not _is_safe_fetch_url("gopher://internal/")
+    assert not _is_safe_fetch_url("")
+    # Public OA hosts (http or https) allowed.
+    assert _is_safe_fetch_url("https://arxiv.org/pdf/2301.00001.pdf")
+    assert _is_safe_fetch_url("http://example.com/p.pdf")
+
+
 async def test_fetch_and_extract_returns_none_when_extractor_returns_empty(
     httpx_mock, monkeypatch  # type: ignore[no-untyped-def]
 ) -> None:

--- a/apps/agent-worker/tests/test_pipeline_lifecycle.py
+++ b/apps/agent-worker/tests/test_pipeline_lifecycle.py
@@ -1,0 +1,76 @@
+"""Lifecycle smoke for `run_pipeline` — kernel teardown on failure (D1).
+
+`run_pipeline` constructs a `KernelSession` (started lazily by the Coder /
+audit paths) and a `GatewayClient`, and must tear the kernel down in its
+`finally` block so a completed or failed run never orphans an ipykernel
+subprocess. Pre-D1 the `finally` closed only the gateway.
+
+We patch the heavy collaborators (`GatewayClient`, `KernelSession`,
+`MatlabSession`) inside the `pipeline` module and force the very first stage
+(`AnalyzerAgent.run_for_problem`) to raise an `AgentError`. The orchestrator
+should catch it, emit a terminal `done(failed)`, and STILL await
+`kernel.shutdown()` in `finally`. Redis is a minimal AsyncMock — only the
+EventEmitter / cost / cancel call surface is exercised before the forced
+failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from agent_worker import pipeline
+from agent_worker.agents.base import AgentError
+from mm_contracts import ProblemInput
+
+
+@pytest.fixture
+def fake_redis() -> AsyncMock:
+    redis = AsyncMock()
+    # Cost / cancel checks read string keys; return benign values so the
+    # pre-failure setup doesn't choke.
+    redis.get.return_value = None
+    redis.incr.return_value = 1
+    return redis
+
+
+async def test_run_pipeline_shuts_down_kernel_on_failure(
+    tmp_path: Path,
+    fake_redis: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = uuid4()
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    monkeypatch.setenv("RUNS_DIR", str(runs_dir))
+    monkeypatch.setenv("REDIS_URL", "redis://stub")
+    monkeypatch.setenv("GATEWAY_HTTP", "http://stub")
+
+    fake_gateway = AsyncMock()
+    fake_kernel = AsyncMock()
+    fake_matlab = AsyncMock()
+
+    monkeypatch.setattr(pipeline, "GatewayClient", lambda *a, **k: fake_gateway)
+    monkeypatch.setattr(pipeline, "KernelSession", lambda *a, **k: fake_kernel)
+    monkeypatch.setattr(pipeline, "MatlabSession", lambda *a, **k: fake_matlab)
+
+    # Force the first pipeline stage to blow up so we hit the failure path.
+    class _BoomAnalyzer:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+        async def run_for_problem(self, *_a: object, **_k: object) -> None:
+            raise AgentError("simulated analyzer failure")
+
+    monkeypatch.setattr(pipeline, "AnalyzerAgent", _BoomAnalyzer)
+
+    problem = ProblemInput(problem_text="stub", competition_type="mcm")
+
+    # Must not re-raise — AgentError is caught and converted to done(failed).
+    await pipeline.run_pipeline(fake_redis, run_id, problem)
+
+    # The whole point of D1: kernel torn down in `finally` despite the failure.
+    fake_kernel.shutdown.assert_awaited_once()
+    fake_gateway.close.assert_awaited_once()

--- a/apps/agent-worker/tests/test_searcher_agent.py
+++ b/apps/agent-worker/tests/test_searcher_agent.py
@@ -462,3 +462,123 @@ async def test_searcher_skips_enrichment_when_no_papers(
     assert out.papers == []
     assert out.paper_fulltext_paths == []
     assert enrich_called is False
+
+
+# --- D7: _stream_and_collect routes through the shared retry helper ---------
+
+
+class _FlakyGateway:
+    """Raises a transport error on the first N calls, then streams `chunks`.
+
+    Records every response_format it was asked for so we can assert the
+    JSON-default vs free-form (None) passthrough is preserved.
+    """
+
+    def __init__(self, chunks: list[str], fail_times: int, exc: Exception) -> None:
+        self._chunks = chunks
+        self._fail_times = fail_times
+        self._exc = exc
+        self.calls = 0
+        self.response_formats: list[object] = []
+
+    async def stream_completion(self, **kwargs: object) -> AsyncIterator[str]:
+        self.calls += 1
+        self.response_formats.append(kwargs.get("response_format"))
+        if self.calls <= self._fail_times:
+            raise self._exc
+        for c in self._chunks:
+            yield c
+
+    async def close(self) -> None:
+        pass
+
+
+async def test_stream_and_collect_retries_on_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ReadTimeout in a Searcher LLM call must be retried (not abort the
+    run). Pre-D7 the bare stream loop had no retry."""
+    import asyncio
+
+    import httpx
+
+    # No real backoff sleeps in the test.
+    async def _no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    gateway = _FlakyGateway(
+        ['{"ok": true}'], fail_times=1, exc=httpx.ReadTimeout("boom")
+    )
+    emitter = _FakeEmitter()
+    agent = SearcherAgent(gateway, emitter)  # type: ignore[arg-type]
+
+    out = await agent._stream_and_collect("model-x", [{"role": "user", "content": "hi"}])
+
+    assert out == '{"ok": true}'
+    assert gateway.calls == 2  # one failure + one success
+    # JSON-object default preserved on every attempt.
+    assert all(rf == {"type": "json_object"} for rf in gateway.response_formats)
+
+
+async def test_stream_and_collect_retries_on_empty_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty 200 (zero content deltas) must trigger a retry."""
+    import asyncio
+
+    async def _no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    class _EmptyThenContentGateway:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def stream_completion(self, **_: object) -> AsyncIterator[str]:
+            self.calls += 1
+            if self.calls == 1:
+                return  # empty 200: yield nothing
+                yield ""  # pragma: no cover — keep this an async generator
+            yield '{"done": true}'
+
+        async def close(self) -> None:
+            pass
+
+    gateway = _EmptyThenContentGateway()
+    emitter = _FakeEmitter()
+    agent = SearcherAgent(gateway, emitter)  # type: ignore[arg-type]
+
+    out = await agent._stream_and_collect("model-x", [{"role": "user", "content": "hi"}])
+    assert out == '{"done": true}'
+    assert gateway.calls == 2
+
+
+async def test_stream_and_collect_preserves_response_format_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The compactor path passes response_format=None for free-form markdown;
+    that must survive the routing through _stream_with_retry."""
+    import asyncio
+
+    import httpx
+
+    async def _no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    gateway = _FlakyGateway(
+        ["# markdown summary"], fail_times=1, exc=httpx.RemoteProtocolError("blip")
+    )
+    emitter = _FakeEmitter()
+    agent = SearcherAgent(gateway, emitter)  # type: ignore[arg-type]
+
+    out = await agent._stream_and_collect(
+        "model-x", [{"role": "user", "content": "hi"}], response_format=None
+    )
+    assert out == "# markdown summary"
+    assert gateway.calls == 2
+    assert all(rf is None for rf in gateway.response_formats)

--- a/apps/agent-worker/tests/test_web_search_mcp.py
+++ b/apps/agent-worker/tests/test_web_search_mcp.py
@@ -272,6 +272,80 @@ async def test_batch_search_web_empty_queries_short_circuits() -> None:
     assert await batch_search_web([]) == {}
 
 
+async def test_batch_search_web_debounce_runs_before_semaphore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D21: the per-engine debounce must be acquired BEFORE the concurrency
+    semaphore, so a debounce sleep never occupies a slot.
+
+    We record the order of (debounce-acquire, sem-acquire) events per query.
+    Pre-fix the order was sem-acquire then debounce-acquire (debounce held the
+    slot); post-fix every query debounces first, then takes the sem.
+    """
+    monkeypatch.setattr(
+        "agent_worker.tools.web_search_mcp._resolve_command",
+        lambda cmd: "/usr/bin/true",
+    )
+
+    events: list[str] = []
+
+    import agent_worker.tools.web_search_mcp as mod
+
+    class _RecordingDebouncer:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+        async def acquire(self, _engines: object) -> None:
+            events.append("debounce")
+
+    real_sem_cls = asyncio.Semaphore
+
+    class _RecordingSemaphore:
+        def __init__(self, value: int) -> None:
+            self._sem = real_sem_cls(value)
+
+        async def __aenter__(self) -> None:
+            await self._sem.acquire()
+            events.append("sem")
+
+        async def __aexit__(self, *_e: object) -> None:
+            self._sem.release()
+
+    monkeypatch.setattr(mod, "_EngineDebouncer", _RecordingDebouncer)
+    monkeypatch.setattr(mod.asyncio, "Semaphore", _RecordingSemaphore)
+
+    session = _FakeSession({"*": {"results": []}})
+
+    out = await batch_search_web(
+        ["q1", "q2"],
+        engines=("bing",),
+        max_per_query=3,
+        concurrency=2,
+        command="fake",
+        stdio_client_factory=_stdio_factory_ok,
+        session_factory=_session_factory_for(session),
+    )
+
+    assert set(out.keys()) == {"q1", "q2"}
+    # Two queries → two debounce events and two sem events.
+    assert events.count("debounce") == 2
+    assert events.count("sem") == 2
+    # The invariant: at every point, the number of semaphore slots taken never
+    # exceeds the number of debounces already completed. Pre-fix (acquire
+    # inside the sem) a 'sem' event preceded its query's 'debounce', so the
+    # running counts would violate this. Post-fix every query debounces first.
+    seen_debounce = 0
+    seen_sem = 0
+    for kind in events:
+        if kind == "debounce":
+            seen_debounce += 1
+        else:
+            seen_sem += 1
+        assert seen_sem <= seen_debounce, (
+            f"a semaphore slot was taken before debounce: {events}"
+        )
+
+
 async def test_batch_search_web_degrades_when_spawn_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/web/src/api/figures.test.ts
+++ b/apps/web/src/api/figures.test.ts
@@ -1,0 +1,108 @@
+// Repro + regression test for D8 — the dev auth token must NOT appear as a
+// `?token=` query param in figure / notebook / paper URLs in production
+// builds (it leaks via copy-URL, Referer, history, proxy/CDN logs). In dev it
+// stays for local convenience.
+//
+// `import.meta.env.{DEV,VITE_DEV_AUTH_TOKEN,VITE_GATEWAY_HTTP}` are inlined by
+// Vite at build time. Under bare node we simulate each build by transpiling
+// figures.ts with esbuild `define`s (see /tmp/esbuild-loader-def.mjs). The
+// runner sets MATHO_DEFINES to pick the dev or prod variant, so this file is
+// invoked twice — once per build mode — by the harness comment below:
+//
+//   MATHO_DEFINES='{"import.meta.env.DEV":"true","import.meta.env.VITE_DEV_AUTH_TOKEN":"\"sekret\"","import.meta.env.VITE_GATEWAY_HTTP":"\"http://gw\""}' \
+//     node --loader /tmp/esbuild-loader-def.mjs --import ./src/api/figures.test.ts
+//   MATHO_DEFINES='{"import.meta.env.DEV":"false", ...}' node ... (prod)
+//
+// It also works in vitest with `vi.stubEnv`.
+
+import {
+  figureUrl,
+  notebookUrl,
+  paperUrl,
+  figurePath,
+  notebookPath,
+} from "./figures";
+
+interface MiniExpect {
+  toBe(v: unknown): void;
+  toContain(v: string): void;
+  not: { toContain(v: string): void };
+}
+type Fn = () => void;
+const g = globalThis as unknown as {
+  describe?: (name: string, fn: Fn) => void;
+  it?: (name: string, fn: Fn) => void;
+  expect?: (actual: unknown) => MiniExpect;
+};
+let failures = 0;
+const describe = g.describe ?? ((_n: string, fn: Fn) => fn());
+const it =
+  g.it ??
+  ((name: string, fn: Fn) => {
+    try {
+      fn();
+      console.log("PASS:", name);
+    } catch (e) {
+      failures++;
+      console.error("FAIL:", name, "—", (e as Error).message);
+    }
+  });
+const expect =
+  g.expect ??
+  ((actual: unknown): MiniExpect => ({
+    toBe(v: unknown) {
+      if (actual !== v)
+        throw new Error(`expected ${String(actual)} to be ${String(v)}`);
+    },
+    toContain(v: string) {
+      if (!String(actual).includes(v))
+        throw new Error(`expected "${String(actual)}" to contain "${v}"`);
+    },
+    not: {
+      toContain(v: string) {
+        if (String(actual).includes(v))
+          throw new Error(`expected "${String(actual)}" NOT to contain "${v}"`);
+      },
+    },
+  }));
+
+// Detect which build the harness compiled us for. We re-derive it from a URL:
+// dev appends `?token=`, prod does not.
+const isDevBuild = figureUrl("r1", "figures/a.png").includes("token=");
+
+describe(`figures URL token leak (D8) — ${isDevBuild ? "DEV" : "PROD"} build`, () => {
+  if (isDevBuild) {
+    it("DEV: keeps ?token= for local convenience", () => {
+      expect(figureUrl("r1", "figures/a.png")).toContain("token=");
+      expect(notebookUrl("r1")).toContain("token=");
+      expect(paperUrl("r1")).toContain("token=");
+      expect(paperUrl("r1", true)).toContain("token=");
+    });
+  } else {
+    it("PROD: figureUrl carries NO token query param", () => {
+      const u = figureUrl("r1", "figures/a.png");
+      expect(u).not.toContain("token=");
+      expect(u).not.toContain("sekret");
+    });
+    it("PROD: notebookUrl carries NO token query param", () => {
+      expect(notebookUrl("r1")).not.toContain("token=");
+    });
+    it("PROD: paperUrl (download + inline) carries NO token query param", () => {
+      expect(paperUrl("r1")).not.toContain("token=");
+      expect(paperUrl("r1", true)).not.toContain("token=");
+      // inline flag must still be present, just without the token.
+      expect(paperUrl("r1", true)).toContain("inline=true");
+    });
+  }
+
+  it("path helpers are always token-free (header/cookie auth path)", () => {
+    expect(figurePath("r1", "figures/a.png")).not.toContain("token=");
+    expect(notebookPath("r1")).not.toContain("token=");
+  });
+});
+
+if (!g.it && failures > 0) {
+  console.error(`\n${failures} failure(s)`);
+  const proc = (globalThis as { process?: { exitCode?: number } }).process;
+  if (proc) proc.exitCode = 1;
+}

--- a/apps/web/src/api/figures.ts
+++ b/apps/web/src/api/figures.ts
@@ -1,8 +1,19 @@
 // URL helpers for kernel-produced artifacts served by the gateway.
 //
 // Figures and notebooks require Bearer auth. `<img>` tags can't set headers,
-// so we attach the dev token as a `?token=` query param — the gateway accepts
-// both `Authorization: Bearer ...` and `?token=...` (see docs/auth.md).
+// so in *development* we attach the dev token as a `?token=` query param — the
+// gateway accepts both `Authorization: Bearer ...` and `?token=...` (see
+// docs/auth.md). This is acceptable in dev: the token is a throwaway local
+// value and requests go same-origin through the Vite `/api` proxy.
+//
+// SECURITY (D8): in *production builds* we must NOT bake the dev token into
+// the bundle and emit it as `?token=` in `<img src>` / `<a href>` URLs — the
+// raw credential would leak via copy-URL, Referer headers, browser history and
+// proxy/CDN access logs. So the query-param fallback is gated to DEV only.
+// Production is expected to authenticate protected assets via cookies / a
+// reverse-proxy session, or via short-lived signed URLs issued per resource
+// (see fetchAuthedBlobUrl below for the header-carrying download path, and the
+// orchestrator flag for the signed-URL design decision still owed).
 //
 // `VITE_GATEWAY_HTTP` is the direct gateway origin (e.g. http://127.0.0.1:8080).
 // We don't use the Vite `/api` proxy here because `<img src>` happens after
@@ -10,6 +21,15 @@
 
 const BASE = import.meta.env.VITE_GATEWAY_HTTP ?? "";
 const TOKEN = import.meta.env.VITE_DEV_AUTH_TOKEN ?? "";
+const IS_DEV = import.meta.env.DEV;
+
+// Append the dev token as a query param ONLY in dev builds. In prod the token
+// is omitted entirely so it can never end up in a URL/log.
+function withDevToken(url: string): string {
+  if (!IS_DEV || !TOKEN) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}token=${encodeURIComponent(TOKEN)}`;
+}
 
 export function figureUrl(runId: string, relPath: string): string {
   // `relPath` is produced by the worker as e.g. "figures/fig-0.png". It may
@@ -19,18 +39,59 @@ export function figureUrl(runId: string, relPath: string): string {
     .split("/")
     .map((s) => encodeURIComponent(s))
     .join("/");
-  return `${BASE}/runs/${runId}/figures/${encoded}?token=${encodeURIComponent(TOKEN)}`;
+  return withDevToken(`${BASE}/runs/${runId}/figures/${encoded}`);
 }
 
 export function notebookUrl(runId: string): string {
-  return `${BASE}/runs/${runId}/notebook?token=${encodeURIComponent(TOKEN)}`;
+  return withDevToken(`${BASE}/runs/${runId}/notebook`);
 }
 
 // Paper markdown URL. `inline=true` renders in-browser (text/markdown +
 // Content-Disposition: inline); omitted for attachment download.
 export function paperUrl(runId: string, inline = false): string {
-  const t = encodeURIComponent(TOKEN);
+  const url = inline
+    ? `${BASE}/runs/${runId}/paper?inline=true`
+    : `${BASE}/runs/${runId}/paper`;
+  return withDevToken(url);
+}
+
+// Fetch a protected gateway resource carrying the Bearer token in the
+// `Authorization` *header* (never the URL) and return a same-origin blob URL
+// safe to use as an `<img src>` / `<a href>`. This keeps the credential out of
+// URLs/logs in every build. Callers own the returned object URL and should
+// `URL.revokeObjectURL` it when the element is torn down.
+//
+// Returns null on any failure so callers can fall back to the plain URL
+// (e.g. when prod auth is cookie-based and a header isn't needed).
+export async function fetchAuthedBlobUrl(url: string): Promise<string | null> {
+  try {
+    const headers = new Headers({ accept: "*/*" });
+    if (TOKEN) headers.set("authorization", `Bearer ${TOKEN}`);
+    const res = await fetch(url, { method: "GET", headers });
+    if (!res.ok) return null;
+    const blob = await res.blob();
+    return URL.createObjectURL(blob);
+  } catch {
+    return null;
+  }
+}
+
+// Plain (token-free) resource URLs, for callers using fetchAuthedBlobUrl or a
+// cookie-based prod session. Exposed so components don't reconstruct paths.
+export function figurePath(runId: string, relPath: string): string {
+  const encoded = relPath
+    .split("/")
+    .map((s) => encodeURIComponent(s))
+    .join("/");
+  return `${BASE}/runs/${runId}/figures/${encoded}`;
+}
+
+export function notebookPath(runId: string): string {
+  return `${BASE}/runs/${runId}/notebook`;
+}
+
+export function paperPath(runId: string, inline = false): string {
   return inline
-    ? `${BASE}/runs/${runId}/paper?inline=true&token=${t}`
-    : `${BASE}/runs/${runId}/paper?token=${t}`;
+    ? `${BASE}/runs/${runId}/paper?inline=true`
+    : `${BASE}/runs/${runId}/paper`;
 }

--- a/apps/web/src/api/figures.ts
+++ b/apps/web/src/api/figures.ts
@@ -31,6 +31,19 @@ function withDevToken(url: string): string {
   return `${url}${sep}token=${encodeURIComponent(TOKEN)}`;
 }
 
+// Production figure/notebook/paper requests ride in `<img src>` / `<a href>`,
+// which cannot carry an Authorization header. The gateway accepts an `mm_auth`
+// cookie for GET asset routes only (so it can't be replayed as CSRF against the
+// mutating POST endpoints), so we set it once at app init from the configured
+// token — the token never enters a URL. In dev the SPA is cross-origin to the
+// gateway (Vite proxy, different port) so this cookie isn't sent and the
+// DEV-only `?token=` fallback applies; in prod the SPA is served same-origin
+// (see config/Caddyfile.prod) and the browser sends the cookie automatically.
+export function ensureAuthCookie(): void {
+  if (typeof document === "undefined" || !TOKEN) return;
+  document.cookie = `mm_auth=${TOKEN}; path=/; SameSite=Lax`;
+}
+
 export function figureUrl(runId: string, relPath: string): string {
   // `relPath` is produced by the worker as e.g. "figures/fig-0.png". It may
   // already contain slashes — encode each segment so a stray space or non-ascii

--- a/apps/web/src/api/ws.test.ts
+++ b/apps/web/src/api/ws.test.ts
@@ -1,0 +1,171 @@
+// Repro + regression test for D25 — a non-1000 close arriving *after* a
+// terminal `done` must NOT schedule a reconnect, and RunWsClient must expose
+// its terminal decision so the store can mirror it authoritatively.
+//
+// Written in vitest shape (describe/it/expect) and also runnable under bare
+// node via the shim at the bottom:
+//
+//   node --experimental-strip-types --loader <ts-ext-loader> \
+//        --import ./src/api/ws.test.ts
+//
+// ws.ts imports AgentEvent only as a `type`, so it has no runtime dependency
+// on @mathodology/contracts under type-stripping.
+
+import { RunWsClient } from "./ws";
+
+// ---- minimal WebSocket stub -----------------------------------------------
+// Captures handlers and lets the test drive onmessage/onclose synchronously,
+// the way the real server's done-then-close sequence would.
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static OPEN = 1;
+  onopen: (() => void) | null = null;
+  onmessage: ((m: { data: string }) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onclose: ((e: { code: number; reason?: string }) => void) | null = null;
+  sent: string[] = [];
+  closed = false;
+  url: string;
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+  send(d: string) {
+    this.sent.push(d);
+  }
+  close(code = 1000, reason = "") {
+    this.closed = true;
+    this.onclose?.({ code, reason });
+  }
+}
+
+// ---- harness --------------------------------------------------------------
+interface MiniExpect {
+  toBe(v: unknown): void;
+}
+type Fn = () => void;
+const g = globalThis as unknown as {
+  describe?: (name: string, fn: Fn) => void;
+  it?: (name: string, fn: Fn) => void;
+  expect?: (actual: unknown) => MiniExpect;
+};
+let failures = 0;
+const describe = g.describe ?? ((_n: string, fn: Fn) => fn());
+const it =
+  g.it ??
+  ((name: string, fn: Fn) => {
+    try {
+      fn();
+      console.log("PASS:", name);
+    } catch (e) {
+      failures++;
+      console.error("FAIL:", name, "—", (e as Error).message);
+    }
+  });
+const expect =
+  g.expect ??
+  ((actual: unknown): MiniExpect => ({
+    toBe(v: unknown) {
+      if (actual !== v)
+        throw new Error(`expected ${String(actual)} to be ${String(v)}`);
+    },
+  }));
+
+// Install the fake globally for the duration of the run.
+const realWs = (globalThis as { WebSocket?: unknown }).WebSocket;
+(globalThis as { WebSocket?: unknown }).WebSocket =
+  FakeWebSocket as unknown as typeof WebSocket;
+
+const ev = (kind: string, seq: number) =>
+  JSON.stringify({ run_id: "r1", kind, seq, ts: "2026-01-01T00:00:00Z" });
+
+describe("RunWsClient terminal-after-done close (D25)", () => {
+  it("does not reconnect when a non-1000 close follows a done event", () => {
+    FakeWebSocket.instances = [];
+    let reconnectScheduled = false;
+    // Spy on setTimeout to detect a scheduled reconnect.
+    const realSetTimeout = globalThis.setTimeout;
+    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = (() => {
+      reconnectScheduled = true;
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+
+    try {
+      const client = new RunWsClient({
+        runId: "r1",
+        wsBase: "ws://x",
+        token: "t",
+        handlers: { onEvent: () => {} },
+      });
+      client.connect();
+      const sock = FakeWebSocket.instances[0]!;
+      // Server sends terminal `done`, then closes with 1001 (going away).
+      sock.onmessage?.({ data: ev("done", 5) });
+      expect(client.isTerminal()).toBe(true);
+      sock.onclose?.({ code: 1001 });
+      // A non-1000 close after done must NOT schedule a reconnect.
+      expect(reconnectScheduled).toBe(false);
+      // No new socket should have been opened.
+      expect(FakeWebSocket.instances.length).toBe(1);
+    } finally {
+      (globalThis as { setTimeout: typeof setTimeout }).setTimeout =
+        realSetTimeout;
+    }
+  });
+
+  it("still reconnects on a genuine mid-run drop (no done, code 1006)", () => {
+    FakeWebSocket.instances = [];
+    let reconnectScheduled = false;
+    const realSetTimeout = globalThis.setTimeout;
+    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = (() => {
+      reconnectScheduled = true;
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    try {
+      const client = new RunWsClient({
+        runId: "r1",
+        wsBase: "ws://x",
+        token: "t",
+        handlers: { onEvent: () => {} },
+      });
+      client.connect();
+      const sock = FakeWebSocket.instances[0]!;
+      sock.onmessage?.({ data: ev("stage.start", 1) });
+      expect(client.isTerminal()).toBe(false);
+      sock.onclose?.({ code: 1006 });
+      expect(reconnectScheduled).toBe(true);
+    } finally {
+      (globalThis as { setTimeout: typeof setTimeout }).setTimeout =
+        realSetTimeout;
+    }
+  });
+
+  it("mirrors the store's reconnect rule: terminal => no reconnect flag", () => {
+    // Reproduce the store's onClose decision in isolation against the client's
+    // authoritative terminal flag, proving the D25 fix: isTerminal() short-
+    // circuits the reconnect flag regardless of close code.
+    FakeWebSocket.instances = [];
+    const client = new RunWsClient({
+      runId: "r1",
+      wsBase: "ws://x",
+      token: "t",
+      handlers: { onEvent: () => {} },
+    });
+    client.connect();
+    const sock = FakeWebSocket.instances[0]!;
+    sock.onmessage?.({ data: ev("done", 9) });
+    // Store-side decision (copied from stores/run.ts onClose):
+    const code: number = 1001;
+    const reachedTerminal = client.isTerminal();
+    const wsReconnecting = code !== 1000 && !reachedTerminal;
+    expect(wsReconnecting).toBe(false);
+  });
+});
+
+(globalThis as { WebSocket?: unknown }).WebSocket = realWs;
+
+if (!g.it && failures > 0) {
+  console.error(`\n${failures} failure(s)`);
+  const proc = (globalThis as { process?: { exitCode?: number } }).process;
+  if (proc) proc.exitCode = 1;
+}

--- a/apps/web/src/api/ws.ts
+++ b/apps/web/src/api/ws.ts
@@ -84,6 +84,15 @@ export class RunWsClient {
     this.ws?.close(1000, "client-closed");
     this.ws = null;
   }
+
+  // True once a terminal `done` event has been received on this socket. The
+  // client uses this to suppress reconnects after a clean end-of-run; the
+  // store consults it in its onClose handler so a non-1000 close that arrives
+  // *after* done (e.g. server closes with 1001) doesn't get mistaken for a
+  // mid-run drop and stick the "reconnecting…" indicator on.
+  isTerminal(): boolean {
+    return this.terminal;
+  }
 }
 
 function isAgentEvent(v: unknown): v is AgentEvent {

--- a/apps/web/src/components/FinetuneChat.vue
+++ b/apps/web/src/components/FinetuneChat.vue
@@ -11,7 +11,7 @@
 // KaTeX inside chat — overkill for ad-hoc messages, and the assistant rarely
 // emits raw $...$ in chat replies (it edits sections instead).
 import { computed, nextTick, ref, watch } from "vue";
-import { Marked } from "marked";
+import { createSafeMarked } from "@/lib/safe-markdown";
 import { useFinetuneStore } from "@/stores/finetune";
 import type { Message, ToolCall } from "@/stores/finetune";
 import { useI18n } from "@/composables/useI18n";
@@ -29,8 +29,13 @@ const emit = defineEmits<{
 const store = useFinetuneStore();
 
 // --- markdown rendering ---------------------------------------------------
-// Plain GFM with no walker — chat doesn't need figure URL rewriting.
-const md = new Marked({ gfm: true, breaks: false });
+// The assistant text streams from the `finetune.token` WS channel — i.e.
+// untrusted LLM output that is manipulable via prompt injection. We render it
+// through `v-html`, so the markdown MUST be sanitized first: a vanilla
+// `marked` instance passes raw `<script>` / `<img onerror=...>` straight
+// through. `createSafeMarked` escapes raw HTML and strips dangerous URL
+// schemes while keeping legitimate markdown (code, links, lists) intact.
+const md = createSafeMarked();
 
 function renderMd(text: string): string {
   if (!text) return "";

--- a/apps/web/src/lib/safe-markdown.test.ts
+++ b/apps/web/src/lib/safe-markdown.test.ts
@@ -1,0 +1,129 @@
+// Repro + regression test for D16 — XSS via unsanitized markdown of
+// LLM-streamed assistant text in FinetuneChat.
+//
+// The web app has no test runner wired yet (no vitest/jest). These cases are
+// written in the vitest `describe/it/expect` shape so they slot straight in
+// once a runner is added, and they are *also* runnable today with:
+//
+//   node --experimental-strip-types --import ./src/lib/safe-markdown.test.ts
+//
+// (a tiny shim at the bottom executes them under plain node when the vitest
+// globals are absent). The pre-fix `new Marked({gfm:true,breaks:false})`
+// emitted `<img src=x onerror=alert(1)>` verbatim into v-html — these assert
+// the sanitizing renderer neutralizes that while keeping real markdown.
+
+import { createSafeMarked, sanitizeUrl } from "./safe-markdown";
+
+interface MiniExpect {
+  toBe(v: unknown): void;
+  toContain(v: string): void;
+  toMatch(re: RegExp): void;
+  not: { toMatch(re: RegExp): void; toContain(v: string): void };
+}
+
+// Resolve a vitest-compatible (describe, it, expect) trio, or fall back to a
+// minimal harness so the file runs under bare node for the repro.
+type Fn = () => void;
+const g = globalThis as unknown as {
+  describe?: (name: string, fn: Fn) => void;
+  it?: (name: string, fn: Fn) => void;
+  expect?: (actual: unknown) => MiniExpect;
+};
+
+let failures = 0;
+const describe =
+  g.describe ??
+  ((_name: string, fn: Fn) => {
+    fn();
+  });
+const it =
+  g.it ??
+  ((name: string, fn: Fn) => {
+    try {
+      fn();
+      console.log("PASS:", name);
+    } catch (e) {
+      failures++;
+      console.error("FAIL:", name, "—", (e as Error).message);
+    }
+  });
+const expect =
+  g.expect ??
+  ((actual: unknown): MiniExpect => {
+    const fail = (msg: string) => {
+      throw new Error(msg);
+    };
+    const api = {
+      toBe(v: unknown) {
+        if (actual !== v) fail(`expected ${String(actual)} to be ${String(v)}`);
+      },
+      toContain(v: string) {
+        if (!String(actual).includes(v))
+          fail(`expected output to contain ${v}`);
+      },
+      toMatch(re: RegExp) {
+        if (!re.test(String(actual))) fail(`expected output to match ${re}`);
+      },
+      not: {
+        toMatch(re: RegExp) {
+          if (re.test(String(actual))) fail(`expected output NOT to match ${re}`);
+        },
+        toContain(v: string) {
+          if (String(actual).includes(v))
+            fail(`expected output NOT to contain ${v}`);
+        },
+      },
+    };
+    return api;
+  });
+
+const md = createSafeMarked();
+const render = (s: string) => md.parse(s, { async: false }) as string;
+
+describe("safe-markdown / FinetuneChat XSS (D16)", () => {
+  it("neutralizes a raw <img onerror> payload (the audit repro)", () => {
+    const out = render("<img src=x onerror=alert(1)>");
+    expect(out).not.toMatch(/<img[^>]*onerror/i);
+    expect(out).toContain("&lt;img");
+  });
+
+  it("neutralizes inline <script>", () => {
+    const out = render("hello <script>alert(1)</script> world");
+    expect(out).not.toMatch(/<script>/i);
+  });
+
+  it("strips javascript: from markdown links", () => {
+    const out = render("[click](javascript:alert(1))");
+    expect(out).not.toMatch(/href="javascript:/i);
+  });
+
+  it("strips javascript: from markdown images", () => {
+    const out = render("![x](javascript:alert(1))");
+    expect(out).not.toMatch(/src="javascript:/i);
+  });
+
+  it("strips data: URLs (markup smuggling)", () => {
+    expect(sanitizeUrl("data:text/html;base64,PHNjcmlwdD4=")).toBe("");
+  });
+
+  it("keeps legitimate markdown intact", () => {
+    const out = render("**bold** and `code` and [link](https://e.com)");
+    expect(out).toContain("<strong>bold</strong>");
+    expect(out).toContain("<code>code</code>");
+    expect(out).toMatch(/href="https:\/\/e\.com"/);
+  });
+
+  it("sanitizeUrl keeps http/https/relative", () => {
+    expect(sanitizeUrl("https://x.com")).toBe("https://x.com");
+    expect(sanitizeUrl("figures/a.png")).toBe("figures/a.png");
+  });
+});
+
+// Bare-node exit code so the repro can gate CI / manual runs. Guarded via
+// globalThis so this file also typechecks in the browser tsconfig (no
+// @types/node).
+if (!g.it && failures > 0) {
+  console.error(`\n${failures} failure(s)`);
+  const proc = (globalThis as { process?: { exitCode?: number } }).process;
+  if (proc) proc.exitCode = 1;
+}

--- a/apps/web/src/lib/safe-markdown.ts
+++ b/apps/web/src/lib/safe-markdown.ts
@@ -1,0 +1,85 @@
+// Sanitizing markdown renderer for *untrusted* model output.
+//
+// The fine-tune assistant streams its replies over the `finetune.token` WS
+// channel — i.e. raw LLM output that is manipulable via prompt injection.
+// Rendering that through `v-html` with a vanilla `marked` instance is an XSS
+// sink: marked (v14) does NOT escape raw HTML by default, so a streamed
+// `<img src=x onerror=alert(1)>` or `<script>` would execute in the user's
+// session.
+//
+// Rather than add a runtime sanitizer dependency (DOMPurify), we neutralize
+// the dangerous surface inside marked's renderer — the same escape-based
+// approach PaperDraft uses for its custom image renderer:
+//   - `html`  : escape any raw HTML block / inline HTML so tags render as
+//               visible text instead of live DOM.
+//   - `link`  / `image`: drop dangerous URI schemes (javascript:, data:,
+//               vbscript:, file:) and add `rel="noopener noreferrer"` +
+//               `target="_blank"` to links.
+//
+// Legitimate markdown (headings, bold/italic, code, lists, tables, safe
+// links/images) still renders normally — only raw HTML and dangerous URLs
+// are stripped.
+
+import { Marked } from "marked";
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// Schemes that can execute script or smuggle markup when placed in an
+// `href`/`src`. We allow everything else (http/https/mailto/relative paths).
+const DANGEROUS_SCHEME_RE = /^\s*(?:javascript|vbscript|data|file):/i;
+
+export function sanitizeUrl(href: string | null | undefined): string {
+  if (!href) return "";
+  const t = href.trim();
+  if (DANGEROUS_SCHEME_RE.test(t)) return "";
+  return t;
+}
+
+/**
+ * Build a `Marked` instance that escapes raw HTML and strips dangerous URL
+ * schemes. Use for any markdown that originates from model output before it
+ * reaches `v-html`.
+ */
+export function createSafeMarked(): Marked {
+  const md = new Marked({ gfm: true, breaks: false });
+  md.use({
+    renderer: {
+      // Raw HTML (block or inline) — render the source as escaped text so it
+      // can never become live DOM.
+      html(token): string {
+        const raw =
+          typeof token === "string"
+            ? token
+            : (token.text ?? token.raw ?? "");
+        return escapeHtml(raw);
+      },
+      link(token): string {
+        const href = sanitizeUrl(token.href);
+        const inner = this.parser.parseInline(token.tokens);
+        // Dangerous scheme stripped — fall back to rendering the link text
+        // only, so the user still sees the words without a clickable sink.
+        if (!href) return inner;
+        const title = token.title
+          ? ` title="${escapeHtml(token.title)}"`
+          : "";
+        return `<a href="${escapeHtml(href)}"${title} target="_blank" rel="noopener noreferrer">${inner}</a>`;
+      },
+      image(token): string {
+        const href = sanitizeUrl(token.href);
+        const alt = escapeHtml(token.text ?? "");
+        if (!href) return alt;
+        const title = token.title
+          ? ` title="${escapeHtml(token.title)}"`
+          : "";
+        return `<img src="${escapeHtml(href)}" alt="${alt}"${title} loading="lazy" decoding="async" />`;
+      },
+    },
+  });
+  return md;
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -2,7 +2,12 @@ import { createApp } from "vue";
 import { createPinia } from "pinia";
 import App from "./App.vue";
 import { router } from "./router";
+import { ensureAuthCookie } from "./api/figures";
 import "katex/dist/katex.min.css";
 import "./styles.css";
+
+// Set the `mm_auth` cookie so same-origin <img>/<a> asset GETs (figures,
+// notebook, paper) authenticate without a token in the URL (D8).
+ensureAuthCookie();
 
 createApp(App).use(createPinia()).use(router).mount("#app");

--- a/apps/web/src/stores/run.flush.test.ts
+++ b/apps/web/src/stores/run.flush.test.ts
@@ -1,0 +1,167 @@
+// Repro + regression test for D24 — the module-level `_flushScheduled` flag
+// and the rAF handle must be reset/cancelled in reset() so the next run's
+// first token frame is not dropped.
+//
+// The store's token-batching block (stores/run.ts) is module-level state that
+// can't be imported in isolation under bare node (pinia + import.meta.env +
+// `@/` aliases). This test reproduces that exact scheduling pattern — the
+// `_flushScheduled` flag, the cancellable handle, and the reset path — and
+// proves the bug deterministically:
+//
+//   BUGGY (no reset of the flag/handle): a flush scheduled for run A leaves
+//   _flushScheduled === true after reset(); run B's first token sees the flag
+//   set and schedules NOTHING, so run B's opening frame never paints until the
+//   stale run-A callback eventually fires.
+//
+//   FIXED (reset cancels the handle and clears the flag): run B's first token
+//   schedules a fresh flush and the opening frame paints.
+//
+// Runnable in vitest shape and under bare node (via the shim at the bottom).
+
+interface MiniExpect {
+  toBe(v: unknown): void;
+}
+type Fn = () => void;
+const g = globalThis as unknown as {
+  describe?: (name: string, fn: Fn) => void;
+  it?: (name: string, fn: Fn) => void;
+  expect?: (actual: unknown) => MiniExpect;
+};
+let failures = 0;
+const describe = g.describe ?? ((_n: string, fn: Fn) => fn());
+const it =
+  g.it ??
+  ((name: string, fn: Fn) => {
+    try {
+      fn();
+      console.log("PASS:", name);
+    } catch (e) {
+      failures++;
+      console.error("FAIL:", name, "—", (e as Error).message);
+    }
+  });
+const expect =
+  g.expect ??
+  ((actual: unknown): MiniExpect => ({
+    toBe(v: unknown) {
+      if (actual !== v)
+        throw new Error(`expected ${String(actual)} to be ${String(v)}`);
+    },
+  }));
+
+// A manual rAF queue so the test controls exactly when flushes fire.
+function makeScheduler() {
+  const queued = new Map<number, () => void>();
+  let nextId = 1;
+  return {
+    raf(cb: () => void): number {
+      const id = nextId++;
+      queued.set(id, cb);
+      return id;
+    },
+    cancel(id: number) {
+      queued.delete(id);
+    },
+    // Fire all currently-queued callbacks (simulating the next frame).
+    frame() {
+      const cbs = [...queued.values()];
+      queued.clear();
+      for (const cb of cbs) cb();
+    },
+    pendingCount() {
+      return queued.size;
+    },
+  };
+}
+
+// Model of the store's token-flush singletons, parameterised by whether
+// reset() applies the D24 fix. We expose the internal flag/handle so the test
+// can assert on the scheduling state directly — that is the root cause.
+function makeStore(opts: { applyFix: boolean }) {
+  const sched = makeScheduler();
+  const pending = new Map<string, string>();
+  const tokens: Record<string, string> = {};
+  const internal = { flushScheduled: false, flushHandle: null as number | null };
+  let freshSchedules = 0;
+
+  function onToken(agent: string, delta: string) {
+    pending.set(agent, (pending.get(agent) ?? "") + delta);
+    if (!internal.flushScheduled) {
+      internal.flushScheduled = true;
+      freshSchedules++;
+      internal.flushHandle = sched.raf(() => {
+        internal.flushScheduled = false;
+        internal.flushHandle = null;
+        for (const [k, v] of pending) tokens[k] = (tokens[k] ?? "") + v;
+        pending.clear();
+      });
+    }
+  }
+
+  function reset() {
+    pending.clear();
+    if (opts.applyFix) {
+      if (internal.flushHandle !== null) {
+        sched.cancel(internal.flushHandle);
+        internal.flushHandle = null;
+      }
+      internal.flushScheduled = false;
+    }
+    for (const k of Object.keys(tokens)) delete tokens[k];
+  }
+
+  return {
+    sched,
+    tokens,
+    internal,
+    onToken,
+    reset,
+    freshSchedulesSince(n: number) {
+      return freshSchedules - n;
+    },
+    freshSchedules: () => freshSchedules,
+  };
+}
+
+describe("token flush scheduling across run switch (D24)", () => {
+  it("BUGGY reset leaves _flushScheduled stuck true, so run B schedules no fresh frame", () => {
+    const s = makeStore({ applyFix: false });
+    // Run A: a token is buffered and a flush is scheduled (not yet fired).
+    s.onToken("writer", "A-first");
+    // User clicks "New run" before the frame fires -> reset() (buggy: leaves
+    // the flag set and the stale handle queued).
+    s.reset();
+    expect(s.internal.flushScheduled).toBe(true); // <-- the defect
+    const before = s.freshSchedules();
+    // Run B: first token arrives but, seeing the stale flag, schedules NO
+    // fresh flush — run B's opening frame is bound to run A's stale callback.
+    s.onToken("writer", "B-first");
+    expect(s.freshSchedulesSince(before)).toBe(0);
+  });
+
+  it("FIXED reset clears the flag so run B schedules its own first frame", () => {
+    const s = makeStore({ applyFix: true });
+    s.onToken("writer", "A-first");
+    s.reset();
+    expect(s.internal.flushScheduled).toBe(false);
+    const before = s.freshSchedules();
+    s.onToken("writer", "B-first");
+    expect(s.freshSchedulesSince(before)).toBe(1);
+    s.sched.frame();
+    expect(s.tokens["writer"]).toBe("B-first");
+  });
+
+  it("FIXED reset cancels the stale handle (no leftover pending frame)", () => {
+    const s = makeStore({ applyFix: true });
+    s.onToken("writer", "A-first");
+    s.reset();
+    // After reset there must be no queued frame from run A.
+    expect(s.sched.pendingCount()).toBe(0);
+  });
+});
+
+if (!g.it && failures > 0) {
+  console.error(`\n${failures} failure(s)`);
+  const proc = (globalThis as { process?: { exitCode?: number } }).process;
+  if (proc) proc.exitCode = 1;
+}

--- a/apps/web/src/stores/run.ts
+++ b/apps/web/src/stores/run.ts
@@ -152,6 +152,13 @@ let ws: RunWsClient | null = null;
 // the render rate is capped at ~60fps regardless of token rate.
 const _pendingTokenDeltas: Map<string, { delta: string; model: string | null; ts: string }> = new Map();
 let _flushScheduled = false;
+// Handle for the currently-scheduled rAF flush (or the setTimeout fallback in
+// headless envs). Tracked so reset() can cancel a stale flush before it fires
+// — otherwise a flush scheduled for the *previous* run would clear
+// _flushScheduled mid-frame and the next run's first token frame would have no
+// flush scheduled until that stale callback ran.
+let _flushHandle: number | null = null;
+let _flushUsesRaf = false;
 
 export const useRunStore = defineStore("run", {
   state: (): State => ({
@@ -194,6 +201,21 @@ export const useRunStore = defineStore("run", {
       // Drop any pending token deltas from the prior run so they don't
       // leak into the fresh `tokens` state on the next rAF flush.
       _pendingTokenDeltas.clear();
+      // Cancel any in-flight flush and clear the scheduling flag. Without
+      // this, a flush scheduled for the prior run is still pending: when it
+      // fires it sets _flushScheduled=false, but in the window before it
+      // fires the next run's first token sees _flushScheduled===true and
+      // schedules nothing, dropping the opening frame. Cancelling here keeps
+      // the module-level singletons consistent with the cleared buffer.
+      if (_flushHandle !== null) {
+        if (_flushUsesRaf && typeof cancelAnimationFrame !== "undefined") {
+          cancelAnimationFrame(_flushHandle);
+        } else {
+          clearTimeout(_flushHandle);
+        }
+        _flushHandle = null;
+      }
+      _flushScheduled = false;
       this.runId = null;
       this.status = "idle";
       this.events = [];
@@ -249,6 +271,15 @@ export const useRunStore = defineStore("run", {
     },
 
     openWs(runId: string) {
+      // Close any socket still assigned to the module-level `ws` before we
+      // overwrite it. reset() normally does this, but openWs can be called
+      // directly (Workbench route change) without a preceding reset on every
+      // path, and a rapid re-entry would otherwise orphan the prior socket
+      // (it keeps its handlers wired and leaks until GC closes it).
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
       const wsBase = import.meta.env.VITE_GATEWAY_WS ?? "ws://127.0.0.1:8080";
       const client = new RunWsClient({
         runId,
@@ -262,17 +293,20 @@ export const useRunStore = defineStore("run", {
           },
           onClose: (ev) => {
             this.wsConnected = false;
-            // The RunWsClient already decides whether to attempt a reconnect
-            // (closedByUser, terminal, code 1000 → no retry). We mirror its
-            // rule here so the UI only shows "reconnecting" when one is
-            // actually scheduled. The terminal `done` event flips status
-            // and clears this on the next tick.
-            const willRetry =
-              ev.code !== 1000 &&
-              this.status !== "done" &&
-              this.status !== "failed" &&
-              this.status !== "cancelled";
-            this.wsReconnecting = willRetry;
+            // The RunWsClient owns the authoritative reconnect decision
+            // (closedByUser, terminal `done` received, code 1000 → no retry).
+            // We mirror its rule here so the UI only shows "reconnecting" when
+            // a retry is actually scheduled. Crucially we consult the client's
+            // own terminal flag (set synchronously when the `done` frame is
+            // parsed, before this onClose runs) — not just `this.status`,
+            // which can lag the close under a done-then-1001 sequence and
+            // would otherwise stick the "reconnecting…" indicator on forever.
+            const reachedTerminal =
+              client.isTerminal() ||
+              this.status === "done" ||
+              this.status === "failed" ||
+              this.status === "cancelled";
+            this.wsReconnecting = ev.code !== 1000 && !reachedTerminal;
           },
           onError: () => {
             this.wsConnected = false;
@@ -329,6 +363,7 @@ export const useRunStore = defineStore("run", {
           _flushScheduled = true;
           const flush = (): void => {
             _flushScheduled = false;
+            _flushHandle = null;
             if (_pendingTokenDeltas.size === 0) return;
             for (const [k, p] of _pendingTokenDeltas) {
               const existing = this.tokens[k] ?? emptyStream();
@@ -341,10 +376,12 @@ export const useRunStore = defineStore("run", {
             _pendingTokenDeltas.clear();
           };
           if (typeof requestAnimationFrame !== "undefined") {
-            requestAnimationFrame(flush);
+            _flushUsesRaf = true;
+            _flushHandle = requestAnimationFrame(flush);
           } else {
             // Headless fallback (tests / SSR).
-            setTimeout(flush, 16);
+            _flushUsesRaf = false;
+            _flushHandle = setTimeout(flush, 16) as unknown as number;
           }
         }
         return;

--- a/apps/web/src/views/Workbench.vue
+++ b/apps/web/src/views/Workbench.vue
@@ -75,9 +75,38 @@ const routeRunId = computed<string | null>(() => {
 // the route param changes. Null until the fetch resolves.
 const runRecord = ref<RunRecord | null>(null);
 
+// Terminal statuses as reported by GET /runs/:id. When the record already
+// shows one of these, the run is finished on the server and WS replay (if it
+// happens at all) will only re-confirm it — so we can trust the HTTP status
+// immediately instead of leaving the UI on the optimistic "running".
+const TERMINAL_RECORD_STATUSES = new Set(["done", "failed", "cancelled"]);
+
 async function loadRunRecord(id: string) {
   try {
-    runRecord.value = await http.get<RunRecord>(`/runs/${id}`);
+    const rec = await http.get<RunRecord>(`/runs/${id}`);
+    runRecord.value = rec;
+    // D26: the route handler optimistically sets run.status = "running" while
+    // the WS connects. If this run is already terminal on the server, the WS
+    // replay can lag (or the run pre-dates this tab entirely), so the header
+    // would show a transient/permanent "running" until events arrive. Apply
+    // the authoritative HTTP status here — but ONLY when (a) this is still the
+    // run we're looking at, (b) the record is terminal, and (c) the store
+    // hasn't already reached a terminal state via WS, so we never clobber a
+    // live run that is genuinely receiving events.
+    if (
+      run.runId === id &&
+      TERMINAL_RECORD_STATUSES.has(rec.status) &&
+      run.status !== "done" &&
+      run.status !== "failed" &&
+      run.status !== "cancelled"
+    ) {
+      run.status = rec.status as typeof run.status;
+      // Adopt the recorded cost too so the header isn't blank/stale for a run
+      // that finished before this tab opened (mirrors the costTarget fallback).
+      if (run.costRmb === 0 && typeof rec.cost_rmb === "number") {
+        run.costRmb = rec.cost_rmb;
+      }
+    }
   } catch (err) {
     console.error("[Workbench] /runs/:id fetch failed", err);
     runRecord.value = null;

--- a/crates/gateway/src/auth.rs
+++ b/crates/gateway/src/auth.rs
@@ -1,12 +1,21 @@
 use axum::extract::{Request, State};
-use axum::http::header::AUTHORIZATION;
+use axum::http::header::{AUTHORIZATION, COOKIE};
+use axum::http::Method;
 use axum::middleware::Next;
 use axum::response::Response;
 
 use crate::error::AppError;
 use crate::state::AppState;
 
-/// Require `Authorization: Bearer <token>` OR `?token=<token>` matching DEV_AUTH_TOKEN.
+/// Require `Authorization: Bearer <token>`, OR `?token=<token>`, OR (for safe
+/// GET/HEAD requests only) an `mm_auth=<token>` cookie — all matching
+/// DEV_AUTH_TOKEN.
+///
+/// The cookie path lets same-origin `<img>`/`<a>` asset requests (figures,
+/// notebook, paper) authenticate without putting the token in the URL (where it
+/// would leak via Referer/history/access logs — D8). It is restricted to
+/// GET/HEAD so it cannot be replayed as CSRF against the mutating POST
+/// endpoints, which still require the header.
 ///
 /// Applied to `/runs` and `/ws/runs/*`. NOT applied to `/health`.
 pub async fn require_dev_token(
@@ -35,6 +44,23 @@ pub async fn require_dev_token(
             let v = it.next().unwrap_or("");
             if k == "token" && constant_time_eq(v.as_bytes(), expected.as_bytes()) {
                 return Ok(next.run(req).await);
+            }
+        }
+    }
+
+    // 3) For safe (read-only) requests only, accept an `mm_auth` cookie. This
+    //    authenticates same-origin <img>/<a> asset GETs without a token in the
+    //    URL. GET/HEAD only so it can't be abused for CSRF against mutations.
+    if matches!(*req.method(), Method::GET | Method::HEAD) {
+        if let Some(val) = req.headers().get(COOKIE) {
+            if let Ok(s) = val.to_str() {
+                for pair in s.split(';') {
+                    if let Some(tok) = pair.trim().strip_prefix("mm_auth=") {
+                        if constant_time_eq(tok.as_bytes(), expected.as_bytes()) {
+                            return Ok(next.run(req).await);
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/src/dispatch.rs
+++ b/crates/gateway/src/dispatch.rs
@@ -19,6 +19,11 @@ pub fn events_stream_key(run_id: &Uuid) -> String {
     format!("mm:events:{run_id}")
 }
 
+/// Approximate MAXLEN for each per-run `mm:events:<run_id>` stream. Must match
+/// the worker emitter's cap so the gateway and worker trim consistently.
+/// Single source of truth shared by the cost ledger and the LLM token fan-out.
+pub const EVENTS_MAXLEN: usize = 5000;
+
 /// XADD mm:jobs with approximate maxlen, fields: run_id, payload, created_at.
 pub async fn enqueue_job(
     redis: &mut ConnectionManager,

--- a/crates/gateway/src/llm/cost.rs
+++ b/crates/gateway/src/llm/cost.rs
@@ -14,13 +14,10 @@ use redis::AsyncCommands;
 use serde_json::json;
 use uuid::Uuid;
 
-use crate::dispatch::events_stream_key;
+use crate::dispatch::{events_stream_key, EVENTS_MAXLEN};
 use crate::llm::canonical::Usage;
 use crate::llm::config::{Price, PriceTable};
 use crate::llm::stream::next_seq;
-
-/// Stream MAXLEN for `mm:events:<run_id>`. Matches worker emitter.
-const EVENTS_MAXLEN: usize = 5000;
 
 /// Redis key that holds the per-run running cost total in RMB. Mirrors
 /// `runs.cost_rmb` in Postgres so consumers (e.g. the Python worker's

--- a/crates/gateway/src/llm/providers/anthropic.rs
+++ b/crates/gateway/src/llm/providers/anthropic.rs
@@ -230,7 +230,11 @@ impl ProviderAdapter for AnthropicAdapter {
     }
 
     fn has_credentials(&self) -> bool {
-        !self.api_key.is_empty()
+        // Mirror openai_compat: a local/no-auth endpoint (self-hosted proxy or
+        // test mock speaking the Anthropic API) is usable without a key.
+        // Without this the router's credentials gate skipped a keyless local
+        // Anthropic provider entirely (it returned 500 "no adapter").
+        !self.api_key.is_empty() || super::is_local_base_url(&self.base_url)
     }
 
     async fn complete(&self, req: CanonicalRequest) -> Result<CanonicalResponse, ProviderError> {
@@ -575,6 +579,27 @@ mod tests {
         assert_eq!(msgs.len(), 3);
         assert_eq!(msgs[0]["role"], "user");
         assert_eq!(msgs[1]["role"], "assistant");
+    }
+
+    #[test]
+    fn has_credentials_true_for_key_or_local_endpoint() {
+        let mk = |base: &str, key: &str| {
+            AnthropicAdapter::new(
+                "anth".into(),
+                base.into(),
+                key.into(),
+                vec!["claude-sonnet-4-6".into()],
+                Client::new(),
+            )
+        };
+        // Real API + key: has creds.
+        assert!(mk("https://api.anthropic.com", "sk").has_credentials());
+        // Remote endpoint, empty key: dead key -> skipped by the router.
+        assert!(!mk("https://api.anthropic.com", "").has_credentials());
+        // Local/no-auth endpoint, empty key: usable (mirrors openai_compat).
+        // This is exactly the case that made the anthropic_stream mock 500.
+        assert!(mk("http://127.0.0.1:8123", "").has_credentials());
+        assert!(mk("http://localhost:8123", "").has_credentials());
     }
 
     #[test]

--- a/crates/gateway/src/llm/providers/anthropic.rs
+++ b/crates/gateway/src/llm/providers/anthropic.rs
@@ -189,14 +189,18 @@ impl AnthropicAdapter {
                 body["system"] = json!(system);
             }
         }
-        if let Some(t) = req.temperature {
-            body["temperature"] = json!(t);
-        }
         if thinking_budget > 0 {
+            // Extended thinking is mutually exclusive with a non-1 temperature:
+            // Anthropic's /v1/messages returns HTTP 400 ("`temperature` may only
+            // be set to 1 when thinking is enabled") if both are present. The
+            // pipeline sends temperature≈0.2 by default, so we OMIT temperature
+            // entirely on the thinking path (equivalent to the required temp=1).
             body["thinking"] = json!({
                 "type": "enabled",
                 "budget_tokens": thinking_budget,
             });
+        } else if let Some(t) = req.temperature {
+            body["temperature"] = json!(t);
         }
         body
     }
@@ -629,6 +633,58 @@ mod tests {
                 "max_tokens {mt} < budget+1024 for {level}"
             );
         }
+    }
+
+    #[test]
+    fn build_body_omits_temperature_when_thinking_enabled() {
+        // D3 regression: Anthropic returns HTTP 400 if `temperature` is sent
+        // alongside extended thinking unless temperature==1. The default
+        // pipeline temperature is 0.2, so we must omit it on the thinking path.
+        let adapter = AnthropicAdapter::new(
+            "anth".into(),
+            "https://x".into(),
+            "k".into(),
+            vec!["claude-sonnet-4-6".into()],
+            Client::new(),
+        );
+        for level in ["low", "medium", "high"] {
+            let mut req = mk_req_with(vec![("user", "go")]);
+            req.temperature = Some(0.2);
+            req.reasoning_effort = Some(level.into());
+            let body = adapter.build_body(&req, false);
+            assert_eq!(body["thinking"]["type"], "enabled", "level {level}");
+            assert!(
+                body.get("temperature").is_none(),
+                "temperature must be omitted when thinking is enabled (level {level})"
+            );
+        }
+    }
+
+    #[test]
+    fn build_body_keeps_temperature_without_thinking() {
+        // D3 regression: the non-thinking path must still forward temperature.
+        let adapter = AnthropicAdapter::new(
+            "anth".into(),
+            "https://x".into(),
+            "k".into(),
+            vec!["claude-sonnet-4-6".into()],
+            Client::new(),
+        );
+        let mut req = mk_req_with(vec![("user", "go")]);
+        req.temperature = Some(0.2);
+        req.reasoning_effort = Some("off".into());
+        let body = adapter.build_body(&req, false);
+        assert!(body.get("thinking").is_none());
+        let t = body["temperature"].as_f64().expect("temperature present");
+        assert!((t - 0.2).abs() < 1e-6, "temperature {t} should be ~0.2");
+
+        // And with reasoning_effort unset entirely.
+        let mut req = mk_req_with(vec![("user", "go")]);
+        req.temperature = Some(0.7);
+        let body = adapter.build_body(&req, false);
+        assert!(body.get("thinking").is_none());
+        let t = body["temperature"].as_f64().expect("temperature present");
+        assert!((t - 0.7).abs() < 1e-6, "temperature {t} should be ~0.7");
     }
 
     #[test]

--- a/crates/gateway/src/llm/providers/mod.rs
+++ b/crates/gateway/src/llm/providers/mod.rs
@@ -73,6 +73,16 @@ impl From<ProviderError> for AppError {
     }
 }
 
+/// True when a provider base URL points at a local endpoint that usually needs
+/// no auth (Ollama, a self-hosted proxy, or a test mock). Adapters use this so
+/// an empty API key against a local URL counts as "intentionally
+/// unauthenticated" rather than a dead key — keeping `has_credentials()`
+/// consistent across adapters (anthropic previously lacked this clause, so a
+/// keyless local Anthropic-shaped endpoint was wrongly skipped by the router).
+pub(crate) fn is_local_base_url(base_url: &str) -> bool {
+    base_url.contains("127.0.0.1") || base_url.contains("localhost")
+}
+
 /// Adapter that can route a canonical request to a concrete upstream
 /// provider. Each live adapter holds its own HTTP client, base URL, and key.
 #[async_trait::async_trait]

--- a/crates/gateway/src/llm/providers/openai_compat.rs
+++ b/crates/gateway/src/llm/providers/openai_compat.rs
@@ -126,11 +126,10 @@ impl ProviderAdapter for OpenAICompatAdapter {
     fn has_credentials(&self) -> bool {
         // Empty string = no auth available (the constructor preserves the
         // empty-string convention used by the Ollama-local case AND by
-        // dead-key providers loaded from a missing env var). The Ollama
-        // base URL exception keeps it functional offline.
-        !self.api_key.is_empty()
-            || self.base_url.contains("127.0.0.1")
-            || self.base_url.contains("localhost")
+        // dead-key providers loaded from a missing env var). The local
+        // base-URL exception keeps it functional offline (shared with the
+        // anthropic adapter via `is_local_base_url`).
+        !self.api_key.is_empty() || super::is_local_base_url(&self.base_url)
     }
 
     async fn complete(&self, req: CanonicalRequest) -> Result<CanonicalResponse, ProviderError> {

--- a/crates/gateway/src/routes/export.rs
+++ b/crates/gateway/src/routes/export.rs
@@ -354,18 +354,16 @@ pub(crate) async fn render_tex(
     // blocks (via pandoc's `raw_attribute` extension), then shell out to
     // pandoc to convert the substituted markdown to LaTeX.
     //
-    // We also pandoc-render the section TITLE so inline math like
-    // "§8.2 Focused $\pm10\%$ ..." survives the journey. Title pandoc
-    // output is wrapped in `\hypertarget{}{...}` etc, which is unwanted
-    // inside `\section{...}`; we strip those wrappers below.
+    // The section TITLE is emitted via Tera's `latex_escape` filter (see the
+    // `\section{ {{- sec.title | latex_escape -}} }` line in each template),
+    // so we do NOT pandoc-render it here — that produced an unused
+    // `title_latex` field and burned one pandoc invocation per section.
     let mut rendered_sections: Vec<serde_json::Value> = Vec::with_capacity(meta.sections.len());
     for sec in &meta.sections {
         let substituted = substitute_figures(&sec.body_markdown, &figure_map);
         let body_latex = md_to_latex(&substituted).await?;
-        let title_latex = md_inline_to_latex(&sec.title).await?;
         rendered_sections.push(serde_json::json!({
             "title": sec.title,
-            "title_latex": title_latex,
             "body_latex": body_latex,
         }));
     }
@@ -501,83 +499,6 @@ async fn md_to_latex(md: &str) -> Result<String, AppError> {
     )
     .await?;
     String::from_utf8(out).map_err(|e| AppError::Internal(format!("pandoc output not utf-8: {e}")))
-}
-
-/// Pandoc-convert a single-line inline string (e.g. a section title) and
-/// strip wrappers that pandoc adds for block context but that are illegal
-/// inside `\section{...}` / `\subsection{...}` arguments.
-///
-/// Returns the inline-safe LaTeX. Falls back to `latex_escape` when pandoc
-/// fails so a single weird title can't tank the whole render.
-async fn md_inline_to_latex(md: &str) -> Result<String, AppError> {
-    let trimmed = md.trim();
-    if trimmed.is_empty() {
-        return Ok(String::new());
-    }
-    match md_to_latex(trimmed).await {
-        Ok(out) => Ok(strip_block_wrappers(&out)),
-        Err(_) => Ok(latex_escape(trimmed)),
-    }
-}
-
-/// Remove pandoc-added block context that can't live inside section args:
-/// trailing newlines, leading/trailing `\hypertarget{...}{...}` / `\label{}` /
-/// `\section{}` lines. We keep the inner inline text untouched.
-fn strip_block_wrappers(s: &str) -> String {
-    let trimmed = s.trim();
-    // If pandoc emitted a real `\section{...}` block (because input had a
-    // `#` heading), unwrap one level.
-    for prefix in [
-        "\\section",
-        "\\subsection",
-        "\\subsubsection",
-        "\\paragraph",
-        "\\subparagraph",
-    ] {
-        if let Some(rest) = trimmed.strip_prefix(prefix) {
-            if let Some(inner) = rest.strip_prefix('{') {
-                if let Some(end) = matching_brace_end(inner) {
-                    return inner[..end].to_string();
-                }
-            }
-        }
-    }
-    // Strip a leading `\hypertarget{...}{` wrapper if present and find its
-    // matching close brace; otherwise pass through.
-    if let Some(after) = trimmed.strip_prefix("\\hypertarget{") {
-        if let Some(target_end) = after.find('}') {
-            let after_target = &after[target_end + 1..];
-            if let Some(inner) = after_target.strip_prefix('{') {
-                if let Some(end) = matching_brace_end(inner) {
-                    return inner[..end].to_string();
-                }
-            }
-        }
-    }
-    trimmed.to_string()
-}
-
-fn matching_brace_end(s: &str) -> Option<usize> {
-    let mut depth: i32 = 1;
-    let mut escaped = false;
-    for (i, ch) in s.char_indices() {
-        if escaped {
-            escaped = false;
-            continue;
-        }
-        match ch {
-            '\\' => escaped = true,
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(i);
-                }
-            }
-            _ => {}
-        }
-    }
-    None
 }
 
 /// Cap on concurrent `tectonic` invocations across the whole process.
@@ -1144,6 +1065,34 @@ mod tests {
         assert!(out.contains("\\documentclass[a4paper,11pt]{article}"));
         assert!(out.contains("Team Control Number"));
         assert!(out.contains("\\section{Results}"));
+    }
+
+    /// Regression: a preamble LaTeX comment once contained the literal text
+    /// `{% raw %}`, which Tera parsed as the real raw-block opener. That left
+    /// the *intended* `{% raw %}` as literal output; since `%` starts a LaTeX
+    /// comment, the `\providecommand{\tightlist}` line got commented out, so
+    /// any paper with a pandoc "tight list" failed to compile with "Undefined
+    /// control sequence \tightlist". Guard all three competition templates: no
+    /// Tera tag may survive into the output, and the tightlist shim must be
+    /// present on a non-comment line.
+    #[test]
+    fn templates_strip_tera_tags_and_define_tightlist() {
+        for kind in [TemplateKind::Mcm, TemplateKind::Cumcm, TemplateKind::Huashu] {
+            let name = kind.file();
+            let out = render_template(kind);
+            assert!(
+                !out.contains("{% raw %}") && !out.contains("{% endraw %}"),
+                "{name}: a Tera tag leaked into rendered output (a comment likely contains a literal raw/endraw tag)"
+            );
+            let defines_tightlist = out.lines().any(|l| {
+                let t = l.trim_start();
+                !t.starts_with('%') && t.contains("\\providecommand{\\tightlist}")
+            });
+            assert!(
+                defines_tightlist,
+                "{name}: \\providecommand{{\\tightlist}} missing or commented out — pandoc tight lists will fail to compile to PDF"
+            );
+        }
     }
 
     #[test]

--- a/crates/gateway/src/routes/health.rs
+++ b/crates/gateway/src/routes/health.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::Json;
 use serde_json::{json, Value};
 
@@ -8,16 +9,35 @@ use crate::dispatch::ping_redis;
 use crate::state::AppState;
 
 #[tracing::instrument(skip_all)]
-pub async fn health(State(mut state): State<AppState>) -> Json<Value> {
+pub async fn health(State(mut state): State<AppState>) -> (StatusCode, Json<Value>) {
     let redis_ok = ping_redis(&mut state.redis).await;
     let postgres_ok = ping_postgres(&state.pg).await;
 
-    Json(json!({
-        "status": if redis_ok && postgres_ok { "ok" } else { "degraded" },
-        "version": env!("CARGO_PKG_VERSION"),
-        "redis_ok": redis_ok,
-        "postgres_ok": postgres_ok,
-    }))
+    // C7: surface degradation in the HTTP status, not just the body. LB / k8s
+    // probes only look at the status code, so a 200-on-degraded gateway keeps
+    // receiving traffic even when Redis or Postgres is down.
+    let healthy = redis_ok && postgres_ok;
+    let status = health_status(healthy);
+
+    (
+        status,
+        Json(json!({
+            "status": if healthy { "ok" } else { "degraded" },
+            "version": env!("CARGO_PKG_VERSION"),
+            "redis_ok": redis_ok,
+            "postgres_ok": postgres_ok,
+        })),
+    )
+}
+
+/// Map the aggregate health to an HTTP status: 200 when every dependency is
+/// reachable, 503 otherwise (C7).
+fn health_status(healthy: bool) -> StatusCode {
+    if healthy {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
 }
 
 /// `SELECT 1` with a hard 500ms ceiling. Never returns an error; callers only
@@ -34,5 +54,17 @@ async fn ping_postgres(pg: &sqlx::PgPool) -> bool {
             tracing::warn!("postgres health probe timed out");
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn degraded_maps_to_503_and_healthy_to_200() {
+        // C7: a degraded gateway must report 503 so LB/k8s probes drain it.
+        assert_eq!(health_status(true), StatusCode::OK);
+        assert_eq!(health_status(false), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/crates/gateway/src/routes/llm.rs
+++ b/crates/gateway/src/routes/llm.rs
@@ -22,15 +22,12 @@ use redis::AsyncCommands;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use crate::dispatch::events_stream_key;
+use crate::dispatch::{events_stream_key, EVENTS_MAXLEN};
 use crate::error::AppError;
 use crate::llm::canonical::{CanonicalChunk, CanonicalRequest, Usage};
 use crate::llm::providers::ProviderError;
 use crate::llm::{cache, cost, stream as llm_stream};
 use crate::state::AppState;
-
-/// Stream MAXLEN for `mm:events:<run_id>`. Matches worker emitter.
-const EVENTS_MAXLEN: usize = 5000;
 
 /// Entry point registered in `app::build_router`.
 #[tracing::instrument(skip_all)]
@@ -221,6 +218,36 @@ fn build_forward_stream(
         cost_finalized: bool,
     }
 
+    impl S {
+        /// Record the accumulated usage against the cost ledger exactly once.
+        /// Shared by the clean-EOF (`None`) and the upstream-error (`Err`)
+        /// paths so partial usage is never silently dropped from the ledger
+        /// when a stream ends with an error (D11). Idempotent via
+        /// `cost_finalized`.
+        async fn finalize_cost(&mut self) {
+            if self.cost_finalized {
+                return;
+            }
+            self.cost_finalized = true;
+            let usage = self.usage.clone().unwrap_or_default();
+            if let Err(e) = cost::record_completion_cost(
+                &self.pg,
+                &mut self.redis,
+                &self.llm.prices,
+                self.runs_dir.as_ref(),
+                self.run_id,
+                self.agent.as_deref(),
+                &self.served_model,
+                &usage,
+                false,
+            )
+            .await
+            {
+                tracing::warn!(error = %e, "cost accounting failed on stream end");
+            }
+        }
+    }
+
     let init = S {
         upstream,
         redis,
@@ -276,6 +303,12 @@ fn build_forward_stream(
             }
             Some(Err(err)) => {
                 tracing::warn!(error = %err, "upstream stream error; emitting error event");
+                // D11: finalize cost BEFORE terminating. The provider already
+                // billed for any tokens consumed before the error (usage is
+                // captured in `s.usage`); without this the partial usage is
+                // dropped from the ledger and `mm:cost` since the `None` branch
+                // is bypassed once `done_sent` is set.
+                s.finalize_cost().await;
                 let data = json!({
                     "error": err.to_string(),
                 })
@@ -286,25 +319,7 @@ fn build_forward_stream(
             }
             None => {
                 // Upstream exhausted cleanly. Finalize cost + emit [DONE].
-                if !s.cost_finalized {
-                    s.cost_finalized = true;
-                    let usage = s.usage.clone().unwrap_or_default();
-                    if let Err(e) = cost::record_completion_cost(
-                        &s.pg,
-                        &mut s.redis,
-                        &s.llm.prices,
-                        s.runs_dir.as_ref(),
-                        s.run_id,
-                        s.agent.as_deref(),
-                        &s.served_model,
-                        &usage,
-                        false,
-                    )
-                    .await
-                    {
-                        tracing::warn!(error = %e, "cost accounting failed on stream end");
-                    }
-                }
+                s.finalize_cost().await;
                 s.done_sent = true;
                 Some((Ok(Event::default().data("[DONE]")), s))
             }

--- a/crates/gateway/src/routes/runs.rs
+++ b/crates/gateway/src/routes/runs.rs
@@ -106,8 +106,32 @@ pub async fn create_run(
     })?;
 
     // 2) Enqueue job onto mm:jobs.
+    //
+    // D10: INSERT + XADD are not transactional. If the XADD fails, the row we
+    // just inserted would be left permanently `queued` with no worker
+    // consuming it and no audit task (spawn_audit_task below never runs). Roll
+    // back by deleting the orphaned row before propagating the error.
     let payload = serde_json::to_value(&input)?;
-    let stream_id = enqueue_job(&mut state.redis, &run_id, &payload).await?;
+    let stream_id = match enqueue_job(&mut state.redis, &run_id, &payload).await {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::error!(%run_id, error = %e, "enqueue_job failed; deleting orphaned run row");
+            if let Err(del_err) = sqlx::query("DELETE FROM runs WHERE id = $1")
+                .bind(run_id)
+                .execute(&state.pg)
+                .await
+            {
+                // Best-effort cleanup: if even the delete fails we still surface
+                // the original enqueue error, but log the leak for operators.
+                tracing::error!(
+                    %run_id,
+                    error = %del_err,
+                    "failed to delete orphaned run row after enqueue failure; row leaked as 'queued'"
+                );
+            }
+            return Err(e);
+        }
+    };
     tracing::info!(%run_id, stream_id, "run enqueued to mm:jobs");
 
     // 3) Spawn the audit task that tails mm:events:<run_id> into events_audit.
@@ -227,10 +251,35 @@ pub async fn cancel_run(
     ))
 }
 
+/// Query params for `GET /runs/:run_id` event pagination (D23).
+///
+/// The Redis events stream is capped at MAXLEN ~5000, but `events_audit` in
+/// Postgres is unbounded, so a streaming-heavy run can accumulate thousands of
+/// rows. Without a LIMIT the whole table materializes into one response. We
+/// page by `seq` cursor (events are monotonically increasing and gap-free per
+/// run), keeping the default response bounded while staying backwards
+/// compatible: callers that pass nothing get up to `DEFAULT_EVENTS_LIMIT`
+/// events from the start, which covers every normal run.
+#[derive(Debug, Deserialize)]
+pub struct GetRunQuery {
+    /// Return events with `seq > after_seq`. Omit to start from the beginning.
+    pub after_seq: Option<i64>,
+    /// Max events to return (default `DEFAULT_EVENTS_LIMIT`, hard cap `MAX_EVENTS_LIMIT`).
+    pub limit: Option<u32>,
+}
+
+/// Default page size when the caller doesn't specify `limit`. Matches the
+/// Redis stream MAXLEN so the default response is the same set a fresh WS
+/// subscriber would replay for a typical run.
+const DEFAULT_EVENTS_LIMIT: i64 = 5000;
+/// Absolute ceiling on a single page, independent of the requested `limit`.
+const MAX_EVENTS_LIMIT: i64 = 5000;
+
 #[tracing::instrument(skip_all, fields(%run_id))]
 pub async fn get_run(
     State(state): State<AppState>,
     Path(run_id): Path<Uuid>,
+    axum::extract::Query(q): axum::extract::Query<GetRunQuery>,
 ) -> Result<Json<Value>, AppError> {
     // Fetch the run row. RowNotFound -> 404.
     let run: RunRow = sqlx::query_as::<_, RunRow>(
@@ -246,18 +295,35 @@ pub async fn get_run(
     .fetch_one(&state.pg)
     .await?;
 
-    // Fetch all audit events for this run, ordered.
-    let events: Vec<EventRow> = sqlx::query_as::<_, EventRow>(
+    let limit = q
+        .limit
+        .map(|l| (l as i64).clamp(1, MAX_EVENTS_LIMIT))
+        .unwrap_or(DEFAULT_EVENTS_LIMIT);
+    let after_seq = q.after_seq.unwrap_or(0);
+
+    // Fetch a bounded page of audit events for this run, ordered by seq, after
+    // the cursor. LIMIT+1 is requested so we can report `has_more` without a
+    // second COUNT query.
+    let mut events: Vec<EventRow> = sqlx::query_as::<_, EventRow>(
         r#"
         SELECT run_id, seq, ts, agent, kind, payload
         FROM events_audit
-        WHERE run_id = $1
+        WHERE run_id = $1 AND seq > $2
         ORDER BY seq ASC
+        LIMIT $3
         "#,
     )
     .bind(run_id)
+    .bind(after_seq)
+    .bind(limit + 1)
     .fetch_all(&state.pg)
     .await?;
+
+    let has_more = events.len() as i64 > limit;
+    if has_more {
+        events.truncate(limit as usize);
+    }
+    let next_after_seq = events.last().map(|e| e.seq);
 
     let events_json: Vec<Value> = events
         .into_iter()
@@ -285,6 +351,10 @@ pub async fn get_run(
         "notebook_path": run.notebook_path,
         "paper_path": run.paper_path,
         "events": events_json,
+        // Pagination metadata (D23). `has_more` true means call again with
+        // `?after_seq=<next_after_seq>` to fetch the next page.
+        "has_more": has_more,
+        "next_after_seq": next_after_seq,
     })))
 }
 

--- a/crates/gateway/src/routes/submission.rs
+++ b/crates/gateway/src/routes/submission.rs
@@ -396,6 +396,7 @@ async fn build_support_zip(run_root: &StdPath) -> Result<Vec<u8>, AppError> {
         let mut budget = SupportBudget::new();
         add_dir_to_zip(
             &mut zw,
+            run_root,
             &run_root.join("figures"),
             "figures",
             opts,
@@ -404,7 +405,7 @@ async fn build_support_zip(run_root: &StdPath) -> Result<Vec<u8>, AppError> {
         .await?;
         let data_dir = run_root.join("data");
         if is_existing_dir(&data_dir).await {
-            add_dir_to_zip(&mut zw, &data_dir, "data", opts, &mut budget).await?;
+            add_dir_to_zip(&mut zw, run_root, &data_dir, "data", opts, &mut budget).await?;
         }
 
         // 5. README inside the inner zip — survives unpacking the
@@ -465,6 +466,7 @@ impl SupportBudget {
 ///     `PayloadTooLarge` if budget is busted.
 async fn add_dir_to_zip<W: Write + std::io::Seek>(
     zw: &mut ZipWriter<W>,
+    run_root: &StdPath,
     src_dir: &StdPath,
     prefix: &str,
     opts: SimpleFileOptions,
@@ -480,7 +482,14 @@ async fn add_dir_to_zip<W: Write + std::io::Seek>(
         .map_err(|e| AppError::Internal(format!("walk {}: {e}", src_dir.display())))?
     {
         let path = entry.path();
-        let meta = match tokio::fs::metadata(&path).await {
+        // D17: canonicalize and verify the entry stays under run_root before
+        // touching it. tokio::fs::metadata/read follow symlinks, so a symlink
+        // planted in figures/ or data/ pointing at /etc/passwd (or another
+        // run's data) would otherwise be packed into the bundle.
+        let Some(canon) = canonicalize_within(run_root, &path).await else {
+            continue;
+        };
+        let meta = match tokio::fs::metadata(&canon).await {
             Ok(m) => m,
             Err(_) => continue,
         };
@@ -506,9 +515,9 @@ async fn add_dir_to_zip<W: Write + std::io::Seek>(
             continue;
         }
         budget.try_reserve(size)?;
-        let bytes = tokio::fs::read(&path)
+        let bytes = tokio::fs::read(&canon)
             .await
-            .map_err(|e| AppError::Internal(format!("read {}: {e}", path.display())))?;
+            .map_err(|e| AppError::Internal(format!("read {}: {e}", canon.display())))?;
         zw.start_file(format!("{prefix}/{name}"), opts)
             .map_err(zip_err)?;
         zw.write_all(&bytes).map_err(zip_err)?;
@@ -537,7 +546,12 @@ async fn add_archival_figures_to_zip<W: Write + std::io::Seek>(
         .map_err(|e| AppError::Internal(format!("walk figures: {e}")))?
     {
         let path = entry.path();
-        let meta = match tokio::fs::metadata(&path).await {
+        // D17: same symlink-escape guard as add_dir_to_zip — canonicalize and
+        // confirm the entry stays under run_root before reading.
+        let Some(canon) = canonicalize_within(run_root, &path).await else {
+            continue;
+        };
+        let meta = match tokio::fs::metadata(&canon).await {
             Ok(m) => m,
             Err(_) => continue,
         };
@@ -559,14 +573,33 @@ async fn add_archival_figures_to_zip<W: Write + std::io::Seek>(
             );
             continue;
         }
-        let bytes = tokio::fs::read(&path)
+        let bytes = tokio::fs::read(&canon)
             .await
-            .map_err(|e| AppError::Internal(format!("read {}: {e}", path.display())))?;
+            .map_err(|e| AppError::Internal(format!("read {}: {e}", canon.display())))?;
         zw.start_file(format!("{prefix}/{name}"), opts)
             .map_err(zip_err)?;
         zw.write_all(&bytes).map_err(zip_err)?;
     }
     Ok(())
+}
+
+/// Canonicalize `path` and return it only if the real path stays under the
+/// canonical `run_root`. Returns `None` when the path can't be resolved (e.g.
+/// a dangling symlink) or escapes the run directory (D17). Mirrors the
+/// `resolve_within` containment pattern used by the file-serving routes.
+async fn canonicalize_within(run_root: &StdPath, path: &StdPath) -> Option<std::path::PathBuf> {
+    let canon = tokio::fs::canonicalize(path).await.ok()?;
+    if canon.starts_with(run_root) {
+        Some(canon)
+    } else {
+        tracing::warn!(
+            path = %path.display(),
+            resolved = %canon.display(),
+            run_root = %run_root.display(),
+            "support archive: skipping entry that escapes run_root (symlink?)"
+        );
+        None
+    }
 }
 
 /// Async replacement for `Path::is_dir()` which would otherwise issue a
@@ -1076,6 +1109,21 @@ mod tests {
             out.contains("No LLM calls recorded"),
             "empty model list yields the fallback row"
         );
+        // D4 regression: section 5's `\begin{itemize}` must never be emitted
+        // empty — tectonic/XeTeX hard-errors ("missing \item") on an empty
+        // itemize, crashing the documented "no LLM assistance" submission path.
+        // Verify every itemize block in the fragment contains at least one
+        // `\item` even when `models` is empty.
+        for block in out.split("\\begin{itemize}").skip(1) {
+            let body = block
+                .split("\\end{itemize}")
+                .next()
+                .expect("itemize must be closed");
+            assert!(
+                body.contains("\\item"),
+                "empty itemize would crash LaTeX; block was:\n{body}"
+            );
+        }
     }
 
     #[test]
@@ -1260,5 +1308,57 @@ mod tests {
             !out.contains("stage.done"),
             "non-cost events must not appear in the report"
         );
+    }
+
+    // --- D17: symlink-escape containment ----------------------------------
+
+    #[tokio::test]
+    async fn canonicalize_within_accepts_in_root_files() {
+        let root_tmp = tempfile::tempdir().expect("tmp");
+        let run_root = tokio::fs::canonicalize(root_tmp.path()).await.unwrap();
+        let figures = run_root.join("figures");
+        tokio::fs::create_dir_all(&figures).await.unwrap();
+        let png = figures.join("fig-0.png");
+        tokio::fs::write(&png, b"\x89PNG").await.unwrap();
+
+        let resolved = canonicalize_within(&run_root, &png).await;
+        assert!(
+            resolved.is_some(),
+            "a real file under run_root must be accepted"
+        );
+        assert!(resolved.unwrap().starts_with(&run_root));
+    }
+
+    #[tokio::test]
+    async fn canonicalize_within_rejects_symlink_escape() {
+        // A symlink inside figures/ pointing at a file OUTSIDE run_root must
+        // be rejected so it can never be packed into the support archive.
+        let outside_tmp = tempfile::tempdir().expect("outside tmp");
+        let secret = outside_tmp.path().join("secret.txt");
+        tokio::fs::write(&secret, b"TOP SECRET").await.unwrap();
+        let secret = tokio::fs::canonicalize(&secret).await.unwrap();
+
+        let root_tmp = tempfile::tempdir().expect("run tmp");
+        let run_root = tokio::fs::canonicalize(root_tmp.path()).await.unwrap();
+        let figures = run_root.join("figures");
+        tokio::fs::create_dir_all(&figures).await.unwrap();
+        let evil = figures.join("evil.png");
+        std::os::unix::fs::symlink(&secret, &evil).expect("symlink");
+
+        let resolved = canonicalize_within(&run_root, &evil).await;
+        assert!(
+            resolved.is_none(),
+            "a symlink escaping run_root must be rejected (got {resolved:?})"
+        );
+    }
+
+    #[tokio::test]
+    async fn canonicalize_within_rejects_dangling_symlink() {
+        let root_tmp = tempfile::tempdir().expect("run tmp");
+        let run_root = tokio::fs::canonicalize(root_tmp.path()).await.unwrap();
+        let dangling = run_root.join("figures-link");
+        std::os::unix::fs::symlink("/nonexistent/path/xyz", &dangling).expect("symlink");
+        let resolved = canonicalize_within(&run_root, &dangling).await;
+        assert!(resolved.is_none(), "dangling symlink must be rejected");
     }
 }

--- a/crates/gateway/src/routes/ws_run.rs
+++ b/crates/gateway/src/routes/ws_run.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use axum::extract::ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path, State};
-use axum::response::IntoResponse;
 use redis::aio::ConnectionManager;
 use redis::streams::{StreamReadOptions, StreamReadReply};
 use redis::AsyncCommands;
@@ -28,12 +27,25 @@ pub async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<AppState>,
     Path(run_id): Path<Uuid>,
-) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| async move {
+) -> Result<axum::response::Response, crate::error::AppError> {
+    // C6: reject unknown run_ids with a 404 BEFORE upgrading, mirroring
+    // cancel_run / finetune_run. Without this, any authenticated client can
+    // subscribe to an arbitrary UUID and the handler polls a non-existent
+    // stream every ~100ms forever.
+    let exists: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM runs WHERE id = $1")
+        .bind(run_id)
+        .fetch_optional(&state.pg)
+        .await
+        .map_err(|e| crate::error::AppError::Internal(format!("lookup run: {e}")))?;
+    if exists.is_none() {
+        return Err(crate::error::AppError::NotFound);
+    }
+
+    Ok(ws.on_upgrade(move |socket| async move {
         if let Err(e) = handle_socket(socket, state, run_id).await {
             tracing::warn!(%run_id, error = %e, "ws session ended with error");
         }
-    })
+    }))
 }
 
 async fn handle_socket(mut socket: WebSocket, state: AppState, run_id: Uuid) -> anyhow::Result<()> {
@@ -72,31 +84,36 @@ async fn handle_socket(mut socket: WebSocket, state: AppState, run_id: Uuid) -> 
             // (a) Redis-side pull.
             read_res = xread_once(&mut redis, &stream_key, &last_id, &opts) => {
                 match read_res {
-                    Ok(Some(entries)) => {
-                        for (entry_id, payload) in entries {
-                            // Advance Redis cursor for the next read regardless of filter.
-                            last_id = entry_id;
+                    Ok(Some(batch)) => {
+                        // D5: always advance the cursor past EVERY consumed
+                        // entry (incl. payload-less ones), so a malformed XADD
+                        // can't pin us in an infinite re-read loop.
+                        last_id = batch.max_id;
 
-                            // Skip events already seen by the client.
-                            if event_seq(&payload).is_some_and(|s| s <= last_seq) {
-                                continue;
-                            }
+                        // Decide what to forward + whether the batch contained
+                        // a `done` event. Pure logic, unit-tested as `plan_batch`.
+                        let plan = plan_batch(&batch.entries, last_seq);
 
-                            if socket.send(Message::Text(payload.clone())).await.is_err() {
+                        // D12: forward the remaining entries in the batch even
+                        // after a `done` is seen, then close. Closing the moment
+                        // we see `done` would drop trailing tokens that raced
+                        // ahead of the worker's done XADD in the same batch.
+                        for payload in plan.forward {
+                            if socket.send(Message::Text(payload.to_string())).await.is_err() {
                                 tracing::debug!(%run_id, "client send failed; closing");
                                 return Ok(());
                             }
+                        }
 
-                            // If this was a `done` event, flush + close cleanly.
-                            if is_done_event(&payload) {
-                                tracing::info!(%run_id, "done event forwarded; closing ws");
-                                tokio::time::sleep(Duration::from_millis(50)).await;
-                                let _ = socket.send(Message::Close(Some(CloseFrame {
-                                    code: axum::extract::ws::close_code::NORMAL,
-                                    reason: std::borrow::Cow::Borrowed("run done"),
-                                }))).await;
-                                return Ok(());
-                            }
+                        // Close cleanly once the whole batch has been flushed.
+                        if plan.saw_done {
+                            tracing::info!(%run_id, "done event forwarded; closing ws");
+                            tokio::time::sleep(Duration::from_millis(50)).await;
+                            let _ = socket.send(Message::Close(Some(CloseFrame {
+                                code: axum::extract::ws::close_code::NORMAL,
+                                reason: std::borrow::Cow::Borrowed("run done"),
+                            }))).await;
+                            return Ok(());
                         }
                     }
                     Ok(None) => {
@@ -133,6 +150,19 @@ async fn handle_socket(mut socket: WebSocket, state: AppState, run_id: Uuid) -> 
     }
 }
 
+/// Result of a single [`xread_once`] call: the forwardable `(entry_id, payload)`
+/// pairs plus the maximum stream id consumed in this batch (whether or not it
+/// carried a payload).
+struct XreadBatch {
+    /// Entries with a usable `payload` field, in stream order.
+    entries: Vec<(String, String)>,
+    /// The highest stream id seen in this batch. The caller MUST advance its
+    /// cursor to this even when `entries` is empty (D5): a batch made entirely
+    /// of payload-less entries would otherwise leave the cursor unchanged and
+    /// the next XREAD would re-fetch the same entries forever.
+    max_id: String,
+}
+
 /// Single XREAD call. Returns `Ok(None)` if the command blocked and returned
 /// no entries (timeout), `Ok(Some(...))` otherwise.
 async fn xread_once(
@@ -140,7 +170,7 @@ async fn xread_once(
     stream_key: &str,
     last_id: &str,
     opts: &StreamReadOptions,
-) -> redis::RedisResult<Option<Vec<(String, String)>>> {
+) -> redis::RedisResult<Option<XreadBatch>> {
     let reply: Option<StreamReadReply> =
         redis.xread_options(&[stream_key], &[last_id], opts).await?;
 
@@ -148,9 +178,15 @@ async fn xread_once(
         return Ok(None);
     };
 
-    let mut out = Vec::new();
+    let mut entries = Vec::new();
+    let mut max_id: Option<String> = None;
     for key in reply.keys {
         for entry in key.ids {
+            // Track the cursor over EVERY consumed id, including entries we
+            // can't forward (missing/malformed payload). XREAD ids are
+            // monotonically increasing within a batch, so the last one is max.
+            max_id = Some(entry.id.clone());
+
             // Events are stored with a single `payload` field holding the JSON string.
             let payload = match entry.map.get("payload") {
                 Some(redis::Value::BulkString(bytes)) => {
@@ -159,10 +195,15 @@ async fn xread_once(
                 Some(redis::Value::SimpleString(s)) => s.clone(),
                 _ => continue,
             };
-            out.push((entry.id, payload));
+            entries.push((entry.id, payload));
         }
     }
-    Ok(Some(out))
+
+    // An empty reply object (no keys/ids) is treated like a timeout.
+    let Some(max_id) = max_id else {
+        return Ok(None);
+    };
+    Ok(Some(XreadBatch { entries, max_id }))
 }
 
 /// True if the JSON payload has `"kind":"done"` at the top level.
@@ -179,4 +220,125 @@ fn event_seq(payload: &str) -> Option<u64> {
     serde_json::from_str::<Value>(payload)
         .ok()
         .and_then(|v| v.get("seq").and_then(|s| s.as_u64()))
+}
+
+/// Outcome of planning a single XREAD batch: the payloads to forward (in
+/// order, with already-seen `seq <= last_seq` entries filtered out) and
+/// whether a `done` event appeared anywhere in the batch.
+struct BatchPlan<'a> {
+    forward: Vec<&'a str>,
+    saw_done: bool,
+}
+
+/// Decide which batch entries to forward and whether the batch terminates the
+/// run. Pure so D5/D12 behavior is unit-testable without a live socket/Redis.
+///
+/// D12: a `done` does NOT stop forwarding — all subsequent entries in the same
+/// batch are still forwarded (a token can race ahead of the worker's `done`
+/// XADD and land in the same XREAD batch). The caller closes the socket only
+/// after every forwarded entry has been flushed.
+fn plan_batch(entries: &[(String, String)], last_seq: u64) -> BatchPlan<'_> {
+    let mut forward = Vec::new();
+    let mut saw_done = false;
+    for (_entry_id, payload) in entries {
+        // Skip events already seen by the client.
+        if event_seq(payload).is_some_and(|s| s <= last_seq) {
+            continue;
+        }
+        if is_done_event(payload) {
+            saw_done = true;
+        }
+        forward.push(payload.as_str());
+    }
+    BatchPlan { forward, saw_done }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(seq: u64, kind: &str) -> String {
+        serde_json::json!({ "seq": seq, "kind": kind, "payload": {} }).to_string()
+    }
+
+    #[test]
+    fn plan_batch_forwards_trailing_entries_after_done() {
+        // D12 regression: [token_A, done, token_B] must forward all three;
+        // closing on `done` would drop token_B.
+        let entries = vec![
+            ("1-0".into(), ev(1, "token")),
+            ("2-0".into(), ev(2, "done")),
+            ("3-0".into(), ev(3, "token")),
+        ];
+        let plan = plan_batch(&entries, 0);
+        assert!(plan.saw_done, "done present in batch");
+        assert_eq!(plan.forward.len(), 3, "all three entries forwarded");
+        // token_B (seq=3) is present.
+        assert!(plan.forward.iter().any(|p| p.contains("\"seq\":3")));
+    }
+
+    #[test]
+    fn plan_batch_filters_already_seen_seq() {
+        let entries = vec![
+            ("1-0".into(), ev(1, "token")),
+            ("2-0".into(), ev(2, "token")),
+            ("3-0".into(), ev(3, "token")),
+        ];
+        // Client already saw seq<=2; only seq=3 should forward.
+        let plan = plan_batch(&entries, 2);
+        assert!(!plan.saw_done);
+        assert_eq!(plan.forward.len(), 1);
+        assert!(plan.forward[0].contains("\"seq\":3"));
+    }
+
+    #[test]
+    fn plan_batch_empty_when_all_seen() {
+        let entries = vec![("1-0".into(), ev(1, "token"))];
+        let plan = plan_batch(&entries, 5);
+        assert!(plan.forward.is_empty());
+        assert!(!plan.saw_done);
+    }
+
+    // --- D5: cursor advancement past payload-less entries ------------------
+    //
+    // `xread_once` builds `XreadBatch.max_id` from EVERY consumed entry id, not
+    // just the forwardable ones. We can't issue a real XREAD here, but we can
+    // verify the parsing/cursor invariant that drives the fix: the max_id must
+    // track the highest id even when an entry carries no `payload` field. The
+    // helper below mirrors the parse loop in `xread_once`.
+    fn parse_ids_and_payloads(
+        raw: &[(&str, Option<&str>)],
+    ) -> Option<(Vec<(String, String)>, String)> {
+        let mut entries = Vec::new();
+        let mut max_id: Option<String> = None;
+        for (id, payload) in raw {
+            max_id = Some((*id).to_string());
+            if let Some(p) = payload {
+                entries.push(((*id).to_string(), (*p).to_string()));
+            }
+        }
+        max_id.map(|m| (entries, m))
+    }
+
+    #[test]
+    fn cursor_advances_past_payloadless_entries() {
+        // Batch: one payload-less entry followed by one valid entry.
+        let valid = ev(6, "token");
+        let raw = vec![("5-0", None), ("6-0", Some(valid.as_str()))];
+        let (entries, max_id) = parse_ids_and_payloads(&raw).expect("non-empty batch");
+        // Only the valid entry is forwardable...
+        assert_eq!(entries.len(), 1);
+        // ...but the cursor advances past BOTH (to "6-0"), so the next XREAD
+        // won't re-fetch the payload-less "5-0" forever.
+        assert_eq!(max_id, "6-0");
+
+        // Batch made ENTIRELY of payload-less entries still advances the cursor.
+        let raw = vec![("7-0", None), ("8-0", None)];
+        let (entries, max_id) = parse_ids_and_payloads(&raw).expect("non-empty batch");
+        assert!(entries.is_empty());
+        assert_eq!(
+            max_id, "8-0",
+            "cursor must advance even with zero forwardable entries"
+        );
+    }
 }

--- a/crates/gateway/templates/ai_use_report.tex.tera
+++ b/crates/gateway/templates/ai_use_report.tex.tera
@@ -57,7 +57,8 @@ All AI outputs in the submitted paper were reviewed by the team for mathematical
 
 \begin{itemize}
 {% for m in models %}\item {{ m.name | latex_escape }} ({{ m.provider | latex_escape }}). Used for the purposes listed in section~3.
-{% endfor %}\end{itemize}
+{% endfor %}{% if not models or models | length == 0 %}\item N/A --- no LLM calls recorded; this submission was prepared without AI assistance.
+{% endif %}\end{itemize}
 
 \vspace{1em}
 {\small\textit{Generated on {{ generated_at | latex_escape }} from the run's accounting log.}}

--- a/crates/gateway/templates/cumcm.tex.tera
+++ b/crates/gateway/templates/cumcm.tex.tera
@@ -13,7 +13,7 @@
 \usepackage{calc}
 % Pandoc-emitted macros that must exist in preamble. Consolidated into
 % one block to drop the historical duplicate \providecommand{\tightlist}
-% that landed across two separate {% raw %} sections.
+% that landed across two separate verbatim sections.
 {% raw %}\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \providecommand{\passthrough}[1]{#1}
 \providecommand{\real}[1]{#1}

--- a/crates/gateway/templates/huashu.tex.tera
+++ b/crates/gateway/templates/huashu.tex.tera
@@ -13,7 +13,7 @@
 \usepackage{calc}
 % Pandoc-emitted macros that must exist in preamble. Consolidated into
 % one block to drop the historical duplicate \providecommand{\tightlist}
-% that landed across two separate {% raw %} sections.
+% that landed across two separate verbatim sections.
 {% raw %}\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \providecommand{\passthrough}[1]{#1}
 \providecommand{\real}[1]{#1}

--- a/crates/gateway/templates/mcm.tex.tera
+++ b/crates/gateway/templates/mcm.tex.tera
@@ -21,7 +21,7 @@
 % Pandoc-emitted macros that must exist in preamble. \providecommand
 % is a no-op when the macro is already defined, so duplicating one of
 % these between sections is harmless — but the old layout split them
-% across two {% raw %} blocks and the second instance silently
+% across two verbatim blocks and the second instance silently
 % re-declared \tightlist. Consolidated to a single block.
 {% raw %}\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \providecommand{\passthrough}[1]{#1}

--- a/crates/gateway/tests/runs_lifecycle.rs
+++ b/crates/gateway/tests/runs_lifecycle.rs
@@ -328,3 +328,70 @@ async fn c7_health_ok_returns_200() {
     let body: serde_json::Value = resp.json().await.expect("json");
     assert_eq!(body["status"], "ok");
 }
+
+/// D8: an `mm_auth` cookie authenticates GET asset requests (so prod
+/// `<img>`/`<a>` loads work without a token in the URL), but must NOT be
+/// honoured for mutating POSTs — otherwise it would be a CSRF vector.
+#[tokio::test]
+async fn d8_cookie_auth_authorizes_get_only() {
+    let providers = providers_toml();
+    let state = build_state(providers.path().to_path_buf()).await;
+
+    let run_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO runs (id, problem_text, competition_type, status) VALUES ($1,$2,$3,'done')",
+    )
+    .bind(run_id)
+    .bind("D8 cookie auth probe")
+    .bind("mcm")
+    .execute(&state.pg)
+    .await
+    .expect("insert run");
+
+    let addr = boot(state.clone()).await;
+    let client = reqwest::Client::new();
+
+    // Valid cookie, NO Authorization header -> 200 (the <img>/<a> path).
+    let ok = client
+        .get(format!("http://{addr}/runs/{run_id}"))
+        .header("Cookie", format!("mm_auth={DEV_TOKEN}"))
+        .send()
+        .await
+        .expect("cookie GET");
+    let ok_status = ok.status().as_u16();
+
+    // Wrong cookie -> 401.
+    let bad = client
+        .get(format!("http://{addr}/runs/{run_id}"))
+        .header("Cookie", "mm_auth=not-the-token")
+        .send()
+        .await
+        .expect("bad cookie GET");
+    let bad_status = bad.status().as_u16();
+
+    // Cookie-only POST must be rejected (CSRF guard): mutations need the header.
+    let csrf_marker = format!("D8 csrf probe {}", Uuid::new_v4());
+    let csrf = client
+        .post(format!("http://{addr}/runs"))
+        .header("Cookie", format!("mm_auth={DEV_TOKEN}"))
+        .header(CONTENT_TYPE, "application/json")
+        .json(&serde_json::json!({"problem_text": csrf_marker, "competition_type": "mcm"}))
+        .send()
+        .await
+        .expect("csrf POST");
+    let csrf_status = csrf.status().as_u16();
+
+    // Cleanup before assertions so a failure never leaks rows for siblings.
+    let _ = sqlx::query("DELETE FROM runs WHERE id = $1 OR problem_text = $2")
+        .bind(run_id)
+        .bind(&csrf_marker)
+        .execute(&state.pg)
+        .await;
+
+    assert_eq!(ok_status, 200, "valid mm_auth cookie authorizes a GET");
+    assert_eq!(bad_status, 401, "wrong cookie is rejected");
+    assert_eq!(
+        csrf_status, 401,
+        "cookie must NOT authorize a mutating POST (CSRF guard)"
+    );
+}

--- a/crates/gateway/tests/runs_lifecycle.rs
+++ b/crates/gateway/tests/runs_lifecycle.rs
@@ -1,0 +1,330 @@
+//! Integration tests for run lifecycle endpoints, covering audit fixes:
+//!   * D10 — orphaned 'queued' row is rolled back when enqueue_job (XADD)
+//!           fails after the INSERT.
+//!   * D23 — GET /runs/:id paginates events_audit (LIMIT + after_seq cursor).
+//!   * C6  — WS upgrade to an unknown run_id returns 404 before upgrade.
+//!   * C7  — GET /health returns 503 when a dependency is degraded.
+//!
+//! Like the sibling integration tests, these rely on a live Redis + Postgres
+//! reachable at `TEST_REDIS_URL` / `TEST_DATABASE_URL` (defaults mirror
+//! `.env.example`). The gateway's migrations are expected to have already been
+//! applied to the test database (tables `runs`, `events_audit`, `cost_ledger`).
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::serve;
+use redis::AsyncCommands;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use sqlx::postgres::PgPoolOptions;
+use tempfile::NamedTempFile;
+use tokio::net::TcpListener;
+use uuid::Uuid;
+
+use gateway::app::build_router;
+use gateway::config::AppConfig;
+use gateway::dispatch::JOBS_STREAM;
+use gateway::llm::LlmContext;
+use gateway::state::AppState;
+
+const DEV_TOKEN: &str = "test-token-runs-lifecycle";
+
+fn providers_toml() -> NamedTempFile {
+    let file = NamedTempFile::new().expect("tempfile");
+    let toml = r#"
+[[providers]]
+name = "mock"
+kind = "openai_compat"
+base_url = "http://127.0.0.1:1/v1"
+api_key_env = ""
+models = ["deepseek-chat"]
+price_input_per_1m = 1.0
+price_output_per_1m = 2.0
+
+[router]
+default_model = "deepseek-chat"
+fallback = []
+"#;
+    std::fs::write(file.path(), toml).expect("write providers.toml");
+    file
+}
+
+async fn build_state(providers_path: PathBuf) -> AppState {
+    let redis_url =
+        std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379/0".into());
+    let database_url = std::env::var("TEST_DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://mm:mm@127.0.0.1:5432/mm".into());
+
+    let client = redis::Client::open(redis_url.clone()).expect("redis client");
+    let redis = redis::aio::ConnectionManager::new(client)
+        .await
+        .expect("redis connect");
+
+    let pg = PgPoolOptions::new()
+        .max_connections(4)
+        .acquire_timeout(Duration::from_secs(3))
+        .connect(&database_url)
+        .await
+        .expect("postgres connect");
+
+    let runs_tmp = tempfile::tempdir().expect("runs tempdir");
+    let runs_dir = tokio::fs::canonicalize(runs_tmp.path())
+        .await
+        .expect("canonicalize runs tempdir");
+    std::mem::forget(runs_tmp);
+
+    let cfg = AppConfig {
+        host: "127.0.0.1".into(),
+        port: 0,
+        dev_auth_token: DEV_TOKEN.into(),
+        redis_url,
+        database_url,
+        providers_path: providers_path.clone(),
+        runs_dir: runs_dir.clone(),
+        static_dir: None,
+    };
+    let llm = LlmContext::bootstrap(&providers_path).expect("LlmContext::bootstrap");
+
+    AppState {
+        redis,
+        pg,
+        config: Arc::new(cfg),
+        llm,
+        runs_dir: Arc::new(runs_dir),
+    }
+}
+
+async fn boot(state: AppState) -> SocketAddr {
+    let router = build_router(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = serve(listener, router).await;
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    addr
+}
+
+fn auth_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {DEV_TOKEN}")).unwrap(),
+    );
+    headers
+}
+
+/// D10: when XADD onto `mm:jobs` fails AFTER the INSERT, the run row must be
+/// rolled back (deleted) so we don't leak a permanently-'queued' row that no
+/// worker consumes.
+///
+/// We force a deterministic XADD failure by pre-setting `mm:jobs` to a plain
+/// string: a subsequent XADD against a non-stream key returns WRONGTYPE.
+#[tokio::test]
+async fn d10_orphaned_queued_row_rolled_back_on_enqueue_failure() {
+    // Unique marker so we count only THIS test's rows (sibling test binaries
+    // run against the same DB concurrently and may insert unrelated rows).
+    let marker = format!("D10 rollback probe {}", Uuid::new_v4());
+    let providers = providers_toml();
+    let mut state = build_state(providers.path().to_path_buf()).await;
+
+    // Defensive: clear any leftover poison from a previous crashed run so the
+    // SET below establishes the WRONGTYPE condition cleanly.
+    let _: () = state.redis.del(JOBS_STREAM).await.unwrap_or(());
+    // Force XADD to fail: set mm:jobs to a string (WRONGTYPE on XADD).
+    let _: () = state
+        .redis
+        .set(JOBS_STREAM, "not-a-stream")
+        .await
+        .expect("poison mm:jobs");
+
+    let addr = boot(state.clone()).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/runs"))
+        .headers(auth_headers())
+        .json(&serde_json::json!({
+            "problem_text": marker,
+            "competition_type": "mcm",
+        }))
+        .send()
+        .await
+        .expect("send");
+
+    let status = resp.status();
+    let body_txt = resp.text().await.unwrap_or_default();
+
+    // Count rows matching THIS test's unique marker. The rollback must have
+    // deleted the inserted row, so the count must be zero.
+    let leaked: (i64,) = sqlx::query_as("SELECT count(*) FROM runs WHERE problem_text = $1")
+        .bind(&marker)
+        .fetch_one(&state.pg)
+        .await
+        .expect("count leaked");
+
+    // Cleanup the poisoned shared key BEFORE any assertion can panic, so a
+    // failure here never leaves `mm:jobs` poisoned for sibling tests. Also
+    // best-effort delete our marker row if the fix regressed.
+    let _: () = state.redis.clone().del(JOBS_STREAM).await.unwrap_or(());
+    let _ = sqlx::query("DELETE FROM runs WHERE problem_text = $1")
+        .bind(&marker)
+        .execute(&state.pg)
+        .await;
+
+    // The enqueue failure surfaces as a 5xx (Internal).
+    assert!(
+        status.is_server_error(),
+        "expected 5xx on enqueue failure, got {status}: {body_txt}"
+    );
+    assert_eq!(
+        leaked.0, 0,
+        "orphaned 'queued' run row leaked after enqueue failure (count={})",
+        leaked.0
+    );
+}
+
+/// D23: GET /runs/:id must page events. We seed >limit events and assert the
+/// default page is bounded, `has_more` is reported, and `after_seq` advances.
+#[tokio::test]
+async fn d23_get_run_paginates_events() {
+    let providers = providers_toml();
+    let state = build_state(providers.path().to_path_buf()).await;
+
+    // Seed a run + a handful of audit events directly.
+    let run_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO runs (id, problem_text, competition_type, status) VALUES ($1,$2,$3,'done')",
+    )
+    .bind(run_id)
+    .bind("D23 pagination probe")
+    .bind("mcm")
+    .execute(&state.pg)
+    .await
+    .expect("insert run");
+
+    let total = 25_i64;
+    for seq in 1..=total {
+        sqlx::query(
+            "INSERT INTO events_audit (run_id, seq, ts, agent, kind, payload) VALUES ($1,$2, now(), $3, $4, $5)",
+        )
+        .bind(run_id)
+        .bind(seq)
+        .bind("writer")
+        .bind("token")
+        .bind(serde_json::json!({"text": format!("t{seq}")}))
+        .execute(&state.pg)
+        .await
+        .expect("insert event");
+    }
+
+    let addr = boot(state.clone()).await;
+    let client = reqwest::Client::new();
+
+    // First page with limit=10.
+    let body: serde_json::Value = client
+        .get(format!("http://{addr}/runs/{run_id}?limit=10"))
+        .headers(auth_headers())
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+
+    let events = body["events"].as_array().expect("events array");
+    assert_eq!(events.len(), 10, "first page is capped at limit");
+    assert_eq!(body["has_more"], true, "more events remain");
+    let next = body["next_after_seq"].as_i64().expect("next_after_seq");
+    assert_eq!(next, 10, "cursor points at the last seq of the page");
+
+    // Second page picks up where the first left off.
+    let body2: serde_json::Value = client
+        .get(format!(
+            "http://{addr}/runs/{run_id}?limit=10&after_seq={next}"
+        ))
+        .headers(auth_headers())
+        .send()
+        .await
+        .expect("send2")
+        .json()
+        .await
+        .expect("json2");
+    let events2 = body2["events"].as_array().expect("events2");
+    assert_eq!(events2.len(), 10);
+    assert_eq!(events2[0]["seq"], 11, "second page starts after the cursor");
+    assert_eq!(body2["has_more"], true);
+
+    // Final page returns the remainder with has_more=false.
+    let body3: serde_json::Value = client
+        .get(format!("http://{addr}/runs/{run_id}?limit=10&after_seq=20"))
+        .headers(auth_headers())
+        .send()
+        .await
+        .expect("send3")
+        .json()
+        .await
+        .expect("json3");
+    let events3 = body3["events"].as_array().expect("events3");
+    assert_eq!(events3.len(), 5, "remainder is 5 events");
+    assert_eq!(body3["has_more"], false);
+
+    // Cleanup (events cascade on run delete via FK).
+    let _ = sqlx::query("DELETE FROM runs WHERE id = $1")
+        .bind(run_id)
+        .execute(&state.pg)
+        .await;
+}
+
+/// C6: WS upgrade to an unknown run_id must 404 before upgrading. A real
+/// WebSocket upgrade attempt against a random UUID should be rejected.
+#[tokio::test]
+async fn c6_ws_unknown_run_id_returns_404() {
+    let providers = providers_toml();
+    let state = build_state(providers.path().to_path_buf()).await;
+    let addr = boot(state).await;
+
+    let unknown = Uuid::new_v4();
+    // Attempt a WS handshake via reqwest with Upgrade headers. axum runs our
+    // 404 guard before `on_upgrade`, so the server replies with a normal HTTP
+    // 404 instead of switching protocols.
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/ws/runs/{unknown}"))
+        .header(AUTHORIZATION, format!("Bearer {DEV_TOKEN}"))
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .send()
+        .await
+        .expect("send");
+
+    assert_eq!(
+        resp.status().as_u16(),
+        404,
+        "unknown run_id must 404 before WS upgrade"
+    );
+}
+
+/// C7: /health returns 200 when both deps are up. (Degraded -> 503 is asserted
+/// by the unit test in health.rs; here we confirm the happy path still 200s
+/// with the new (StatusCode, Json) return type.)
+#[tokio::test]
+async fn c7_health_ok_returns_200() {
+    let providers = providers_toml();
+    let state = build_state(providers.path().to_path_buf()).await;
+    let addr = boot(state).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/health"))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["status"], "ok");
+}

--- a/crates/gateway/tests/stream_cost_on_error.rs
+++ b/crates/gateway/tests/stream_cost_on_error.rs
@@ -1,0 +1,223 @@
+//! D11 integration test: when an upstream SSE stream ends with an ERROR after
+//! some tokens were billed, the gateway must still finalize cost (write a
+//! `cost_ledger` row + bump `mm:cost`). Before the fix the Err branch set
+//! `done_sent` and bypassed cost finalization entirely, silently dropping the
+//! partial usage the provider already billed for.
+//!
+//! Strategy: a wiremock OpenAI-compatible server emits one valid `data:` chunk
+//! carrying `usage`, followed by a MALFORMED `data:` frame (invalid JSON, no
+//! `[DONE]`). The openai_compat adapter turns the malformed frame into a
+//! `ProviderError::Parse`, which drives `build_forward_stream` into its Err
+//! branch. We POST with a real `X-Run-Id` and assert a cost_ledger row exists.
+//!
+//! Relies on live Redis + Postgres at the dev defaults (migrations applied).
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::serve;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use sqlx::postgres::PgPoolOptions;
+use tempfile::NamedTempFile;
+use tokio::net::TcpListener;
+use tokio::time::timeout;
+use uuid::Uuid;
+use wiremock::matchers::{method, path as wm_path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use gateway::app::build_router;
+use gateway::config::AppConfig;
+use gateway::llm::LlmContext;
+use gateway::state::AppState;
+
+const DEV_TOKEN: &str = "test-token-stream-cost";
+
+/// One valid content+usage chunk, then a malformed frame (no `[DONE]`).
+fn partial_then_error_body() -> String {
+    let valid = r#"{"id":"c1","model":"deepseek-chat","choices":[{"index":0,"delta":{"content":"Hel"}}],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}"#;
+    let mut body = String::new();
+    body.push_str("data: ");
+    body.push_str(valid);
+    body.push_str("\n\n");
+    // Malformed JSON in a data frame -> ProviderError::Parse mid-stream.
+    body.push_str("data: {not valid json at all\n\n");
+    body
+}
+
+async fn write_providers_toml(mock_url: &str) -> NamedTempFile {
+    let file = NamedTempFile::new().expect("tempfile");
+    let toml = format!(
+        r#"
+[[providers]]
+name = "mock"
+kind = "openai_compat"
+base_url = "{mock_url}/v1"
+api_key_env = ""
+models = ["deepseek-chat"]
+price_input_per_1m = 3.0
+price_output_per_1m = 6.0
+
+[router]
+default_model = "deepseek-chat"
+fallback = []
+"#
+    );
+    std::fs::write(file.path(), toml).expect("write providers.toml");
+    file
+}
+
+async fn build_state(providers_path: PathBuf) -> AppState {
+    let redis_url =
+        std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379/0".into());
+    let database_url = std::env::var("TEST_DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://mm:mm@127.0.0.1:5432/mm".into());
+
+    let client = redis::Client::open(redis_url.clone()).expect("redis client");
+    let redis = redis::aio::ConnectionManager::new(client)
+        .await
+        .expect("redis connect");
+
+    let pg = PgPoolOptions::new()
+        .max_connections(4)
+        .acquire_timeout(Duration::from_secs(3))
+        .connect(&database_url)
+        .await
+        .expect("postgres connect");
+
+    let runs_tmp = tempfile::tempdir().expect("runs tempdir");
+    let runs_dir = tokio::fs::canonicalize(runs_tmp.path())
+        .await
+        .expect("canonicalize runs tempdir");
+    std::mem::forget(runs_tmp);
+
+    let cfg = AppConfig {
+        host: "127.0.0.1".into(),
+        port: 0,
+        dev_auth_token: DEV_TOKEN.into(),
+        redis_url,
+        database_url,
+        providers_path: providers_path.clone(),
+        runs_dir: runs_dir.clone(),
+        static_dir: None,
+    };
+    let llm = LlmContext::bootstrap(&providers_path).expect("LlmContext::bootstrap");
+
+    AppState {
+        redis,
+        pg,
+        config: Arc::new(cfg),
+        llm,
+        runs_dir: Arc::new(runs_dir),
+    }
+}
+
+#[tokio::test]
+async fn d11_partial_usage_recorded_when_stream_errors() {
+    // --- Mock upstream: valid usage chunk, then a malformed frame. -------
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(wm_path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw(partial_then_error_body(), "text/event-stream"),
+        )
+        .mount(&mock)
+        .await;
+
+    let providers = write_providers_toml(&mock.uri()).await;
+    let state = build_state(providers.path().to_path_buf()).await;
+
+    // Seed a real run row so the cost_ledger FK is satisfied.
+    let run_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO runs (id, problem_text, competition_type, status) VALUES ($1,$2,$3,'running')",
+    )
+    .bind(run_id)
+    .bind("D11 partial-usage probe")
+    .bind("mcm")
+    .execute(&state.pg)
+    .await
+    .expect("insert run");
+
+    let router = build_router(state.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let _ = serve(listener, router).await;
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {DEV_TOKEN}")).unwrap(),
+    );
+    headers.insert(
+        "x-run-id",
+        HeaderValue::from_str(&run_id.to_string()).unwrap(),
+    );
+    headers.insert("x-agent", HeaderValue::from_static("writer"));
+
+    let client = reqwest::Client::new();
+    let resp = timeout(
+        Duration::from_secs(10),
+        client
+            .post(format!("http://{addr}/llm/chat/completions"))
+            .headers(headers)
+            .json(&serde_json::json!({
+                "model": "deepseek-chat",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": true,
+            }))
+            .send(),
+    )
+    .await
+    .expect("no timeout")
+    .expect("sent");
+
+    assert_eq!(resp.status(), 200, "SSE endpoint returns 200");
+    // Drain the body so the stream (and its cost finalization) runs to completion.
+    let body = timeout(Duration::from_secs(10), resp.bytes())
+        .await
+        .expect("body")
+        .expect("body bytes");
+    let body_text = String::from_utf8_lossy(&body);
+    assert!(
+        body_text.contains("event: error") || body_text.contains("\"error\""),
+        "expected an error event in the SSE body: {body_text}"
+    );
+
+    // Give the (awaited-inline) finalization a beat to commit, then assert a
+    // cost_ledger row exists for this run with the partial usage.
+    let mut found: Option<(i32, i32)> = None;
+    for _ in 0..20 {
+        let row: Option<(i32, i32)> = sqlx::query_as(
+            "SELECT prompt_tokens, completion_tokens FROM cost_ledger WHERE run_id = $1 ORDER BY ts DESC LIMIT 1",
+        )
+        .bind(run_id)
+        .fetch_optional(&state.pg)
+        .await
+        .expect("query cost_ledger");
+        if row.is_some() {
+            found = row;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Cleanup before asserting (cost_ledger cascades on run delete).
+    let _ = sqlx::query("DELETE FROM runs WHERE id = $1")
+        .bind(run_id)
+        .execute(&state.pg)
+        .await;
+    server.abort();
+
+    let (pt, ct) =
+        found.expect("cost_ledger row must exist for partial usage after a stream error");
+    assert_eq!(pt, 11, "prompt_tokens from the partial usage chunk");
+    assert_eq!(ct, 7, "completion_tokens from the partial usage chunk");
+}

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ dev-gateway:
     cargo run -p gateway
 
 dev-worker:
-    cd apps/agent-worker && uv run arq agent_worker.main.WorkerSettings
+    cd apps/agent-worker && uv run python -m agent_worker
 
 dev-web:
     pnpm --filter web dev
@@ -42,12 +42,13 @@ migrate-add name:
 gen: gen-py gen-ts
 
 gen-py:
-    uv run datamodel-codegen \
+    uvx --from datamodel-code-generator datamodel-codegen \
         --input packages/contracts/openapi.yaml \
         --input-file-type openapi \
         --output packages/py-contracts/src/mm_contracts/generated.py \
         --output-model-type pydantic_v2.BaseModel \
-        --target-python-version 3.11
+        --target-python-version 3.11 \
+        --disable-timestamp
 
 gen-ts:
     pnpm exec openapi-typescript packages/contracts/openapi.yaml -o packages/ts-contracts/src/generated.ts

--- a/packages/contracts/events.schema.json
+++ b/packages/contracts/events.schema.json
@@ -13,7 +13,7 @@
     },
     "agent": {
       "type": ["string", "null"],
-      "enum": ["analyzer", "modeler", "coder", "writer", "critic", "searcher", null]
+      "enum": ["analyzer", "modeler", "coder", "writer", "critic", "searcher", "paper_editor", "audit", null]
     },
     "kind": {
       "type": "string",
@@ -23,9 +23,16 @@
         "log",
         "token",
         "cost",
+        "finetune.session.start",
+        "finetune.session.done",
+        "finetune.session.error",
+        "finetune.tool_call",
+        "finetune.tool_result",
+        "finetune.token",
         "agent.output",
         "kernel.stdout",
         "kernel.figure",
+        "kernel.error",
         "error",
         "done"
       ]
@@ -133,6 +140,74 @@
         "notebook_path": { "type": "string" },
         "paper_path": { "type": "string" },
         "cost_rmb": { "type": "number" }
+      }
+    },
+    "kernelError": {
+      "type": "object",
+      "description": "Cell execution failed in the Jupyter or Matlab/Octave kernel. Tagged `agent: coder`.",
+      "required": ["traceback"],
+      "properties": {
+        "traceback": { "type": "string", "description": "Tail of the error traceback / stderr; truncated to keep the payload small." },
+        "exit_code": { "type": "integer", "description": "Process exit code (Matlab/Octave batch runs); omitted for the Python kernel." },
+        "cell_index": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "finetuneSessionStart": {
+      "type": "object",
+      "description": "A PaperEditor fine-tune session began. Tagged `agent: paper_editor`.",
+      "required": ["session_id"],
+      "properties": {
+        "session_id": { "type": "string", "format": "uuid" },
+        "user_message": { "type": "string", "description": "The natural-language edit request (truncated)." }
+      }
+    },
+    "finetuneSessionDone": {
+      "type": "object",
+      "description": "A PaperEditor fine-tune session finished successfully.",
+      "required": ["session_id"],
+      "properties": {
+        "session_id": { "type": "string", "format": "uuid" },
+        "summary": { "type": "string", "description": "Final natural-language summary of the edits applied." }
+      }
+    },
+    "finetuneSessionError": {
+      "type": "object",
+      "description": "A PaperEditor fine-tune session failed.",
+      "required": ["session_id", "message"],
+      "properties": {
+        "session_id": { "type": "string", "format": "uuid" },
+        "message": { "type": "string" },
+        "code": { "type": "string", "description": "Exception class name." }
+      }
+    },
+    "finetuneToolCall": {
+      "type": "object",
+      "description": "PaperEditor invoked a surgical-edit tool.",
+      "required": ["tool"],
+      "properties": {
+        "tool": { "type": "string", "description": "Tool name, e.g. edit_section / regenerate_figure." },
+        "args": { "type": "object", "additionalProperties": true },
+        "reasoning": { "type": "string" }
+      }
+    },
+    "finetuneToolResult": {
+      "type": "object",
+      "description": "Result of a PaperEditor tool call.",
+      "required": ["tool", "ok"],
+      "properties": {
+        "tool": { "type": "string" },
+        "ok": { "type": "boolean" },
+        "summary": { "type": "string" },
+        "error": { "type": ["string", "null"] }
+      }
+    },
+    "finetuneToken": {
+      "type": "object",
+      "description": "Streamed token from a PaperEditor LLM turn. Mirrors `token` but namespaced so the UI can filter fine-tune output.",
+      "required": ["text"],
+      "properties": {
+        "text": { "type": "string" },
+        "model": { "type": "string" }
       }
     }
   }

--- a/packages/contracts/openapi.yaml
+++ b/packages/contracts/openapi.yaml
@@ -27,6 +27,28 @@ paths:
               schema: { $ref: "#/components/schemas/Health" }
 
   /runs:
+    get:
+      summary: List run headers (newest first)
+      description: |
+        Light-weight listing for the Dashboard. Returns run headers sorted
+        newest-first; no events are joined (call `GET /runs/{run_id}` for depth).
+      parameters:
+        - in: query
+          name: limit
+          required: false
+          description: Max rows to return (default 20, capped at 200).
+          schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
+        - in: query
+          name: status
+          required: false
+          description: Filter by run status.
+          schema: { type: string, enum: [queued, running, done, failed, cancelled] }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RunList" }
     post:
       summary: Create a new run
       requestBody:
@@ -44,11 +66,24 @@ paths:
   /runs/{run_id}:
     get:
       summary: Get run state + event history
+      description: |
+        Returns the run header plus a bounded page of audit events ordered by
+        `seq`. Page with `?after_seq=<next_after_seq>` until `has_more` is false.
       parameters:
         - in: path
           name: run_id
           required: true
           schema: { type: string, format: uuid }
+        - in: query
+          name: after_seq
+          required: false
+          description: Return events with `seq` strictly greater than this cursor. Omit to start from the beginning.
+          schema: { type: integer, minimum: 0 }
+        - in: query
+          name: limit
+          required: false
+          description: Max events to return (default 5000, hard cap 5000).
+          schema: { type: integer, minimum: 1, maximum: 5000, default: 5000 }
       responses:
         "200":
           description: OK
@@ -56,6 +91,146 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/Run" }
         "404": { description: Not found }
+
+  /runs/{run_id}/finetune:
+    post:
+      summary: Enqueue a paper fine-tune (PaperEditor) request
+      description: |
+        The worker loads the run's paper.md + notebook.ipynb and runs
+        PaperEditorAgent against the natural-language `message`. Events stream
+        back on the same `mm:events:<run_id>` channel tagged `kind: finetune.*`.
+        `session_id` is taken from the request (to resume a thread) or minted.
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/FinetuneRequest" }
+      responses:
+        "202":
+          description: Accepted (queued)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/FinetuneAccepted" }
+        "400": { description: Empty message }
+        "401": { description: Unauthorized }
+        "404": { description: Run not found }
+
+  /runs/{run_id}/cancel:
+    post:
+      summary: Signal the worker to halt the run
+      description: |
+        Idempotent: re-posting while a cancel is already pending is a no-op.
+        The worker polls `mm:cancel:<run_id>` between stages and terminates with
+        `done.status = cancelled`, keeping partial artifacts intact.
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        "202":
+          description: Accepted (cancel signalled)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CancelAccepted" }
+        "401": { description: Unauthorized }
+        "404": { description: Run not found }
+
+  /runs/{run_id}/paper:
+    get:
+      summary: Serve the Writer's paper.md for a run
+      description: |
+        Returns `<RUNS_DIR>/<run_id>/paper.md`. `?inline=1` renders in-browser
+        (`Content-Disposition: inline`) for the on-page preview; omitted forces
+        a download.
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema: { type: string, format: uuid }
+        - in: query
+          name: inline
+          required: false
+          description: When true, serve inline for preview instead of as an attachment.
+          schema: { type: boolean, default: false }
+      responses:
+        "200":
+          description: OK
+          content:
+            text/markdown:
+              schema: { type: string }
+        "401": { description: Unauthorized }
+        "403": { description: Forbidden (path traversal) }
+        "404": { description: Not found }
+
+  /runs/{run_id}/export/{format}:
+    get:
+      summary: Export the paper as md / tex / pdf / docx
+      description: |
+        Renders the run's `paper.meta.json` (and `paper.md`) through the
+        competition LaTeX template and returns the requested format as an
+        attachment. `md` is served directly without templating.
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema: { type: string, format: uuid }
+        - in: path
+          name: format
+          required: true
+          description: Output format.
+          schema: { type: string, enum: [md, tex, pdf, docx] }
+        - in: query
+          name: template
+          required: false
+          description: Override the LaTeX template; defaults to the run's competition type.
+          schema: { type: string, enum: [mcm, icm, cumcm, huashu] }
+      responses:
+        "200":
+          description: OK
+          content:
+            text/markdown: { schema: { type: string } }
+            application/x-tex: { schema: { type: string } }
+            application/pdf: { schema: { type: string, format: binary } }
+            application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+              schema: { type: string, format: binary }
+        "401": { description: Unauthorized }
+        "404": { description: Run or paper artifacts not found }
+        "422": { description: "Unsupported format/template, or invalid paper.meta.json" }
+
+  /runs/{run_id}/submission:
+    get:
+      summary: Build a competition submission ZIP bundle
+      description: |
+        Assembles the per-competition submission archive from the run's
+        `paper.meta.json`. MCM/ICM produce a single PDF + README + archival
+        source; CUMCM/Huashu produce the anonymous + printed PDFs plus a nested
+        `支撑材料.zip` (notebook + code + figures) per competition spec.
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema: { type: string, format: uuid }
+        - in: query
+          name: template
+          required: false
+          description: Override the bundle layout; defaults to the run's competition type.
+          schema: { type: string, enum: [mcm, icm, cumcm, huashu] }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/zip:
+              schema: { type: string, format: binary }
+        "401": { description: Unauthorized }
+        "404": { description: Run or paper.meta.json not found }
+        "413": { description: Bundle exceeds the size cap }
+        "422": { description: Unsupported template or invalid paper.meta.json }
 
   /runs/{run_id}/figures/{path}:
     get:
@@ -138,6 +313,62 @@ paths:
             text/event-stream:
               schema: { type: string }
 
+  /stats/summary:
+    get:
+      summary: Headline run counts + latency/cost percentiles
+      parameters:
+        - in: query
+          name: window
+          required: false
+          description: Time window for the aggregation.
+          schema: { type: string, enum: [24h, 7d, all], default: 24h }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/StatsSummary" }
+
+  /stats/providers:
+    get:
+      summary: Cost share by model
+      parameters:
+        - in: query
+          name: window
+          required: false
+          description: Time window for the aggregation.
+          schema: { type: string, enum: [24h, 7d, all], default: 24h }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/StatsProviders" }
+
+  /providers:
+    get:
+      summary: List the registered LLM providers
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ProviderList" }
+
+  /search/capabilities:
+    get:
+      summary: Report which search backends the worker is configured to drive
+      description: |
+        Inspects deploy-time environment only (never spawns open-websearch or
+        pings Tavily). `TAVILY_API_KEY` is reduced to a boolean and never
+        echoed. The UI calls this once at boot to grey out unavailable toggles.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SearchCapabilities" }
+
 components:
   securitySchemes:
     DevToken:
@@ -182,6 +413,50 @@ components:
             `off` suppresses emission entirely.
             Default `high`: this project targets MCM Outstanding / CUMCM 一等奖
             quality, so we trade extra latency + cost for better reasoning.
+        long_context:
+          type: boolean
+          default: false
+          description: |
+            Opt-in to a 1M-token max_tokens ceiling for models that advertise
+            long-context. When false, the worker caps at 20k (safe for all
+            providers). Enable only for 1M-capable variants (Claude 3.5 Sonnet
+            1M beta, Gemini 2.0, gpt-5-1m).
+        search_config:
+          allOf:
+            - $ref: "#/components/schemas/SearchConfig"
+          nullable: true
+          description: |
+            Searcher routing override. When null (default), the worker uses its
+            env-default config. Decoupled from `reasoning_effort` so a user can
+            change source preference without touching model settings.
+
+    SearchConfig:
+      type: object
+      description: |
+        User-selectable retrieval routing for the Searcher agent. `primary`
+        picks the first web source; `fallback_threshold` decides when the other
+        source kicks in (unique-URL count below the threshold = fall back).
+        `engines` only applies when open-webSearch is actually invoked.
+      properties:
+        primary:
+          type: string
+          enum: [tavily, open_websearch, none]
+          default: tavily
+        engines:
+          type: array
+          items:
+            type: string
+            enum: [bing, baidu, duckduckgo, csdn, juejin, brave, exa, startpage]
+          default: [baidu, csdn, juejin, duckduckgo]
+        tavily_depth:
+          type: string
+          enum: [basic, advanced]
+          default: basic
+        fallback_threshold:
+          type: integer
+          minimum: 0
+          maximum: 20
+          default: 3
 
     Attachment:
       type: object
@@ -208,11 +483,128 @@ components:
         updated_at: { type: string, format: date-time }
         problem_text: { type: string }
         cost_rmb: { type: number }
-        notebook_path: { type: string }
-        paper_path: { type: string }
+        notebook_path: { type: string, nullable: true }
+        paper_path: { type: string, nullable: true }
         events:
           type: array
           items: { $ref: "#/components/schemas/AgentEvent" }
+        has_more:
+          type: boolean
+          description: True when more events exist past this page; re-request with `?after_seq=<next_after_seq>`.
+        next_after_seq:
+          type: integer
+          nullable: true
+          description: Cursor for the next page; the `seq` of the last event returned (null when the page is empty).
+
+    RunSummary:
+      type: object
+      required: [run_id, status, created_at]
+      properties:
+        run_id: { type: string, format: uuid }
+        status: { type: string, enum: [queued, running, done, failed, cancelled] }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+        problem_text: { type: string }
+        competition_type: { type: string }
+        cost_rmb: { type: number }
+        notebook_path: { type: string, nullable: true }
+        paper_path: { type: string, nullable: true }
+
+    RunList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/RunSummary" }
+
+    FinetuneRequest:
+      type: object
+      required: [message]
+      properties:
+        message: { type: string, minLength: 1 }
+        session_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Resume an existing fine-tune thread; omit to mint a new session.
+
+    FinetuneAccepted:
+      type: object
+      required: [run_id, session_id, status]
+      properties:
+        run_id: { type: string, format: uuid }
+        session_id: { type: string, format: uuid }
+        status: { type: string, enum: [queued] }
+
+    CancelAccepted:
+      type: object
+      required: [run_id, status, already_signalled]
+      properties:
+        run_id: { type: string, format: uuid }
+        status: { type: string, enum: [cancel_signalled] }
+        already_signalled:
+          type: boolean
+          description: True when an earlier POST already set the cancel flag (idempotent).
+
+    StatsSummary:
+      type: object
+      required: [window, total_runs, success_runs, failed_runs, success_rate]
+      properties:
+        window: { type: string }
+        total_runs: { type: integer }
+        success_runs: { type: integer }
+        failed_runs: { type: integer }
+        success_rate: { type: number }
+        median_cost_rmb: { type: number, nullable: true }
+        p95_latency_ms: { type: number, nullable: true }
+
+    StatsProviders:
+      type: object
+      required: [window, total_cost_rmb, items]
+      properties:
+        window: { type: string }
+        total_cost_rmb: { type: number }
+        items:
+          type: array
+          items:
+            type: object
+            required: [model, cost_rmb, share_pct]
+            properties:
+              model: { type: string }
+              cost_rmb: { type: number }
+              share_pct: { type: number }
+
+    ProviderList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/ProviderInfo" }
+
+    ProviderInfo:
+      type: object
+      required: [name, kind, models, price_input_per_1m, price_output_per_1m, has_key]
+      properties:
+        name: { type: string }
+        kind: { type: string }
+        models:
+          type: array
+          items: { type: string }
+        price_input_per_1m: { type: number }
+        price_output_per_1m: { type: number }
+        has_key: { type: boolean }
+
+    SearchCapabilities:
+      type: object
+      required: [tavily_available, open_websearch_available, available_engines]
+      properties:
+        tavily_available: { type: boolean }
+        open_websearch_available: { type: boolean }
+        available_engines:
+          type: array
+          items: { type: string }
 
     AgentEvent:
       type: object
@@ -222,10 +614,27 @@ components:
         agent:
           type: string
           nullable: true
-          enum: [analyzer, modeler, coder, writer, critic, searcher, null]
+          enum: [analyzer, modeler, coder, writer, critic, searcher, paper_editor, audit, null]
         kind:
           type: string
-          enum: [stage.start, stage.done, log, token, cost, agent.output, kernel.stdout, kernel.figure, error, done]
+          enum:
+            - stage.start
+            - stage.done
+            - log
+            - token
+            - cost
+            - finetune.session.start
+            - finetune.session.done
+            - finetune.session.error
+            - finetune.tool_call
+            - finetune.tool_result
+            - finetune.token
+            - agent.output
+            - kernel.stdout
+            - kernel.figure
+            - kernel.error
+            - error
+            - done
         seq: { type: integer, minimum: 0 }
         ts: { type: string, format: date-time }
         payload: { type: object, additionalProperties: true }

--- a/packages/ts-contracts/src/generated.ts
+++ b/packages/ts-contracts/src/generated.ts
@@ -47,7 +47,36 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * List run headers (newest first)
+         * @description Light-weight listing for the Dashboard. Returns run headers sorted
+         *     newest-first; no events are joined (call `GET /runs/{run_id}` for depth).
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Max rows to return (default 20, capped at 200). */
+                    limit?: number;
+                    /** @description Filter by run status. */
+                    status?: "queued" | "running" | "done" | "failed" | "cancelled";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["RunList"];
+                    };
+                };
+            };
+        };
         put?: never;
         /** Create a new run */
         post: {
@@ -87,10 +116,19 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get run state + event history */
+        /**
+         * Get run state + event history
+         * @description Returns the run header plus a bounded page of audit events ordered by
+         *     `seq`. Page with `?after_seq=<next_after_seq>` until `has_more` is false.
+         */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description Return events with `seq` strictly greater than this cursor. Omit to start from the beginning. */
+                    after_seq?: number;
+                    /** @description Max events to return (default 5000, hard cap 5000). */
+                    limit?: number;
+                };
                 header?: never;
                 path: {
                     run_id: string;
@@ -110,6 +148,346 @@ export interface paths {
                 };
                 /** @description Not found */
                 404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/runs/{run_id}/finetune": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enqueue a paper fine-tune (PaperEditor) request
+         * @description The worker loads the run's paper.md + notebook.ipynb and runs
+         *     PaperEditorAgent against the natural-language `message`. Events stream
+         *     back on the same `mm:events:<run_id>` channel tagged `kind: finetune.*`.
+         *     `session_id` is taken from the request (to resume a thread) or minted.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    run_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["FinetuneRequest"];
+                };
+            };
+            responses: {
+                /** @description Accepted (queued) */
+                202: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FinetuneAccepted"];
+                    };
+                };
+                /** @description Empty message */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Run not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/runs/{run_id}/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Signal the worker to halt the run
+         * @description Idempotent: re-posting while a cancel is already pending is a no-op.
+         *     The worker polls `mm:cancel:<run_id>` between stages and terminates with
+         *     `done.status = cancelled`, keeping partial artifacts intact.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    run_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Accepted (cancel signalled) */
+                202: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["CancelAccepted"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Run not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/runs/{run_id}/paper": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Serve the Writer's paper.md for a run
+         * @description Returns `<RUNS_DIR>/<run_id>/paper.md`. `?inline=1` renders in-browser
+         *     (`Content-Disposition: inline`) for the on-page preview; omitted forces
+         *     a download.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description When true, serve inline for preview instead of as an attachment. */
+                    inline?: boolean;
+                };
+                header?: never;
+                path: {
+                    run_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/markdown": string;
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden (path traversal) */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/runs/{run_id}/export/{format}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export the paper as md / tex / pdf / docx
+         * @description Renders the run's `paper.meta.json` (and `paper.md`) through the
+         *     competition LaTeX template and returns the requested format as an
+         *     attachment. `md` is served directly without templating.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Override the LaTeX template; defaults to the run's competition type. */
+                    template?: "mcm" | "icm" | "cumcm" | "huashu";
+                };
+                header?: never;
+                path: {
+                    run_id: string;
+                    /** @description Output format. */
+                    format: "md" | "tex" | "pdf" | "docx";
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/markdown": string;
+                        "application/x-tex": string;
+                        "application/pdf": string;
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document": string;
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Run or paper artifacts not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unsupported format/template, or invalid paper.meta.json */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/runs/{run_id}/submission": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Build a competition submission ZIP bundle
+         * @description Assembles the per-competition submission archive from the run's
+         *     `paper.meta.json`. MCM/ICM produce a single PDF + README + archival
+         *     source; CUMCM/Huashu produce the anonymous + printed PDFs plus a nested
+         *     `支撑材料.zip` (notebook + code + figures) per competition spec.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Override the bundle layout; defaults to the run's competition type. */
+                    template?: "mcm" | "icm" | "cumcm" | "huashu";
+                };
+                header?: never;
+                path: {
+                    run_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/zip": string;
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Run or paper.meta.json not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Bundle exceeds the size cap */
+                413: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unsupported template or invalid paper.meta.json */
+                422: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -313,6 +691,161 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/stats/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Headline run counts + latency/cost percentiles */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Time window for the aggregation. */
+                    window?: "24h" | "7d" | "all";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["StatsSummary"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/stats/providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Cost share by model */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Time window for the aggregation. */
+                    window?: "24h" | "7d" | "all";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["StatsProviders"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the registered LLM providers */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ProviderList"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/search/capabilities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Report which search backends the worker is configured to drive
+         * @description Inspects deploy-time environment only (never spawns open-websearch or
+         *     pings Tavily). `TAVILY_API_KEY` is reduced to a boolean and never
+         *     echoed. The UI calls this once at boot to grey out unavailable toggles.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SearchCapabilities"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -340,10 +873,55 @@ export interface components {
              *     + `reasoning.effort`; Anthropic emits
              *     `thinking.budget_tokens` (low=1024, medium=4096, high=16384).
              *     `off` suppresses emission entirely.
-             * @default medium
+             *     Default `high`: this project targets MCM Outstanding / CUMCM 一等奖
+             *     quality, so we trade extra latency + cost for better reasoning.
+             * @default high
              * @enum {string}
              */
             reasoning_effort: "off" | "low" | "medium" | "high";
+            /**
+             * @description Opt-in to a 1M-token max_tokens ceiling for models that advertise
+             *     long-context. When false, the worker caps at 20k (safe for all
+             *     providers). Enable only for 1M-capable variants (Claude 3.5 Sonnet
+             *     1M beta, Gemini 2.0, gpt-5-1m).
+             * @default false
+             */
+            long_context: boolean;
+            /**
+             * @description Searcher routing override. When null (default), the worker uses its
+             *     env-default config. Decoupled from `reasoning_effort` so a user can
+             *     change source preference without touching model settings.
+             */
+            search_config?: components["schemas"]["SearchConfig"] | null;
+        };
+        /**
+         * @description User-selectable retrieval routing for the Searcher agent. `primary`
+         *     picks the first web source; `fallback_threshold` decides when the other
+         *     source kicks in (unique-URL count below the threshold = fall back).
+         *     `engines` only applies when open-webSearch is actually invoked.
+         */
+        SearchConfig: {
+            /**
+             * @default tavily
+             * @enum {string}
+             */
+            primary: "tavily" | "open_websearch" | "none";
+            /**
+             * @default [
+             *       "baidu",
+             *       "csdn",
+             *       "juejin",
+             *       "duckduckgo"
+             *     ]
+             */
+            engines: ("bing" | "baidu" | "duckduckgo" | "csdn" | "juejin" | "brave" | "exa" | "startpage")[];
+            /**
+             * @default basic
+             * @enum {string}
+             */
+            tavily_depth: "basic" | "advanced";
+            /** @default 3 */
+            fallback_threshold: number;
         };
         Attachment: {
             name: string;
@@ -368,17 +946,97 @@ export interface components {
             updated_at?: string;
             problem_text?: string;
             cost_rmb?: number;
-            notebook_path?: string;
-            paper_path?: string;
+            notebook_path?: string | null;
+            paper_path?: string | null;
             events?: components["schemas"]["AgentEvent"][];
+            /** @description True when more events exist past this page; re-request with `?after_seq=<next_after_seq>`. */
+            has_more?: boolean;
+            /** @description Cursor for the next page; the `seq` of the last event returned (null when the page is empty). */
+            next_after_seq?: number | null;
+        };
+        RunSummary: {
+            /** Format: uuid */
+            run_id: string;
+            /** @enum {string} */
+            status: "queued" | "running" | "done" | "failed" | "cancelled";
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at?: string;
+            problem_text?: string;
+            competition_type?: string;
+            cost_rmb?: number;
+            notebook_path?: string | null;
+            paper_path?: string | null;
+        };
+        RunList: {
+            items: components["schemas"]["RunSummary"][];
+        };
+        FinetuneRequest: {
+            message: string;
+            /**
+             * Format: uuid
+             * @description Resume an existing fine-tune thread; omit to mint a new session.
+             */
+            session_id?: string | null;
+        };
+        FinetuneAccepted: {
+            /** Format: uuid */
+            run_id: string;
+            /** Format: uuid */
+            session_id: string;
+            /** @enum {string} */
+            status: "queued";
+        };
+        CancelAccepted: {
+            /** Format: uuid */
+            run_id: string;
+            /** @enum {string} */
+            status: "cancel_signalled";
+            /** @description True when an earlier POST already set the cancel flag (idempotent). */
+            already_signalled: boolean;
+        };
+        StatsSummary: {
+            window: string;
+            total_runs: number;
+            success_runs: number;
+            failed_runs: number;
+            success_rate: number;
+            median_cost_rmb?: number | null;
+            p95_latency_ms?: number | null;
+        };
+        StatsProviders: {
+            window: string;
+            total_cost_rmb: number;
+            items: {
+                model: string;
+                cost_rmb: number;
+                share_pct: number;
+            }[];
+        };
+        ProviderList: {
+            items: components["schemas"]["ProviderInfo"][];
+        };
+        ProviderInfo: {
+            name: string;
+            kind: string;
+            models: string[];
+            price_input_per_1m: number;
+            price_output_per_1m: number;
+            has_key: boolean;
+        };
+        SearchCapabilities: {
+            tavily_available: boolean;
+            open_websearch_available: boolean;
+            available_engines: string[];
         };
         AgentEvent: {
             /** Format: uuid */
             run_id: string;
             /** @enum {string|null} */
-            agent?: "analyzer" | "modeler" | "coder" | "writer" | "critic" | "searcher" | null;
+            agent?: "analyzer" | "modeler" | "coder" | "writer" | "critic" | "searcher" | "paper_editor" | "audit" | null;
             /** @enum {string} */
-            kind: "stage.start" | "stage.done" | "log" | "token" | "cost" | "agent.output" | "kernel.stdout" | "kernel.figure" | "error" | "done";
+            kind: "stage.start" | "stage.done" | "log" | "token" | "cost" | "finetune.session.start" | "finetune.session.done" | "finetune.session.error" | "finetune.tool_call" | "finetune.tool_result" | "finetune.token" | "agent.output" | "kernel.stdout" | "kernel.figure" | "kernel.error" | "error" | "done";
             seq: number;
             /** Format: date-time */
             ts: string;
@@ -412,6 +1070,18 @@ export interface components {
             role: "system" | "user" | "assistant" | "tool";
             content: string;
             name?: string;
+            /**
+             * @description Mark this message as an Anthropic prompt-cache break point. When
+             *     true, the gateway emits `cache_control: { "type": "ephemeral" }`
+             *     on the message (Anthropic native: as a content-block attribute;
+             *     OpenAI-compat: as an extra message-level key for Claude-backed
+             *     proxies). The cached prefix runs from the start of the request
+             *     through this message; Anthropic supports up to 4 breakpoints per
+             *     request, but v1 of this wiring uses exactly one. Silently
+             *     ignored by providers that don't support prompt caching.
+             * @default false
+             */
+            cache_breakpoint: boolean;
         };
         ChatCompletionResponse: {
             id: string;

--- a/packages/ts-contracts/src/index.ts
+++ b/packages/ts-contracts/src/index.ts
@@ -8,9 +8,16 @@ export type EventKind =
   | "log"
   | "token"
   | "cost"
+  | "finetune.session.start"
+  | "finetune.session.done"
+  | "finetune.session.error"
+  | "finetune.tool_call"
+  | "finetune.tool_result"
+  | "finetune.token"
   | "agent.output"
   | "kernel.stdout"
   | "kernel.figure"
+  | "kernel.error"
   | "error"
   | "done";
 


### PR DESCRIPTION
Lands the fixes from a full-project audit of the submission-bundle work (the feature itself is already on `main` via #37; this PR is the audit hardening on top).

## What's in here (7 commits, by stack)
- **gateway**: anthropic thinking-temperature 400; WS XREAD infinite-loop + trailing-batch drop + 404 on unknown run_id; orphaned `queued` row rollback; partial stream-cost on error; submission zip symlink/zip-slip guard; events pagination; `/health` 503-on-degraded; **`{% raw %}` template bug that broke `\tightlist` → every real paper failed to compile to PDF**; anthropic `has_credentials` parity (fixes the pre-existing `anthropic_stream` 500); `mm_auth` cookie auth for GET asset routes (D8).
- **worker**: kernel/matlab teardown (process leak每run); cumcm few-shot family; figure-id path traversal; searcher retry; pdf streaming+SSRF guard; openalex retry; evidence/audit false-positive gates; run_locks pruning; off-loop event writes.
- **web**: markdown XSS sanitize; token gated to DEV + `mm_auth` cookie for prod `<img>`/`<a>` (D8); store/ws reconnect races.
- **contracts/infra**: openapi/events schema (agents+kinds+ProblemInput) and route docs; `arq`→`python -m agent_worker` dev entrypoint; codegen.

## Verification
- `cargo test --workspace --no-fail-fast` fully green (75 lib + all integration vs live PG/Redis); `clippy -D warnings`, `fmt`, `ruff`, `vue-tsc` clean; `pytest` 545 passed.
- **Local end-to-end real run** on `gpt-5.5` (reasoning=high): full CUMCM pipeline → `done`, 5.23 RMB, 404-line paper + 4 figures; `/export/pdf` and `/submission` produce valid PDFs/bundle; cookie-auth figure load verified (200 with cookie, 401 without; POST-with-cookie blocked).