### PR TITLE
[codex] Add figure generation QA gates

### DIFF
--- a/.claude/agents/mathodology-coder.md
+++ b/.claude/agents/mathodology-coder.md
@@ -14,6 +14,9 @@ Produce:
 - deterministic seeds and environment notes
 - raw results, intermediate tables, final tables, and figures
 - sensitivity, robustness, and ablation outputs
+- result-density map showing which tables or figures support model structure, assumptions or parameters, baseline comparisons, sensitivity, robustness or uncertainty, tradeoffs, and final recommendations
+- figure/table inventory with source data, generation command, evidence role, paper location, and supported claim
+- figure contact sheet or equivalent visual QA artifact
 - reproduction instructions for all reported numbers
 - run log with commands, parameters, timestamps, and output paths
 - source data or data provenance notes for every generated artifact
@@ -23,6 +26,8 @@ Agent handoff must include:
 
 - commands run and expected rerun commands
 - generated files and the paper table or figure they support
+- coverage gaps where a major result still lacks a useful figure or table
+- visual QA evidence: image dimensions, figure count, table count, contact sheet path, and known layout risks
 - seed, environment, dependency, and hardware notes
 - checks performed on outputs
 - known numerical or data-quality risks
@@ -32,7 +37,9 @@ Critic gate for this role:
 - every reported number can be regenerated or manually traced
 - figures and tables have source data
 - baseline, ablation, sensitivity, and robustness checks cover key assumptions
+- figure/table outputs are substantive enough for a paper-first top-tier submission and are not just isolated or decorative plots
+- no generated figure has obvious overlapping labels, clipped axes, duplicate title/caption text, unreadable labels, or excessive whitespace
 - failures and discarded runs are disclosed
 - code does not require hidden local state
 
-Prize-level standard: every table and figure in the final paper must be reproducible from the delivered code or clearly documented manual calculation.
+Prize-level standard: every table and figure in the final paper must be reproducible from the delivered code or clearly documented manual calculation, and the generated artifact set must make the main comparisons, sensitivities, robustness checks, and recommendations inspectable.

--- a/.claude/agents/mathodology-critic.md
+++ b/.claude/agents/mathodology-critic.md
@@ -17,15 +17,19 @@ Check:
 - reproducibility gaps
 - sensitivity and robustness insufficiency
 - paper structure, clarity, and scoring alignment
+- figure/table sufficiency: model structure, main comparisons, sensitivity, robustness or uncertainty, tradeoffs, and recommendations must be visually or tabularly inspectable
+- figure/table rendering quality: no overlapping text, clipped labels, unreadable legends, duplicate caption prefixes, orphaned figures, incoherent table wrapping, or blank/pixelated outputs
 - final package completeness
 - contest compliance: page, size, anonymity, AI-use, citation, and submission rules
 - generic-method stacking or polished but content-light writing
+- sparse, decorative, duplicated, or uninterpreted figures and tables
+- generated chart bugs that survive into the rendered PDF
 - unsupported final claims, recommendations, or policy implications
 
 Severity:
 
 - `blocker`: violates contest rules, breaks prompt coverage, invalidates the model, prevents reproduction, or makes submission unsafe.
-- `high`: likely to lower award level unless fixed.
+- `high`: likely to lower award level unless fixed, including sparse result presentation or visible figure/table rendering defects in a paper-first contest.
 - `medium`: should be fixed or explicitly accepted with rationale.
 - `low`: polish or minor clarity issue that does not affect correctness, scoring, reproducibility, or submission validity.
 
@@ -49,5 +53,7 @@ Meta-review:
 - Findings must cite the artifact, requirement ID, equation, figure, table, command, source, or package file they refer to.
 - Do not block on taste alone; block on correctness, evidence, reproducibility, compliance, or scoring risk.
 - If criticizing another agent, specify the minimum fix needed to pass.
+- For paper-first contests, treat "too few useful figures/tables to evaluate the work" as scoring risk, not style preference.
+- Require evidence from the rendered PDF or contact sheet before accepting chart quality; source Markdown, LaTeX, or script output alone is insufficient.
 
 Prize-level standard: block the workflow if a serious reviewer could reject the solution for a fixable reason.

--- a/.claude/agents/mathodology-paper-editor.md
+++ b/.claude/agents/mathodology-paper-editor.md
@@ -15,10 +15,12 @@ Produce:
 - concise notation and assumption presentation
 - methods narrative that explains why the model is appropriate
 - results narrative tied to tables and figures
+- figure/table placement plan that preserves page budget while covering model structure, primary results, sensitivity, robustness, tradeoffs, and recommendations
 - limitations and improvement section
 - final consistency pass for terminology, numbering, captions, and citations
 - requirement-to-section map
 - claim-to-support map for important conclusions
+- rendered-PDF figure/table QA pass, including caption duplication, float placement, clipping, label readability, and table wrapping
 - AI-use disclosure text when required by the contest
 
 Agent handoff must include:
@@ -26,6 +28,8 @@ Agent handoff must include:
 - draft file paths and section status
 - unresolved writing or layout risks
 - figures, tables, equations, and citations used
+- figure/table coverage gaps and any visuals that should be cut as filler
+- rendered PDF pages or contact sheet inspected, with any layout defects listed
 - claims that still need modeler, coder, or evidence verification
 - summary-sheet readiness assessment
 
@@ -34,7 +38,9 @@ Critic gate for this role:
 - summary states the method and most important conclusions, not just the problem
 - paper reads as a coherent argument rather than an experiment log
 - every figure, table, and equation is introduced and interpreted
+- the final paper does not feel sparse: major comparisons, uncertainty, sensitivity, and decision recommendations are inspectable through figures or tables
+- rendered PDF has no obvious figure/table overlap, clipping, illegible labels, duplicate caption prefixes, or orphaned visuals far from their explanatory text
 - notation, references, captions, and requirement IDs are consistent
 - page, format, anonymity, and AI-use risks are visible before packaging
 
-Prize-level standard: the paper should read like a coherent argument, not a transcript of experiments.
+Prize-level standard: the paper should read like a coherent argument, not a transcript of experiments, and its figure/table system should carry enough evidence for an O-prize or national-first-prize reviewer to evaluate the solution quickly.

--- a/.claude/agents/mathodology-submission-packager.md
+++ b/.claude/agents/mathodology-submission-packager.md
@@ -14,6 +14,7 @@ Produce:
 - source or editable paper file if required
 - code and data archive
 - figure and table outputs
+- figure/table source data or documented calculation paths
 - reproduction README
 - AI-use statement when required
 - checklist mapping prompt requirements to package files
@@ -26,8 +27,10 @@ Agent handoff must include:
 
 - final package tree
 - requirement-to-file checklist
+- final figure/table inventory with source file, source data, and paper location
 - reproducibility README path
 - compliance checks run and results
+- rendered-PDF QA evidence: page count, figure/page contact sheet or screenshots, caption-duplication check, and figure/table count
 - omitted files and reason for omission
 
 Critic gate for this role:
@@ -35,6 +38,8 @@ Critic gate for this role:
 - package matches official contest rules or user-specified rules
 - no secrets, caches, scratch files, identifying information, or unrelated artifacts are included
 - paper, source, code, data notes, figures, tables, README, and AI-use statement are present when required
+- figure/table inventory shows that every final-paper visual is reproducible and that no required evidence role is missing
+- rendered final PDF has no obvious chart rendering bugs, including overlap, clipping, unreadable labels, duplicated captions, or incoherent table wrapping
 - file names, page count, size, and format are submission-safe
 - an outside user can submit and reproduce the package
 

--- a/.claude/skills/mathodology-agent-pipeline/SKILL.md
+++ b/.claude/skills/mathodology-agent-pipeline/SKILL.md
@@ -57,9 +57,9 @@ For all other ambiguity, record the assumption in the phase log and proceed. If 
 - Phase 1: evidence researcher builds source ledger, data dictionary, proxy logic, benchmark inventory, citation plan, and evidence gaps; critic checks traceability and proxy defensibility.
 - Phase 2: at least two model agents propose alternatives; lead compares at least three routes and selects one with rejection reasons; critic checks route fit, novelty, time feasibility, and absence of generic method stacking.
 - Phase 3: modeler writes notation, assumptions, units, objectives, constraints, algorithms, pseudocode, validation metrics, baseline, ablation, sensitivity, and robustness plan; critic checks implementability and mathematical coherence.
-- Phase 4: coder produces reproducible computation, environment notes, raw outputs, tables, figures, baseline, ablations, sensitivity, robustness outputs, and run logs; critic checks number traceability and no cherry-picking.
-- Phase 5: modeler and paper editor translate results into prompt-level answers, captions, recommendations, limitations, uncertainty notes, and claim-source links; critic checks answer coverage and support.
-- Phase 6: paper editor builds summary, coherent paper narrative, references, appendix, and AI-use statement when required; critic checks summary quality, paper coherence, notation, citations, and page/format risk.
+- Phase 4: coder produces reproducible computation, environment notes, raw outputs, tables, figures, baseline, ablations, sensitivity, robustness outputs, and run logs; the figure/table set must cover model structure, primary results, sensitivity, robustness, decision tradeoffs, and final recommendations; critic checks number traceability, source data, density, and no cherry-picking.
+- Phase 5: modeler and paper editor translate results into prompt-level answers, captions, recommendations, limitations, uncertainty notes, claim-source links, and a figure/table coverage map; critic checks answer coverage, support, and whether visual and tabular evidence is sufficient for a top-tier paper.
+- Phase 6: paper editor builds summary, coherent paper narrative, references, appendix, AI-use statement when required, and final figure/table placement; critic checks summary quality, paper coherence, notation, citations, page/format risk, and whether results feel substantive rather than sparse.
 - Phase 7: critic audits prompt coverage, math, evidence, reproducibility, writing, formatting, originality, and final scoring risk; lead reruns specialists until no blocker or high issue remains.
 - Phase 8: packager assembles final paper, source, code, data notes, figures, tables, README, AI-use statement, and checklist; critic checks compliance, anonymity, size/page limits, secrets, scratch artifacts, and submit-readiness.
 
@@ -90,10 +90,32 @@ Block progression if any of these are missing:
 - selected model without rejected alternatives
 - reported number without reproducibility path
 - figure or table without interpretation
+- sparse result presentation: for a paper-first contest, the final draft must contain a purposeful figure/table system, not only a few isolated visuals
+- missing visual/tabular coverage for model architecture, primary comparison, sensitivity, robustness or uncertainty, scenario or policy tradeoff, and final decision summary, unless the contest format explicitly prevents it
+- figure/table count inflated with decorative, duplicate, or unsupported artifacts
+- figure-generation defects such as overlapping labels, clipped axes, unreadable text, duplicate caption prefixes, orphaned figures, or tables that wrap incoherently in the rendered PDF
 - paper claim without support
 - final package without README and requirement-to-file checklist
 - phase artifact without independent critic review
 - blocker or high-severity critic issue without a fix
+
+## Figure And Table Density Standard
+
+For MCM/ICM O-prize, CUMCM national-first-prize, and comparable paper-first contests, treat visual and tabular density as a scoring gate, not cosmetic polish.
+
+Minimum expected coverage before Phase 6 passes:
+
+- one model-architecture diagram or algorithm flowchart
+- one compact data, assumption, or parameter table
+- one baseline or route-comparison figure/table
+- one sensitivity figure or tornado/heatmap-style diagnostic
+- one robustness, uncertainty, or stress-test figure/table
+- one scenario, policy, cost, environmental, or implementation tradeoff figure/table when the problem is decision-facing
+- one final decision dashboard or prompt-by-prompt answer table
+
+These are role requirements, not a fixed count. A short sprint may merge roles into fewer artifacts; a full MCM/ICM or national contest paper should usually exceed this minimum while staying inside the page limit. Do not add filler figures. Every visual must carry a result that a judge can use to understand, verify, or compare the solution.
+
+For the full generation and verification contract, use `docs/WORKFLOWS.md` / `docs/WORKFLOWS_zh.md` section "Figure And Table Generation Specification". The key operational rule is: generate from source data, render the final PDF, create a figure/page contact sheet, visually inspect it, and block any phase with overlap, clipping, illegible text, duplicated captions, or unsupported filler visuals.
 
 ## How To Maintain This Skill
 

--- a/.claude/skills/mathodology-agent-pipeline/agents/openai.yaml
+++ b/.claude/skills/mathodology-agent-pipeline/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Mathodology Agent Pipeline"
   short_description: "Coordinate modeling agents and phases"
-  default_prompt: "Use $mathodology-agent-pipeline. In Codex, classify the contest type, apply the matching workflow adapter, and dispatch independent agents for problem analysis, evidence, model design, computation, critique, writing, and packaging. Require specialist handoffs and independent critic gates for every phase. Ask the user only for contest-critical blockers; otherwise log assumptions and continue from the current phase."
+  default_prompt: "Use $mathodology-agent-pipeline. In Codex, classify the contest type, apply the matching workflow adapter, and dispatch independent agents for problem analysis, evidence, model design, computation, critique, writing, and packaging. Require specialist handoffs, result-density maps, figure/table sufficiency gates, rendered-PDF figure QA, and independent critic gates for every phase. Ask the user only for contest-critical blockers; otherwise log assumptions and continue from the current phase."

--- a/.claude/skills/mathodology-whole-project/SKILL.md
+++ b/.claude/skills/mathodology-whole-project/SKILL.md
@@ -48,7 +48,7 @@ Choose the orchestration mode from the agent environment:
 Codex start prompt:
 
 ```text
-Use $mathodology-whole-project. Run the Mathodology 9-phase award submission workflow in Codex multi-agents mode. Work phase by phase: dispatch independent agents for analysis, modeling, evidence, coding, critique, and writing where applicable; synthesize their output; run the phase gate; then continue automatically. Pause to ask the user only for contest-critical details that would change requirements, data access, model choice, compute budget, or final submission constraints. For ordinary ambiguity, make a conservative assumption, record it in the phase log, and keep going.
+Use $mathodology-whole-project. Run the Mathodology 9-phase award submission workflow in Codex multi-agents mode. Work phase by phase: dispatch independent agents for analysis, modeling, evidence, coding, critique, and writing where applicable; synthesize their output; require result-density maps, figure/table sufficiency gates, and rendered-PDF figure QA; run the phase gate; then continue automatically. Pause to ask the user only for contest-critical details that would change requirements, data access, model choice, compute budget, or final submission constraints. For ordinary ambiguity, make a conservative assumption, record it in the phase log, and keep going.
 ```
 
 ## Codex Resumable Execution
@@ -129,6 +129,7 @@ Codex and Claude Code runs must preserve these guarantees:
 - Every reported number maps to code, data, derivation, citation, or documented manual calculation.
 - Every major assumption maps to evidence, derivation, or sensitivity analysis.
 - At least three model routes are considered before the final route is selected.
+- Paper-first contest drafts must include enough purposeful figures and tables to inspect model structure, primary comparisons, sensitivity, robustness or uncertainty, decision tradeoffs, and final recommendations; sparse, filler, overlapping, clipped, unreadable, or orphaned visuals fail the critic gate.
 - The final paper is checked against prompt coverage, math validity, evidence, reproducibility, writing, formatting, originality, and submission compliance.
 
 Use `docs/WORKFLOWS.md` as the source of truth for the detailed phase-agent-critic matrix.

--- a/.claude/skills/mathodology-whole-project/agents/openai.yaml
+++ b/.claude/skills/mathodology-whole-project/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Mathodology Whole Project"
   short_description: "Run Mathodology skills and award workflows"
-  default_prompt: "Use $mathodology-whole-project. In Codex, classify the contest type in Phase 0, apply the matching Mathodology workflow adapter, then run the 9-phase award workflow with parallel agents, specialist handoffs, phase synthesis, independent critic gates, and resumable phase logs. Target MCM/ICM Outstanding, CUMCM national-first-prize, or the equivalent top tier for the selected contest."
+  default_prompt: "Use $mathodology-whole-project. In Codex, classify the contest type in Phase 0, apply the matching Mathodology workflow adapter, then run the 9-phase award workflow with parallel agents, specialist handoffs, result-density maps, figure/table sufficiency gates, rendered-PDF figure QA, phase synthesis, independent critic gates, and resumable phase logs. Target MCM/ICM Outstanding, CUMCM national-first-prize, or the equivalent top tier for the selected contest."

--- a/.claude/workflows/mathodology-award-submission.md
+++ b/.claude/workflows/mathodology-award-submission.md
@@ -42,6 +42,9 @@ Use these gates to target MCM/ICM Outstanding and CUMCM national-first-prize qua
 - No unaudited artifact: each phase output must pass an independent critic gate before reuse.
 - No paper-only polish: computation, source tracing, and reproducibility must be strong enough for reviewer spot checks.
 - No hidden compliance risk: page, size, anonymity, AI-use, citation, and final package rules are gate items, not final chores.
+- No sparse result presentation: paper-first contests need a purposeful figure/table system that covers model structure, key comparisons, sensitivity, robustness or uncertainty, decision tradeoffs, and final recommendations.
+- No filler visuals: extra figures or tables count only when they are reproducible, interpreted, non-duplicative, and tied to a prompt-level conclusion.
+- No chart rendering bugs: overlapping labels, clipped axes, unreadable text, duplicated caption prefixes, orphaned figures, and incoherent table wrapping are gate failures in the rendered PDF, not cosmetic nits.
 
 ## Phase Review Matrix
 
@@ -51,9 +54,9 @@ Use these gates to target MCM/ICM Outstanding and CUMCM national-first-prize qua
 | 1 | Source ledger, data dictionary, proxy logic, benchmark methods, citation plan | Claims and model inputs are traceable or explicitly assumed with sensitivity plans |
 | 2 | Three or more model routes, tradeoff table, selected route, rejected alternatives, failure modes | Selection fits scoring, data, time, interpretability, and novelty without method stacking |
 | 3 | Notation, assumptions, units, objectives, constraints, algorithms, validation metrics | Coder can implement without inventing math; assumptions and equations survive adversarial review |
-| 4 | Reproducible code, raw outputs, tables, figures, baseline, ablation, sensitivity, robustness | Reported values regenerate or trace; figures have source data; no cherry-picking |
-| 5 | Prompt-by-prompt interpretation, captions, recommendations, limitations, uncertainty | Each conclusion is supported and answers a prompt task |
-| 6 | Summary, coherent paper draft, references, appendix, AI-use statement when needed | Summary is result-first; narrative is coherent; citations, notation, figures, and tasks align |
+| 4 | Reproducible code, raw outputs, tables, figures, baseline, ablation, sensitivity, robustness, result-density map, figure contact sheet | Reported values regenerate or trace; figures have source data; no cherry-picking; figure/table coverage is not sparse; no obvious generated chart defects |
+| 5 | Prompt-by-prompt interpretation, captions, recommendations, limitations, uncertainty, figure/table coverage map | Each conclusion is supported, visual or tabular where useful, and answers a prompt task |
+| 6 | Summary, coherent paper draft, references, appendix, AI-use statement when needed, final figure/table placement, rendered-PDF QA | Summary is result-first; narrative is coherent; citations, notation, figures, tables, and tasks align; rendered figures/tables are readable |
 | 7 | Independent audits and ranked fix list | No unresolved high-severity risk remains |
 | 8 | Final PDF/source/code/data notes/README/checklist package | Package is compliant, anonymous when required, clean of secrets and scratch artifacts |
 
@@ -125,8 +128,10 @@ Deliver:
 - tables
 - figures
 - baseline, ablation, sensitivity, and robustness results
+- result-density map covering model architecture, assumptions or parameters, primary comparison, sensitivity, robustness or uncertainty, decision tradeoffs, and final recommendation dashboard
+- figure/table inventory and a contact sheet or equivalent visual QA artifact
 
-Critic gate: reported numerical results are reproducible and logged; each figure/table has source data and no result is cherry-picked without disclosure.
+Critic gate: reported numerical results are reproducible and logged; each figure/table has source data and no result is cherry-picked without disclosure; a paper-first run fails if the figure/table set is too sparse or if generated visuals show overlap, clipping, unreadable labels, or filler content.
 
 ## Phase 5: Interpretation
 
@@ -138,8 +143,9 @@ Deliver:
 - figure and table captions
 - practical recommendations
 - limitations and uncertainty notes
+- claim-to-figure/table map for the most important conclusions
 
-Critic gate: every result answers a prompt question and is supported by a figure, table, derivation, source, or explicit assumption; limitations do not negate the recommendation.
+Critic gate: every result answers a prompt question and is supported by a figure, table, derivation, source, or explicit assumption; major conclusions are not text-only when a visual or table would make the comparison inspectable; limitations do not negate the recommendation.
 
 ## Phase 6: Paper Draft
 
@@ -153,8 +159,9 @@ Deliver:
 - figures and tables
 - references
 - appendix material
+- rendered-PDF QA evidence for figure/table placement and caption correctness
 
-Critic gate: draft tells one coherent solution story, contains no orphan results, and passes summary, notation, figure, citation, and requirement-coverage checks.
+Critic gate: draft tells one coherent solution story, contains no orphan results, and passes summary, notation, figure/table density, caption, citation, rendered-PDF readability, and requirement-coverage checks.
 
 ## Phase 7: Independent Review
 

--- a/.claude/workflows/mathodology-contest-variants.md
+++ b/.claude/workflows/mathodology-contest-variants.md
@@ -19,6 +19,7 @@ Lead emphasis:
 
 - protect the 25-page solution budget
 - force a result-first summary sheet
+- require enough purposeful figures and tables to make the model, comparisons, sensitivity, robustness, and recommendations inspectable
 - require AI-use disclosure and citation discipline
 - keep source, model, experiment, and paper work synchronized
 
@@ -29,6 +30,7 @@ Critic gate:
 - every outside source and AI use is disclosed
 - references, appendix, code, and problem-specific requirements fit the official page policy
 - paper does not overrun the page limit by hiding essentials in appendices
+- figure/table coverage is substantive without becoming filler or crowding out explanation
 
 ## Adapter: CUMCM National-First-Prize
 
@@ -39,6 +41,7 @@ Lead emphasis:
 - separate paper PDF from support archive
 - maintain an appendix file list
 - keep runnable code and data provenance aligned with paper claims
+- require a dense but readable figure/table system for model structure, result comparison, sensitivity, robustness, and final recommendations
 - check anonymity and similarity-risk language early
 
 Critic gate:
@@ -48,6 +51,7 @@ Critic gate:
 - no school, region, advisor, or team identity appears in prohibited locations
 - support archive contains no secrets, scratch files, caches, or unrelated material
 - core results survive spot reproduction
+- figure/table inventory in the support archive matches the paper and source code
 
 ## Adapter: HiMCM / MidMCM
 
@@ -151,6 +155,7 @@ Lead emphasis:
 - define stakeholders and decision horizon
 - separate objectives, constraints, decisions, and uncertainties
 - produce actionable recommendations, not only fitted models
+- use decision dashboards, scenario tables, and tradeoff figures to make recommendations reviewable
 - quantify cost, feasibility, risk, and implementation tradeoffs
 
 Critic gate:

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -30,9 +30,9 @@ Use these signals to calibrate the workflow. They are not templates to copy; the
 | 1. Evidence and data | Ground the problem | source inventory, data plan, benchmark methods, citation notes | every model input has data, proxy logic, or an assumption |
 | 2. Candidate models | Explore routes before committing | three model routes, tradeoff table, selected route | route fits data, time, scoring, and prompt |
 | 3. Math specification | Make the model executable | notation, assumptions, objectives, constraints, algorithms, metrics | coder can implement without inventing math |
-| 4. Experiments | Generate reproducible results | code, raw outputs, tables, figures, sensitivity, robustness | reported numbers are reproducible |
-| 5. Interpretation | Connect results to the prompt | findings, captions, recommendations, limitations | each result answers a prompt question |
-| 6. Paper draft | Produce a coherent paper | abstract, methods, results, references, appendix | no orphan result or unsupported claim |
+| 4. Experiments | Generate reproducible results | code, raw outputs, tables, figures, sensitivity, robustness, result-density map | reported numbers are reproducible and core results are visually or tabularly supported |
+| 5. Interpretation | Connect results to the prompt | findings, captions, recommendations, limitations, figure/table coverage map | each result answers a prompt question |
+| 6. Paper draft | Produce a coherent paper | abstract, methods, results, figures/tables, references, appendix | no orphan result, sparse result section, or unsupported claim |
 | 7. Independent review | Remove fixable weaknesses | prompt, math, evidence, reproducibility, writing audits | no high-severity issue remains |
 | 8. Final package | Assemble submission | paper, source, code, data notes, README, AI-use statement, checklist | package is submit-ready |
 
@@ -46,9 +46,9 @@ Every phase has three layers: specialist work, lead synthesis, and independent c
 | 1. Evidence and data | evidence researcher, problem analyst, critic | Produce a source ledger with URLs or file paths, credibility notes, extraction summaries, data dictionary, proxy logic, citation plan, and evidence gaps. | Every nontrivial constant, dataset, benchmark, or domain claim is traceable or marked as an assumption with a planned sensitivity check. |
 | 2. Candidate model routes | at least two modelers, evidence researcher, critic | Propose at least three routes with inputs, equations or algorithm families, expected outputs, strengths, weaknesses, implementation cost, data fit, and failure modes. | Selected route is justified against scoring, data, time, interpretability, and novelty; rejected routes have concrete rejection reasons; no generic method stacking. |
 | 3. Mathematical specification | modeler, coder, critic | Write notation, assumptions, dimensions or units, objectives, constraints, algorithms, pseudocode, validation metrics, baseline, ablation, sensitivity, and robustness plan. | Coder can implement without inventing math; equations are dimensionally coherent; assumptions are testable or evidence-backed; validation can falsify weak claims. |
-| 4. Computation and experiments | coder, modeler, critic | Create reproducible scripts or notebooks, deterministic seeds, environment notes, raw outputs, cleaned tables, figures, baseline, ablations, sensitivity, robustness, and run log. | Reported numbers can be regenerated or manually traced; figures have source data; failures are logged; no cherry-picked single run is accepted. |
-| 5. Interpretation | modeler, evidence researcher, paper editor, critic | Convert numerical and analytical results into prompt-by-prompt answers, figure/table captions, recommendations, limitations, uncertainty notes, and claim-source links. | Each result answers a task; every claim is supported by data, derivation, figure, table, citation, or explicit assumption; limitations do not undermine the main conclusion. |
-| 6. Paper draft | paper editor, modeler, coder, critic | Draft summary, introduction, assumptions, methods, results, sensitivity, strengths and weaknesses, conclusion, references, appendices, and AI-use statement when needed. | Summary states method and most important conclusions; paper is coherent and not a transcript; notation, captions, references, and requirement coverage are consistent. |
+| 4. Computation and experiments | coder, modeler, critic | Create reproducible scripts or notebooks, deterministic seeds, environment notes, raw outputs, cleaned tables, figures, baseline, ablations, sensitivity, robustness, run log, and a result-density map covering model structure, primary comparisons, sensitivity, robustness, tradeoffs, and recommendations. | Reported numbers can be regenerated or manually traced; figures have source data; failures are logged; no cherry-picked single run is accepted; sparse or decorative visuals fail the gate. |
+| 5. Interpretation | modeler, evidence researcher, paper editor, critic | Convert numerical and analytical results into prompt-by-prompt answers, figure/table captions, recommendations, limitations, uncertainty notes, claim-source links, and a coverage map showing which visual or table supports each major conclusion. | Each result answers a task; every claim is supported by data, derivation, figure, table, citation, or explicit assumption; limitations do not undermine the main conclusion; major conclusions are not left as text-only assertions. |
+| 6. Paper draft | paper editor, modeler, coder, critic | Draft summary, introduction, assumptions, methods, results, sensitivity, strengths and weaknesses, conclusion, references, appendices, AI-use statement when needed, and final figure/table placement under the page limit. | Summary states method and most important conclusions; paper is coherent and not a transcript; notation, captions, references, figure/table density, and requirement coverage are consistent. |
 | 7. Independent review | critic, lead, relevant specialist reruns | Run separate audits for prompt coverage, mathematical validity, evidence, reproducibility, writing, formatting, originality, and final scoring risk. | No high-severity issue remains; each medium issue is fixed or explicitly accepted with rationale; the critic cannot be the same agent that produced the artifact. |
 | 8. Final package | submission packager, paper editor, critic | Assemble final PDF, editable source if required, code, data or provenance notes, figures, tables, reproduction README, AI-use report, and requirement-to-file checklist. | Package matches contest rules, is anonymous where required, has no secrets or scratch files, satisfies size/page limits, and can be submitted by someone outside the working session. |
 
@@ -81,6 +81,178 @@ Each critic gate must be independent, adversarial, and evidence-linked.
 - `low` issues may be queued only when they cannot affect scoring, correctness, reproducibility, or submission validity.
 - A phase cannot pass if any artifact lacks a traceable source, calculation path, or responsible assumption.
 - The lead must document critic findings and fixes before advancing.
+
+## Figure And Table Sufficiency Gate
+
+For MCM/ICM O-prize, CUMCM national-first-prize, and comparable paper-first contests, figure and table density is a gate item. A paper with only a few isolated plots should fail Phase 6 or Phase 7 even if the equations are plausible.
+
+Before the final draft passes, the artifact set should cover these roles:
+
+- model architecture, algorithm flow, or system structure
+- data, parameter, assumption, or notation summary
+- baseline, route, or scenario comparison
+- sensitivity analysis
+- robustness, uncertainty, stress test, or error analysis
+- decision-facing tradeoff such as cost, time, environmental impact, risk, implementation, or policy feasibility
+- final recommendation or prompt-by-prompt answer dashboard
+
+These roles are minimum coverage, not a rigid count. A single strong visual can satisfy more than one role, but filler, duplicated, decorative, or unsupported figures do not count. Every figure and table must have source data or a documented calculation path, a caption that states the takeaway, and surrounding text that explains how it changes the answer.
+
+## Figure And Table Generation Specification
+
+This specification is calibrated from contest rules, public Outstanding-paper artifacts, and plotting-library behavior:
+
+- COMAP requires the submitted solution to be one PDF containing written text, figures, charts, and supporting materials; images, figures, photographs, tables, and drawings must either be created by the team or cited at their location in the submission. Source: `https://www.contest.comap.com/undergraduate/contests/mcm/instructions.php`.
+- COMAP describes the summary, clear organization, key statements, and major results as important to the judge's reading path. The figure system must help that reading path rather than decorate it. Source: `https://www.contest.comap.com/undergraduate/contests/mcm/instructions.php`.
+- Public Outstanding-paper repositories often keep paper source, figure assets, code, and tables together; for example, the 2024 ICM Problem E Outstanding/INFORMS repository contains a full paper, source, and a `paper_source_24/figure` directory, and the LaTeX source introduces figures/tables in the surrounding argument. Source: `https://github.com/ydchen0806/24ICM_E_O_Award_Paper_code`.
+- Matplotlib's constrained layout is designed to keep tick labels, legends, and colorbars from overlapping, but the documentation also states that other artists can still overlap or be clipped, so manual annotations and custom text require separate checks. Sources: `https://matplotlib.org/stable/users/explain/axes/constrainedlayout_guide.html`, `https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.annotate.html`.
+- Matplotlib's bar-label documentation says labels may require axis-limit adjustment, and a real Matplotlib GitHub issue shows bar labels can overlap under common transformations. Sources: `https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.bar_label.html`, `https://github.com/matplotlib/matplotlib/issues/22414`.
+- Seaborn documents explicit style and context controls, including temporary style contexts and font scaling; use this idea even when using plain Matplotlib. Source: `https://seaborn.pydata.org/tutorial/aesthetics.html`.
+
+### Artifact Contract
+
+Every generated figure or table must have:
+
+- a stable file path, deterministic generation command, and source data path
+- a declared evidence role: architecture, data, assumption, baseline, sensitivity, robustness, uncertainty, tradeoff, decision, memo, or appendix
+- a paper location and the exact claim it supports
+- a caption that states the takeaway, not only the chart type
+- units on every quantitative axis or column
+- significant digits justified by data precision
+- a note when values are proxies, assumptions, simulated outputs, or externally sourced
+
+The coder must produce a figure/table inventory before Phase 5. The packager must include this inventory in the final checklist or README.
+
+### Design Rules
+
+Use these defaults unless the contest or journal format requires otherwise:
+
+- Prefer vector output (`.pdf` or `.svg`) for line art, diagrams, maps, and dense labels. Use `.png` only for raster images or when the PDF pipeline requires it; then use at least 180 dpi for draft and 300 dpi for final exported figures.
+- Use `layout="constrained"` or explicit `GridSpec` spacing for multi-panel figures. Do not rely on `tight_layout()` alone for figures with long labels, colorbars, legends, annotations, or suptitles.
+- Use figure sizes that match the paper slot. Typical full-width paper figures should be about 6.5-7.2 inches wide; multi-panel dashboards may be 7.2-9.0 inches wide only if the PDF page and caption remain readable.
+- Keep in-figure text readable after PDF embedding. Axis ticks, legends, node labels, heatmap cell labels, and annotations should normally render at 8 pt or larger in the final PDF.
+- Put only short descriptors in chart titles. Put the claim in the caption and surrounding prose. Avoid `Figure 2: Figure 2.` caption duplication.
+- Long category labels should be wrapped, abbreviated with a table note, or moved to a horizontal bar chart. Avoid diagonal tick labels above 30 degrees unless there is no better option.
+- Use colorblind-aware palettes. Do not use rainbow palettes for ordered values. Use sequential palettes for magnitude, diverging palettes for signed deviations, and categorical palettes for modes or strategies.
+- Never encode an important distinction by color alone when the paper may be printed in grayscale; add markers, line styles, direct labels, hatching, or table values.
+- Prefer direct labels only for the few points that need them. If every point must be identified, use a table, small multiples, or a numbered legend.
+- Use log or symlog scales only when the order-of-magnitude gap is the finding; label the scale clearly and explain it in the caption.
+
+### Plot-Type Rules
+
+Network, flow, and architecture diagrams:
+
+- Node text and edge labels must be separate artists at separate coordinates.
+- Edge labels should sit near edge midpoints with a white or lightly tinted background, never on top of node text.
+- Arrows must not cross node labels unless the crossing is semantically meaningful and still readable.
+- Keep nodes large enough for their labels, or number the nodes and provide a nearby legend table.
+
+Bar and column charts:
+
+- Use horizontal bars for long scenario names.
+- Add numeric labels only when they do not collide with bars, axes, or panel boundaries.
+- If labels are outside bars, expand the axis limit by at least 5-10% after label placement.
+- If values differ by more than one order of magnitude, consider log/symlog scale, an inset, or a table plus chart rather than hiding small bars.
+
+Line charts:
+
+- Label axes with units and scenario meaning.
+- Direct-label lines at the right edge when possible; otherwise keep legends outside the plotting area or in unused white space.
+- Show uncertainty bands or scenario ranges when the line supports a recommendation under uncertainty.
+
+Heatmaps and matrices:
+
+- Include a labeled colorbar with units.
+- Choose cell-label text color based on background contrast, not a fixed black/white default.
+- Keep matrix dimensions small enough to read in the paper; large matrices belong in appendix tables or support files.
+
+Scatter, Pareto, and tradeoff plots:
+
+- State which axis is to be minimized or maximized.
+- Label only the baseline, selected solution, and dominated or frontier points needed for the argument.
+- Make marker size and color legends explicit; never let bubble size imply a value without a legend or note.
+
+Tables:
+
+- Use compact tables for exact values and figures for patterns.
+- Use `booktabs`-style rules or equivalent clean borders; avoid full gridlines unless the table is a matrix.
+- Keep columns narrow by shortening headings and moving explanations into notes.
+- Round consistently. Do not show more decimal places than the model or data supports.
+- A table that spans the page or wraps incoherently should be split, rotated only as a last resort, or moved to support materials.
+
+### Generation Code Rules
+
+Figure-generating code must:
+
+- define reusable style constants for font sizes, colors, line widths, marker sizes, and DPI
+- set a random seed for simulated visuals
+- write source CSV/JSON data before or alongside each generated figure
+- close figures after saving to prevent hidden state
+- avoid handwritten string parsing when structured data is available
+- avoid placing multiple text objects at the same coordinate unless the overlap is intentional and documented
+- save with a white or transparent background that works in PDF conversion
+- include a build command that regenerates all visuals from a clean package root
+
+For Matplotlib specifically:
+
+- prefer `fig, ax = plt.subplots(..., layout="constrained")` or `fig = plt.figure(layout="constrained")`
+- for annotations, use explicit `xy`, `xytext`, `textcoords`, and `bbox`; never reuse a node position as both the node label and edge label
+- after `bar_label` or manual bar labels, adjust `xlim`/`ylim` so labels fit
+- for heatmap labels, choose text color from the normalized cell value
+- for large category labels, use `textwrap.fill` or horizontal bars
+- after saving, inspect the actual exported image rather than the notebook preview
+
+### PDF Embedding Rules
+
+The paper editor must verify the final rendered PDF, not only the source Markdown/LaTeX:
+
+- figure appears within one page of the paragraph that introduces it, unless the figure is explicitly an appendix artifact
+- no figure is clipped, blank, pixelated, or split incoherently
+- no text overlaps inside the figure or table
+- no axis label, tick label, legend, colorbar, table heading, or caption is cropped
+- captions are not duplicated and do not contradict the figure title
+- every figure and table is mentioned in nearby prose before or immediately after it appears
+- page budget remains compliant after figure placement
+
+### Automated And Visual Verification
+
+Before Phase 6 or Phase 8 can pass, run a figure QA sequence:
+
+```bash
+python3 <experiment_script>.py
+find outputs/figures -type f \( -name '*.png' -o -name '*.pdf' -o -name '*.svg' \) | sort
+python3 <make_contact_sheet_or_equivalent>.py
+(cd paper && pandoc solution.md --pdf-engine=tectonic -o solution.pdf)
+pdfinfo paper/solution.pdf
+pdftoppm -png -r 110 paper/solution.pdf /tmp/solution-page
+pdftotext paper/solution.pdf - | rg "Figure [0-9]+: Figure|Table [0-9]+: Table"
+```
+
+The exact commands may differ by environment, but the evidence must include:
+
+- generated figure count and table count
+- contact sheet or individual screenshots of all figures
+- rendered PDF page count
+- rendered PDF page screenshots or contact sheet
+- check for duplicated caption prefixes
+- checksum or clean rebuild proof for the final package
+
+The critic must visually inspect the contact sheet and at least the pages containing dense figures/tables. Automated checks do not replace the visual pass because layout engines can produce mathematically valid but unreadable results.
+
+### Failure Conditions
+
+Block the phase if any of these are present:
+
+- node labels, edge labels, data labels, or annotations overlap
+- text is too small to read in the final PDF
+- a figure is blank, clipped, pixelated, or has excessive unused whitespace
+- chart title, caption, and prose repeat without adding interpretation
+- axes lack units or the scale is misleading
+- a legend or colorbar is missing for encoded values
+- figures float away from the relevant paragraph and create a pile of orphan charts
+- a table wraps into incoherent lines or spills beyond the page
+- a figure exists only to increase count and does not support a claim
+- the code cannot regenerate the figure/table from package data
 
 ## Competition-Type Workflow Adapters
 
@@ -148,7 +320,7 @@ Use this when the skills are installed globally for Codex.
 Start prompt:
 
 ```text
-Use $mathodology-whole-project. Run the Mathodology 9-phase award submission workflow in Codex multi-agents mode. Work phase by phase: dispatch independent agents for analysis, modeling, evidence, coding, critique, and writing where applicable; synthesize their output; run the phase gate; then continue automatically. Pause to ask the user only for contest-critical details that would change requirements, data access, model choice, compute budget, or final submission constraints. For ordinary ambiguity, make a conservative assumption, record it in the phase log, and keep going.
+Use $mathodology-whole-project. Run the Mathodology 9-phase award submission workflow in Codex multi-agents mode. Work phase by phase: dispatch independent agents for analysis, modeling, evidence, coding, critique, and writing where applicable; synthesize their output; require result-density maps, figure/table sufficiency gates, and rendered-PDF figure QA; run the phase gate; then continue automatically. Pause to ask the user only for contest-critical details that would change requirements, data access, model choice, compute budget, or final submission constraints. For ordinary ambiguity, make a conservative assumption, record it in the phase log, and keep going.
 ```
 
 Codex agent roles:
@@ -225,6 +397,7 @@ Do not treat a solution as prize-level until it has:
 - evidence-backed assumptions
 - reproducible computations
 - sensitivity or robustness analysis
+- enough purposeful figures and tables to make model structure, comparisons, sensitivity, robustness, tradeoffs, and final recommendations inspectable
 - prompt-by-prompt answer coverage
 - polished paper narrative
 - independent critic review

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -225,7 +225,10 @@ python3 <make_contact_sheet_or_equivalent>.py
 (cd paper && pandoc solution.md --pdf-engine=tectonic -o solution.pdf)
 pdfinfo paper/solution.pdf
 pdftoppm -png -r 110 paper/solution.pdf /tmp/solution-page
-pdftotext paper/solution.pdf - | rg "Figure [0-9]+: Figure|Table [0-9]+: Table"
+if pdftotext paper/solution.pdf - | rg -q "Figure [0-9]+: Figure|Table [0-9]+: Table"; then
+  echo "duplicated caption prefix found" >&2
+  exit 1
+fi
 ```
 
 The exact commands may differ by environment, but the evidence must include:

--- a/docs/WORKFLOWS_zh.md
+++ b/docs/WORKFLOWS_zh.md
@@ -225,7 +225,10 @@ python3 <make_contact_sheet_or_equivalent>.py
 (cd paper && pandoc solution.md --pdf-engine=tectonic -o solution.pdf)
 pdfinfo paper/solution.pdf
 pdftoppm -png -r 110 paper/solution.pdf /tmp/solution-page
-pdftotext paper/solution.pdf - | rg "Figure [0-9]+: Figure|Table [0-9]+: Table"
+if pdftotext paper/solution.pdf - | rg -q "Figure [0-9]+: Figure|Table [0-9]+: Table"; then
+  echo "发现重复 caption 前缀" >&2
+  exit 1
+fi
 ```
 
 具体命令可随环境调整，但证据必须包含：

--- a/docs/WORKFLOWS_zh.md
+++ b/docs/WORKFLOWS_zh.md
@@ -30,9 +30,9 @@ Mathodology 支持两种编排模式：
 | 1. 证据与数据 | 给问题建立依据 | 来源清单、数据计划、benchmark、引用笔记 | 每个模型输入都有数据、代理逻辑或假设 |
 | 2. 候选模型 | 先比较路线再定型 | 三条模型路线、取舍表、最终路线 | 路线匹配数据、时间、评分和题目 |
 | 3. 数学规格 | 让模型可执行 | 符号、假设、目标、约束、算法、指标 | coder 不需要临时发明数学 |
-| 4. 实验计算 | 生成可复现结果 | 代码、原始输出、表格、图、敏感性、鲁棒性 | 论文中的数字可复现 |
-| 5. 解释结果 | 把结果接回题目 | 结论、图表说明、建议、局限 | 每个结果回答题目问题 |
-| 6. 论文初稿 | 形成完整论文 | 摘要、方法、结果、参考文献、附录 | 没有孤立结果或无支撑论断 |
+| 4. 实验计算 | 生成可复现结果 | 代码、原始输出、表格、图、敏感性、鲁棒性、结果密度映射 | 论文中的数字可复现，核心结果有图表支撑 |
+| 5. 解释结果 | 把结果接回题目 | 结论、图表说明、建议、局限、图表覆盖映射 | 每个结果回答题目问题 |
+| 6. 论文初稿 | 形成完整论文 | 摘要、方法、结果、图表、参考文献、附录 | 没有孤立结果、稀疏结果区或无支撑论断 |
 | 7. 独立审稿 | 删除可修缺陷 | 题目、数学、证据、复现、写作审计 | 无高严重度未解决问题 |
 | 8. 最终提交 | 组装提交包 | 论文、源码、代码、数据说明、README、AI 使用说明、清单 | 用户可直接提交 |
 
@@ -46,9 +46,9 @@ Mathodology 支持两种编排模式：
 | 1. 证据与数据 | evidence researcher, problem analyst, critic | 产出来源台账、链接或文件路径、可信度说明、抽取摘要、数据字典、代理数据逻辑、引用计划和证据缺口。 | 每个重要常数、数据集、benchmark 或领域判断都可追踪，或被标为假设并有敏感性检查计划。 |
 | 2. 候选模型路线 | 至少两个 modeler, evidence researcher, critic | 至少三条路线，包含输入、方程或算法族、输出、优缺点、实现成本、数据匹配度和失败模式。 | 选中路线必须能解释评分、数据、时间、可解释性和创新性；被拒路线有具体理由；禁止通用方法堆砌。 |
 | 3. 数学规格 | modeler, coder, critic | 写清符号、假设、量纲或单位、目标函数、约束、算法、伪代码、验证指标、baseline、ablation、敏感性和鲁棒性计划。 | coder 不需要临时发明数学；方程量纲一致；假设可测试或有证据；验证设计能暴露弱结论。 |
-| 4. 实验计算 | coder, modeler, critic | 产出可复现脚本或 notebook、随机种子、环境说明、原始输出、整理表格、图、baseline、ablation、敏感性、鲁棒性和运行日志。 | 论文数字可重新生成或手工追踪；图有源数据；失败也被记录；不接受挑一次最好结果。 |
-| 5. 解释结果 | modeler, evidence researcher, paper editor, critic | 把结果转成逐问回答、图表标题、建议、局限、不确定性说明和 claim-source 链接。 | 每个结果都回答题目任务；每个论断都有数据、推导、图表、引用或明确假设支撑；局限不推翻主结论。 |
-| 6. 论文初稿 | paper editor, modeler, coder, critic | 完成摘要、引言、假设、方法、结果、敏感性、优缺点、结论、参考文献、附录和必要的 AI 使用说明。 | 摘要说明方法和最重要结论；论文不是实验流水账；符号、图注、引用和需求覆盖一致。 |
+| 4. 实验计算 | coder, modeler, critic | 产出可复现脚本或 notebook、随机种子、环境说明、原始输出、整理表格、图、baseline、ablation、敏感性、鲁棒性、运行日志，以及覆盖模型结构、核心比较、敏感性、鲁棒性、权衡和建议的结果密度映射。 | 论文数字可重新生成或手工追踪；图有源数据；失败也被记录；不接受挑一次最好结果；图表稀疏或装饰性图表不能通过。 |
+| 5. 解释结果 | modeler, evidence researcher, paper editor, critic | 把结果转成逐问回答、图表标题、建议、局限、不确定性说明、claim-source 链接，以及说明每个主要结论由哪张图或表支撑的覆盖映射。 | 每个结果都回答题目任务；每个论断都有数据、推导、图表、引用或明确假设支撑；局限不推翻主结论；重要结论不能只停留在文字断言。 |
+| 6. 论文初稿 | paper editor, modeler, coder, critic | 完成摘要、引言、假设、方法、结果、敏感性、优缺点、结论、参考文献、必要的 AI 使用说明，以及页数约束内的最终图表布局。 | 摘要说明方法和最重要结论；论文不是实验流水账；符号、图注、引用、图表密度和需求覆盖一致。 |
 | 7. 独立审稿 | critic, lead, 相关专家 rerun | 分别审计题目覆盖、数学有效性、证据、复现、写作、格式、原创性和最终评分风险。 | 无 blocker/high 问题；每个 medium 问题已修复或有明确接受理由；critic 不能是原产出 agent。 |
 | 8. 最终提交 | submission packager, paper editor, critic | 组装最终 PDF、必要的可编辑源文件、代码、数据或来源说明、图表、复现 README、AI 使用报告和 requirement-to-file 清单。 | 提交包符合规则、必要时匿名、无密钥和草稿文件、满足大小和页数限制，且未参与工作的人也能提交。 |
 
@@ -81,6 +81,178 @@ Agent handoff:
 - 只有不会影响评分、正确性、复现或提交合法性的 `low` 问题才可排队。
 - 任一产物缺少来源、计算路径或负责假设时，本 phase 不能通过。
 - lead 必须记录 critic 发现和修复后才能推进。
+
+## 图表充足性 Gate
+
+对 MCM/ICM O 奖、CUMCM 国一和类似论文优先竞赛，图表密度是 gate 项，不是最后美化。只有少数孤立图的论文，即使公式看起来合理，也应在 Phase 6 或 Phase 7 失败。
+
+最终初稿通过前，图表系统至少应覆盖这些角色：
+
+- 模型架构、算法流程或系统结构
+- 数据、参数、假设或符号摘要
+- baseline、模型路线或场景比较
+- 敏感性分析
+- 鲁棒性、不确定性、压力测试或误差分析
+- 面向决策的权衡，例如成本、时间、环境影响、风险、实施路径或政策可行性
+- 最终建议或逐问回答 dashboard
+
+这些是最低覆盖角色，不是死板数量。一个强图可以同时承担多个角色，但填充式、重复式、装饰式或无支撑图表不计数。每张图和每个表都必须有源数据或计算路径，图注要写出结论，正文要解释它如何改变答案。
+
+## 图表生成规范
+
+本规范参考竞赛规则、公开 O 奖产物和绘图库真实行为：
+
+- COMAP 要求解答以一个 PDF 提交，PDF 中包含文字、figures、charts 和支撑材料；所有图像、图、照片、表和绘图，要么由队伍创建，要么在提交文件中就地引用来源。来源：`https://www.contest.comap.com/undergraduate/contests/mcm/instructions.php`。
+- COMAP 强调 summary、组织结构、关键语句和主要结果会影响评委阅读路径。图表系统必须服务这个阅读路径，不能只是装饰。来源：`https://www.contest.comap.com/undergraduate/contests/mcm/instructions.php`。
+- 公开 O 奖仓库通常把论文源码、图表资源、代码和表格放在一起；例如 2024 ICM E 题 Outstanding/INFORMS 仓库包含完整论文、源码和 `paper_source_24/figure` 目录，LaTeX 源码中的图表也嵌入对应论证段落。来源：`https://github.com/ydchen0806/24ICM_E_O_Award_Paper_code`。
+- Matplotlib 的 constrained layout 可以减少刻度、图例、colorbar 等重叠，但官方文档也说明其他 artist 仍可能被裁切或重叠，所以 annotation、自定义文字和复杂图必须单独检查。来源：`https://matplotlib.org/stable/users/explain/axes/constrainedlayout_guide.html`，`https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.annotate.html`。
+- Matplotlib 的 bar label 文档说明标签可能需要调整坐标轴范围；真实 GitHub issue 也展示了 bar label 在常见变换下发生重叠的情况。来源：`https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.bar_label.html`，`https://github.com/matplotlib/matplotlib/issues/22414`。
+- Seaborn 文档提供 style/context/font scale 控制。即使用纯 Matplotlib，也要采用这种显式样式管理思路。来源：`https://seaborn.pydata.org/tutorial/aesthetics.html`。
+
+### 产物契约
+
+每张图和每个表必须包含：
+
+- 稳定文件路径、确定性生成命令、源数据路径
+- 明确证据角色：模型结构、数据、假设、baseline、敏感性、鲁棒性、不确定性、权衡、决策、memo 或附录
+- 论文位置，以及它支撑的精确结论
+- 能写出 takeaway 的 caption，而不只是图表类型
+- 每个定量轴或表格列都有单位
+- 有意义的有效数字，不能伪装精度
+- 如果数值来自代理、假设、模拟或外部来源，必须注明
+
+coder 在 Phase 5 前必须产出图表 inventory。packager 必须把 inventory 写入最终 checklist 或 README。
+
+### 设计规则
+
+默认遵守以下规则，除非竞赛或期刊格式另有要求：
+
+- 折线图、流程图、网络图、地图和密集标签图优先输出矢量格式 `.pdf` 或 `.svg`。仅在管线要求时使用 `.png`；草稿至少 180 dpi，最终至少 300 dpi。
+- 多面板图使用 `layout="constrained"` 或显式 `GridSpec` 间距。含长标签、colorbar、legend、annotation 或 suptitle 的图，不能只依赖 `tight_layout()`。
+- 图宽应匹配论文位置。常规全宽图约 6.5-7.2 英寸；多面板 dashboard 可到 7.2-9.0 英寸，但嵌入 PDF 后文字和 caption 必须可读。
+- 最终 PDF 中的刻度、图例、节点标签、热力图单元格和注释通常不小于 8 pt。
+- 图内 title 只放短描述；claim 放在 caption 和正文。避免 `Figure 2: Figure 2.` 这种重复。
+- 长类别标签应换行、缩写并在表注解释，或改用横向条形图。除非没有更好方案，避免超过 30 度的斜刻度。
+- 使用色盲友好 palette。顺序值用 sequential palette，正负偏差用 diverging palette，类别用 categorical palette，避免 rainbow。
+- 重要区别不能只靠颜色表达；需要加 marker、线型、hatching、直接标签或表格数值。
+- 只给关键点直接标注。如果每个点都要识别，改用表格、小多图或编号 legend。
+- 只有当数量级差异本身是结论时才用 log/symlog，并在 caption 中说明。
+
+### 图型规则
+
+网络图、流程图和架构图：
+
+- 节点文字和边标签必须是不同 artist，并放在不同坐标。
+- 边标签放在边的中点附近，使用白色或浅色背景，不能压在节点文字上。
+- 箭头不得穿过节点标签，除非语义必要且仍清晰。
+- 节点必须足够容纳标签；否则节点编号，旁边给 legend 表。
+
+条形图和柱状图：
+
+- 长场景名使用横向条形图。
+- 只有在不碰撞柱、坐标轴或边界时才添加数值标签。
+- 标签在柱外时，标注后把坐标轴范围扩大 5-10%。
+- 值相差超过一个数量级时，考虑 log/symlog、插图，或“表格 + 图”，不能让小柱消失。
+
+折线图：
+
+- 坐标轴必须有单位和场景含义。
+- 尽量在右端直接标线名；否则把 legend 放在图外或空白区域。
+- 当折线支撑不确定性下的建议时，必须展示置信区间、场景范围或敏感性带。
+
+热力图和矩阵：
+
+- 必须有带单位的 colorbar。
+- 单元格文字颜色根据背景亮度选择，不能固定黑字或白字。
+- 矩阵规模必须能在正文读清；大矩阵放附录表或支撑材料。
+
+散点、Pareto 和权衡图：
+
+- 明确说明每个轴是越小越好还是越大越好。
+- 只标注 baseline、被选方案、dominated 点或 frontier 上需要论证的点。
+- marker 大小和颜色必须有 legend 或说明，不能让气泡大小暗示未解释的值。
+
+表格：
+
+- 精确值用表格，趋势和结构用图。
+- 使用 booktabs 风格或同等清晰边线；除矩阵外避免满格线。
+- 表头尽量短，把解释放入表注。
+- 统一舍入，不展示超过模型和数据支撑的位数。
+- 宽表或换行混乱的表应拆分；旋转表只能作为最后方案。
+
+### 生成代码规则
+
+图表生成代码必须：
+
+- 定义可复用 style 常量：字体、颜色、线宽、marker、DPI
+- 模拟类图表设置随机种子
+- 每张图保存前或同时写出源 CSV/JSON 数据
+- 保存后关闭 figure，避免隐藏状态污染
+- 有结构化数据时不要手写字符串解析
+- 除非明确记录，不要把多个文字对象放在同一坐标
+- 导出能适配 PDF 的白底或透明背景
+- 从干净 package root 可一键重生所有图表
+
+Matplotlib 额外规则：
+
+- 优先 `fig, ax = plt.subplots(..., layout="constrained")` 或 `fig = plt.figure(layout="constrained")`
+- annotation 必须显式设置 `xy`、`xytext`、`textcoords` 和 `bbox`；不能把节点坐标同时当节点标签和边标签
+- `bar_label` 或手动 bar label 后，必须调整 `xlim`/`ylim` 让标签可见
+- 热力图单元格文字颜色要根据数值归一化后选择
+- 长类别名用 `textwrap.fill` 或横向条形图
+- 保存后检查真实导出图，不要只看 notebook 预览
+
+### PDF 嵌入规则
+
+paper editor 必须检查最终渲染 PDF，而不仅是 Markdown/LaTeX 源码：
+
+- 图应出现在引入它的段落附近，除非明确是附录图
+- 图不能被裁切、空白、像素化或不合理拆页
+- 图或表内部无文字重叠
+- 坐标轴、刻度、图例、colorbar、表头和 caption 不被裁切
+- caption 不重复、不与图内 title 冲突
+- 每张图和表都在附近正文中被解释
+- 图表放置后仍满足页数限制
+
+### 自动和视觉验证
+
+Phase 6 或 Phase 8 通过前，必须执行图表 QA：
+
+```bash
+python3 <experiment_script>.py
+find outputs/figures -type f \( -name '*.png' -o -name '*.pdf' -o -name '*.svg' \) | sort
+python3 <make_contact_sheet_or_equivalent>.py
+(cd paper && pandoc solution.md --pdf-engine=tectonic -o solution.pdf)
+pdfinfo paper/solution.pdf
+pdftoppm -png -r 110 paper/solution.pdf /tmp/solution-page
+pdftotext paper/solution.pdf - | rg "Figure [0-9]+: Figure|Table [0-9]+: Table"
+```
+
+具体命令可随环境调整，但证据必须包含：
+
+- 生成图数量和表数量
+- 全部图的 contact sheet 或单图截图
+- 渲染后 PDF 页数
+- PDF 页面截图或 contact sheet
+- caption 前缀重复检查
+- 最终包 checksum 或干净重建证明
+
+critic 必须目检 contact sheet，并至少检查含密集图表的页面。自动检查不能替代目检，因为 layout engine 可能给出数学上合法但阅读上失败的结果。
+
+### 失败条件
+
+出现以下任一项即阻断 phase：
+
+- 节点标签、边标签、数据标签或 annotation 重叠
+- 最终 PDF 中文字过小无法阅读
+- 图为空白、被裁切、像素化或有过多无效空白
+- 图题、caption 和正文重复但没有解释
+- 坐标轴缺单位或尺度误导
+- 编码数值缺 legend 或 colorbar
+- 图漂移到远离相关段落的位置，形成孤立图堆
+- 表格换行混乱或溢出页面
+- 图只是凑数量，不支撑任何结论
+- 代码不能从提交包数据重生图表
 
 ## 竞赛类型工作流适配器
 
@@ -148,7 +320,7 @@ Subagents：
 启动提示：
 
 ```text
-Use $mathodology-whole-project. Run the Mathodology 9-phase award submission workflow in Codex multi-agents mode. Work phase by phase: dispatch independent agents for analysis, modeling, evidence, coding, critique, and writing where applicable; synthesize their output; run the phase gate; then continue automatically. Pause to ask the user only for contest-critical details that would change requirements, data access, model choice, compute budget, or final submission constraints. For ordinary ambiguity, make a conservative assumption, record it in the phase log, and keep going.
+Use $mathodology-whole-project. Run the Mathodology 9-phase award submission workflow in Codex multi-agents mode. Work phase by phase: dispatch independent agents for analysis, modeling, evidence, coding, critique, and writing where applicable; synthesize their output; require result-density maps, figure/table sufficiency gates, and rendered-PDF figure QA; run the phase gate; then continue automatically. Pause to ask the user only for contest-critical details that would change requirements, data access, model choice, compute budget, or final submission constraints. For ordinary ambiguity, make a conservative assumption, record it in the phase log, and keep going.
 ```
 
 Codex agent 角色：
@@ -225,6 +397,7 @@ Codex 执行规则：
 - 假设有证据支撑
 - 计算可复现
 - 有敏感性或鲁棒性分析
+- 有足够的有效图表，让模型结构、比较、敏感性、鲁棒性、权衡和最终建议可被评委快速检查
 - 逐问覆盖题目
 - 论文叙事成熟
 - 经过独立 critic 审稿


### PR DESCRIPTION
## What changed

- Added a complete figure and table generation specification to the Mathodology award workflow docs in English and Chinese.
- Added result-density maps, figure/table sufficiency gates, contact-sheet review, and rendered-PDF figure QA as required workflow checks.
- Updated project agents and OpenAI skill prompts so coder, critic, editor, and packager roles block sparse, decorative, overlapping, clipped, or duplicated figures.

## Why

The prior MCM/ICM draft output could pass basic generation while still producing too few figures or visually broken charts. These gates make figure density, reproducibility, caption quality, and final PDF inspection explicit parts of the award-level workflow.

## Validation

- Ran skill frontmatter validation for all `.claude/skills/*` directories: all 7 skills valid.
- Ran metadata consistency check: `skills metadata ok`.
- Ran skills-only tracked-file boundary check: `tracked whitelist ok: 37 files`.
- Ran Markdown local-link check: `markdown local links ok`.
- Ran `git diff --check HEAD~1..HEAD`: no whitespace errors.